### PR TITLE
Fix enum names to conform to Swift 3 syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ _None_
   [Olivier Halligon](https://github.com/alisoftware)
   [#269](https://github.com/SwiftGen/SwiftGenKit/issues/269)
   [#291](https://github.com/SwiftGen/SwiftGenKit/issues/291)
+* Fix remaining enum names not Swift 3 compliant.  
+  [Liquidsoul](https://github.com/liquidsoul)
+  [#297](https://github.com/SwiftGen/SwiftGen/issues/297)
 
 ## 4.2.0
 

--- a/Sources/ArgumentsUtils.swift
+++ b/Sources/ArgumentsUtils.swift
@@ -41,27 +41,27 @@ func printError(string: String) {
 }
 
 enum OutputDestination: ArgumentConvertible {
-  case Console
-  case File(Path)
+  case console
+  case file(Path)
 
   init(parser: ArgumentParser) throws {
     guard let path = parser.shift() else {
       throw ArgumentError.missingValue(argument: nil)
     }
-    self = .File(Path(path))
+    self = .file(Path(path))
   }
   var description: String {
     switch self {
-    case .Console: return "(stdout)"
-    case .File(let path): return path.description
+    case .console: return "(stdout)"
+    case .file(let path): return path.description
     }
   }
 
   func write(content: String, onlyIfChanged: Bool = false) {
     switch self {
-    case .Console:
+    case .console:
       print(content)
-    case .File(let path):
+    case .file(let path):
       do {
         if try onlyIfChanged && path.exists && path.read(.utf8) == content {
           return print("Not writing the file as content is unchanged")
@@ -78,15 +78,15 @@ enum OutputDestination: ArgumentConvertible {
 // MARK: Template Arguments
 
 enum TemplateError: Error, CustomStringConvertible {
-  case NamedTemplateNotFound(name: String)
-  case TemplatePathNotFound(path: Path)
+  case namedTemplateNotFound(name: String)
+  case templatePathNotFound(path: Path)
 
   var description: String {
     switch self {
-    case .NamedTemplateNotFound(let name):
+    case .namedTemplateNotFound(let name):
       return "Template named \(name) not found. Use `swiftgen templates` to list available named templates " +
       "or use --templatePath to specify a template by its full path."
-    case .TemplatePathNotFound(let path):
+    case .templatePathNotFound(let path):
       return "Template not found at path \(path.description)."
     }
   }
@@ -129,7 +129,7 @@ func findTemplate(prefix: String, templateShortName: String, templateFullPath: S
   guard templateFullPath.isEmpty else {
     let fullPath = Path(templateFullPath)
     guard fullPath.isFile else {
-      throw TemplateError.TemplatePathNotFound(path: fullPath)
+      throw TemplateError.templatePathNotFound(path: fullPath)
     }
     return fullPath
   }
@@ -139,7 +139,7 @@ func findTemplate(prefix: String, templateShortName: String, templateFullPath: S
     path = bundledTemplatesPath + "\(prefix)-\(templateShortName).stencil"
   }
   guard path.isFile else {
-    throw TemplateError.NamedTemplateNotFound(name: templateShortName)
+    throw TemplateError.namedTemplateNotFound(name: templateShortName)
   }
   return path
 }

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -35,7 +35,7 @@ let templatePathOption = Option<String>(
 )
 
 let outputOption = Option(
-  "output", OutputDestination.Console, flag: "o",
+  "output", OutputDestination.console, flag: "o",
   description: "The path to the file to generate (Omit to generate to stdout)"
 )
 


### PR DESCRIPTION
* [x] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself
  * [x] Add the entry in the appropriate section (Bug Fix / Nw Feature / Breaking Change / Internal Change)
  * [x] Add a period and 2 spaces at the end of your short entry description
  * [x] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

This fixes the swiftlint errors reported in #296 without addressing the CI reporting issue.