### PR TITLE
Show error when combining `-t` and `-p` cli options #283

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ _None_
 * Removed deprecated CLI options. Should you still use them, SwiftGen will return an error and show the new recommended CLI option to use instead.
   [David Jennes](https://github.com/djbe)
   [#301](https://github.com/SwiftGen/SwiftGenKit/issues/301)
+* Disable default value for named template option and ensure that there is a template option.  
+  [Liquidsoul](https://github.com/liquidsoul)
+  [#283](https://github.com/SwiftGen/SwiftGen/issues/283)
 
 ### New Features
 

--- a/Sources/ArgumentsUtils.swift
+++ b/Sources/ArgumentsUtils.swift
@@ -141,15 +141,16 @@ let bundledTemplatesPath = Path(ProcessInfo.processInfo.arguments[0]).parent() +
  - returns: The Path matching the template to find
  */
 func findTemplate(prefix: String, templateShortName: String, templateFullPath: String) throws -> Path {
-  switch (templateFullPath, templateShortName) {
-  case ("", ""): throw TemplateError.noTemplateProvided
-  case (_, ""):
+  switch (!templateFullPath.isEmpty, !templateShortName.isEmpty) {
+  case (false, false):
+    throw TemplateError.noTemplateProvided
+  case (true, false):
     let fullPath = Path(templateFullPath)
     guard fullPath.isFile else {
       throw TemplateError.templatePathNotFound(path: fullPath)
     }
     return fullPath
-  case ("", _):
+  case (false, true):
     var path = appSupportTemplatesPath + "\(prefix)-\(templateShortName).stencil"
     if !path.isFile {
       path = bundledTemplatesPath + "\(prefix)-\(templateShortName).stencil"
@@ -158,7 +159,7 @@ func findTemplate(prefix: String, templateShortName: String, templateFullPath: S
       throw TemplateError.namedTemplateNotFound(name: templateShortName)
     }
     return path
-  case (_, _):
+  case (true, true):
     throw TemplateError.multipleTemplateOptions(path: templateFullPath, name: templateShortName)
   }
 }

--- a/Sources/ArgumentsUtils.swift
+++ b/Sources/ArgumentsUtils.swift
@@ -80,6 +80,8 @@ enum OutputDestination: ArgumentConvertible {
 enum TemplateError: Error, CustomStringConvertible {
   case namedTemplateNotFound(name: String)
   case templatePathNotFound(path: Path)
+  case noTemplateFound
+  case multipleTemplateOptions(path: String, name: String)
   case deprecated(option: String, replacement: String)
 
   var description: String {
@@ -89,6 +91,15 @@ enum TemplateError: Error, CustomStringConvertible {
       "or use --templatePath to specify a template by its full path."
     case .templatePathNotFound(let path):
       return "Template not found at path \(path.description)."
+    case .noTemplateFound:
+      return "A template must be chosen either via its name using the '-t' / '--template' option" +
+      " or via its path using the '-p' / '--templatePath' option.\n" +
+      "There's no 'default' template anymore: you can still access a bundled template but " +
+      "you have to explicitly specify its name using '-t'.\n" +
+      "To list all the available named templates, you can use the 'swiftgen templates list' command."
+    case let .multipleTemplateOptions(path, name):
+      return "You need to choose EITHER a named template (--template option) " +
+      "OR a template path (option --templatePath). Found name '\(name)' and path '\(path)'"
     case .deprecated(let option, let replacement):
       return "The option '--\(option)' has been deprecated. \(replacement)"
     }
@@ -117,10 +128,11 @@ let bundledTemplatesPath = Path(ProcessInfo.processInfo.arguments[0]).parent() +
  * If `templateFullPath` is empty `""`, search the template named `prefix-templateShortName`
    in the Application Support directory first, then in the bundled templates,
    and returns the path if found (throws if none is found)
+ * If both or neither are empty, an error will be thrown
 
  - parameter prefix:            the prefix for the template, typically name of one of the SwiftGen subcommand
                                 like `strings`, `colors`, etc
- - parameter templateShortName: the short name of the template, might be `"default"` or any custom name
+ - parameter templateShortName: the short name of the template
  - parameter templateFullPath:  the full path of the template to find. If this is set to an existing file, it
                                 returns that Path without even using `prefix` and `templateShortName` parameters.
 
@@ -129,20 +141,24 @@ let bundledTemplatesPath = Path(ProcessInfo.processInfo.arguments[0]).parent() +
  - returns: The Path matching the template to find
  */
 func findTemplate(prefix: String, templateShortName: String, templateFullPath: String) throws -> Path {
-  guard templateFullPath.isEmpty else {
+  switch (templateFullPath, templateShortName) {
+  case ("", ""): throw TemplateError.noTemplateFound
+  case (_, ""):
     let fullPath = Path(templateFullPath)
     guard fullPath.isFile else {
       throw TemplateError.templatePathNotFound(path: fullPath)
     }
     return fullPath
+  case ("", _):
+    var path = appSupportTemplatesPath + "\(prefix)-\(templateShortName).stencil"
+    if !path.isFile {
+      path = bundledTemplatesPath + "\(prefix)-\(templateShortName).stencil"
+    }
+    guard path.isFile else {
+      throw TemplateError.namedTemplateNotFound(name: templateShortName)
+    }
+    return path
+  case (_, _):
+    throw TemplateError.multipleTemplateOptions(path: templateFullPath, name: templateShortName)
   }
-
-  var path = appSupportTemplatesPath + "\(prefix)-\(templateShortName).stencil"
-  if !path.isFile {
-    path = bundledTemplatesPath + "\(prefix)-\(templateShortName).stencil"
-  }
-  guard path.isFile else {
-    throw TemplateError.namedTemplateNotFound(name: templateShortName)
-  }
-  return path
 }

--- a/Sources/ArgumentsUtils.swift
+++ b/Sources/ArgumentsUtils.swift
@@ -80,7 +80,7 @@ enum OutputDestination: ArgumentConvertible {
 enum TemplateError: Error, CustomStringConvertible {
   case namedTemplateNotFound(name: String)
   case templatePathNotFound(path: Path)
-  case noTemplateFound
+  case noTemplateProvided
   case multipleTemplateOptions(path: String, name: String)
   case deprecated(option: String, replacement: String)
 
@@ -91,7 +91,7 @@ enum TemplateError: Error, CustomStringConvertible {
       "or use --templatePath to specify a template by its full path."
     case .templatePathNotFound(let path):
       return "Template not found at path \(path.description)."
-    case .noTemplateFound:
+    case .noTemplateProvided:
       return "A template must be chosen either via its name using the '-t' / '--template' option" +
       " or via its path using the '-p' / '--templatePath' option.\n" +
       "There's no 'default' template anymore: you can still access a bundled template but " +
@@ -142,7 +142,7 @@ let bundledTemplatesPath = Path(ProcessInfo.processInfo.arguments[0]).parent() +
  */
 func findTemplate(prefix: String, templateShortName: String, templateFullPath: String) throws -> Path {
   switch (templateFullPath, templateShortName) {
-  case ("", ""): throw TemplateError.noTemplateFound
+  case ("", ""): throw TemplateError.noTemplateProvided
   case (_, ""):
     let fullPath = Path(templateFullPath)
     guard fullPath.isFile else {

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -23,7 +23,7 @@ if let path = Bundle.main.object(forInfoDictionaryKey: "TemplatePath") as? Strin
 
 func templateOption(prefix: String) -> Option<String> {
   return Option<String>(
-    "template", "default", flag: "t",
+    "template", "", flag: "t",
     description: "The name of the template to use for code generation " +
       "(without the \"\(prefix)\" prefix nor extension)."
   )


### PR DESCRIPTION
* [x] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself
  * [x] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
  * [x] Add a period and 2 spaces at the end of your short entry description
  * [x] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

This is a proposal to implement issue #283.
It includes disabling the default value for the `templateOption` argument which will break existing usage which does not provide any template when invoking swiftgen.