### PR TITLE
Adding reference to script to simplify localization of existing project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### New Features
 
+* Added a script reference to simplify and automate localization of existing non localized project.  
+  [HuguesBR](https://github.com/HuguesBR)
 * Added a `storyboards-osx-swift3` template.  
   [Felix Lisczyk](https://github.com/FelixII)
   [#225](https://github.com/AliSoftware/SwiftGen/pull/225)

--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ let ban = tr(.BananasOwner(2, "John"))
 
 This [script](https://gist.github.com/Lutzifer/3e7d967f73e38b57d4355f23274f303d) from [Lutzifer](https://github.com/Lutzifer/) can be run inside the project to transform `NSLocalizedString(...)` calls to the `tr(...)` syntax.
 
+This [script](https://gist.github.com/huguesbr/375730d567020da83836483074a67ff9) from [HuguesBR](https://github.com/huguesbr) can be run inside the (annotated) project to transform specific string (see detail in the gist) syntax `` to the `tr(...)` syntax as well as populating the `Localizable.strings`'s file
+
 
 ### Dot Syntax Support
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ let ban = tr(.BananasOwner(2, "John"))
 
 This [script](https://gist.github.com/Lutzifer/3e7d967f73e38b57d4355f23274f303d) from [Lutzifer](https://github.com/Lutzifer/) can be run inside the project to transform `NSLocalizedString(...)` calls to the `tr(...)` syntax.
 
-This [script](https://gist.github.com/huguesbr/375730d567020da83836483074a67ff9) from [HuguesBR](https://github.com/huguesbr) can be run inside the (annotated) project to transform specific string (see detail in the gist) syntax `` to the `tr(...)` syntax as well as populating the `Localizable.strings`'s file
+This [script](https://gist.github.com/huguesbr/375730d567020da83836483074a67ff9) from [HuguesBR](https://github.com/huguesbr) can be run inside the (annotated) project to transform specific string (see detail in the gist) syntax to the `tr(...)` syntax as well as populating the `Localizable.strings`'s file
 
 
 ### Dot Syntax Support


### PR DESCRIPTION
Adding link to script trying to simplify the localization of an existing project without any previous localization.
The main pain is to have to perform multiple actions for each localization (copy the existing string, replace it by a `tr(...)` syntax, paste it in the `Localizable.strings`'s file along with the correct key, replacing the variable by string type argument...)