### PR TITLE
Disable old CLI options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ _None_
 
 ### Breaking Changes
 
-_None_
+* Removed deprecated CLI options. Should you still use them, SwiftGen will return an error and show the new recommended CLI option to use instead.
+  [David Jennes](https://github.com/djbe)
+  [#301](https://github.com/SwiftGen/SwiftGenKit/issues/301)
 
 ### New Features
 

--- a/Sources/ArgumentsUtils.swift
+++ b/Sources/ArgumentsUtils.swift
@@ -80,6 +80,7 @@ enum OutputDestination: ArgumentConvertible {
 enum TemplateError: Error, CustomStringConvertible {
   case namedTemplateNotFound(name: String)
   case templatePathNotFound(path: Path)
+  case deprecated(option: String, replacement: String)
 
   var description: String {
     switch self {
@@ -88,6 +89,8 @@ enum TemplateError: Error, CustomStringConvertible {
       "or use --templatePath to specify a template by its full path."
     case .templatePathNotFound(let path):
       return "Template not found at path \(path.description)."
+    case .deprecated(let option, let replacement):
+      return "The option '--\(option)' has been deprecated. \(replacement)"
     }
   }
 }

--- a/Sources/colors.swift
+++ b/Sources/colors.swift
@@ -50,7 +50,7 @@ let colorsCommand = command(
     )
     let template = try StencilSwiftTemplate(templateString: templateRealPath.read(),
                                             environment: stencilSwiftEnvironment())
-    let context = parser.stencilContext(enumName: enumName)
+    let context = parser.stencilContext()
     let enriched = try StencilContext.enrich(context: context, parameters: parameters)
     let rendered = try template.render(enriched)
     output.write(content: rendered, onlyIfChanged: true)

--- a/Sources/colors.swift
+++ b/Sources/colors.swift
@@ -13,10 +13,14 @@ import SwiftGenKit
 let colorsCommand = command(
   outputOption,
   templateOption(prefix: "colors"), templatePathOption,
-  Option<String>("enumName", "ColorName", flag: "e", description: "The name of the enum to generate"),
+  Option<String>("enumName", "", flag: "e", description: "The name of the enum to generate (DEPRECATED)"),
   VariadicOption<String>("param", [], description: "List of template parameters"),
   Argument<Path>("FILE", description: "Colors.txt|.clr|.xml|.json file to parse.", validator: fileExists)
 ) { output, templateName, templatePath, enumName, parameters, path in
+  // show error for old deprecated option
+  guard enumName.isEmpty else {
+    throw TemplateError.deprecated(option: "enumName", replacement: "Please use '--param enumName=...' instead.")
+  }
 
   let parser: ColorsFileParser
   switch path.extension {

--- a/Sources/fonts.swift
+++ b/Sources/fonts.swift
@@ -13,10 +13,14 @@ import SwiftGenKit
 let fontsCommand = command(
   outputOption,
   templateOption(prefix: "fonts"), templatePathOption,
-  Option<String>("enumName", "FontFamily", flag: "e", description: "The name of the enum to generate"),
+  Option<String>("enumName", "", flag: "e", description: "The name of the enum to generate (DEPRECATED)"),
   VariadicOption<String>("param", [], description: "List of template parameters"),
   VariadicArgument<Path>("DIR", description: "Directory to parse.", validator: dirsExist)
   ) { output, templateName, templatePath, enumName, parameters, paths in
+    // show error for old deprecated option
+    guard enumName.isEmpty else {
+      throw TemplateError.deprecated(option: "enumName", replacement: "Please use '--param enumName=...' instead.")
+    }
     let parser = FontsFileParser()
     do {
       for path in paths {

--- a/Sources/fonts.swift
+++ b/Sources/fonts.swift
@@ -33,7 +33,7 @@ let fontsCommand = command(
 
       let template = try StencilSwiftTemplate(templateString: templateRealPath.read(),
                                               environment: stencilSwiftEnvironment())
-      let context = parser.stencilContext(enumName: enumName)
+      let context = parser.stencilContext()
       let enriched = try StencilContext.enrich(context: context, parameters: parameters)
       let rendered = try template.render(enriched)
       output.write(content: rendered, onlyIfChanged: true)

--- a/Sources/images.swift
+++ b/Sources/images.swift
@@ -36,7 +36,7 @@ let imagesCommand = command(
     )
     let template = try StencilSwiftTemplate(templateString: templateRealPath.read(),
                                             environment: stencilSwiftEnvironment())
-    let context = parser.stencilContext(enumName: enumName)
+    let context = parser.stencilContext()
     let enriched = try StencilContext.enrich(context: context, parameters: parameters)
     let rendered = try template.render(enriched)
     output.write(content: rendered, onlyIfChanged: true)

--- a/Sources/images.swift
+++ b/Sources/images.swift
@@ -12,10 +12,14 @@ import SwiftGenKit
 let imagesCommand = command(
   outputOption,
   templateOption(prefix: "images"), templatePathOption,
-  Option<String>("enumName", "Asset", flag: "e", description: "The name of the enum to generate"),
+  Option<String>("enumName", "", flag: "e", description: "The name of the enum to generate (DEPRECATED)"),
   VariadicOption<String>("param", [], description: "List of template parameters"),
   VariadicArgument<Path>("PATHS", description: "Asset Catalog file(s)", validator: dirsExist)
 ) { output, templateName, templatePath, enumName, parameters, paths in
+  // show error for old deprecated option
+  guard enumName.isEmpty else {
+    throw TemplateError.deprecated(option: "enumName", replacement: "Please use '--param enumName=...' instead.")
+  }
   let parser = AssetsCatalogParser()
 
   for path in paths {

--- a/Sources/storyboards.swift
+++ b/Sources/storyboards.swift
@@ -51,8 +51,7 @@ let storyboardsCommand = command(
     )
     let template = try StencilSwiftTemplate(templateString: templateRealPath.read(),
                                             environment: stencilSwiftEnvironment())
-    let context = parser.stencilContext(sceneEnumName: sceneEnumName,
-                                        segueEnumName: segueEnumName)
+    let context = parser.stencilContext()
     let enriched = try StencilContext.enrich(context: context, parameters: parameters)
     let rendered = try template.render(enriched)
     output.write(content: rendered, onlyIfChanged: true)

--- a/Sources/storyboards.swift
+++ b/Sources/storyboards.swift
@@ -12,10 +12,10 @@ import SwiftGenKit
 let storyboardsCommand = command(
   outputOption,
   templateOption(prefix: "storyboards"), templatePathOption,
-  Option<String>("sceneEnumName", "StoryboardScene", flag: "e",
-    description: "The name of the enum to generate for Scenes"),
-  Option<String>("segueEnumName", "StoryboardSegue", flag: "g",
-    description: "The name of the enum to generate for Segues"),
+  Option<String>("sceneEnumName", "", flag: "e",
+    description: "The name of the enum to generate for Scenes (DEPRECATED)"),
+  Option<String>("segueEnumName", "", flag: "g",
+    description: "The name of the enum to generate for Segues (DEPRECATED)"),
   // Note: import option is deprecated.
   VariadicOption<String>("import", [],
     description: "Additional imports to be added to the generated file (DEPRECATED)"),
@@ -24,6 +24,15 @@ let storyboardsCommand = command(
     description: "Directory to scan for .storyboard files. Can also be a path to a single .storyboard",
     validator: pathsExist)
 ) { output, templateName, templatePath, sceneEnumName, segueEnumName, _, parameters, paths in
+  // show error for old deprecated option
+  guard sceneEnumName.isEmpty else {
+    throw TemplateError.deprecated(option: "sceneEnumName",
+                                   replacement: "Please use '--param sceneEnumName=...' instead.")
+  }
+  guard segueEnumName.isEmpty else {
+    throw TemplateError.deprecated(option: "segueEnumName",
+                                   replacement: "Please use '--param segueEnumName=...' instead.")
+  }
   let parser = StoryboardParser()
 
   do {

--- a/Sources/strings.swift
+++ b/Sources/strings.swift
@@ -30,7 +30,7 @@ let stringsCommand = command(
     )
     let template = try StencilSwiftTemplate(templateString: templateRealPath.read(),
                                             environment: stencilSwiftEnvironment())
-    let context = parser.stencilContext(enumName: enumName, tableName: path.lastComponentWithoutExtension)
+    let context = parser.stencilContext(tableName: path.lastComponentWithoutExtension)
     let enriched = try StencilContext.enrich(context: context, parameters: parameters)
     let rendered = try template.render(enriched)
     output.write(content: rendered, onlyIfChanged: true)

--- a/Sources/strings.swift
+++ b/Sources/strings.swift
@@ -12,10 +12,14 @@ import SwiftGenKit
 let stringsCommand = command(
   outputOption,
   templateOption(prefix: "strings"), templatePathOption,
-  Option<String>("enumName", "L10n", flag: "e", description: "The name of the enum to generate"),
+  Option<String>("enumName", "", flag: "e", description: "The name of the enum to generate (DEPRECATED)"),
   VariadicOption<String>("param", [], description: "List of template parameters"),
   Argument<Path>("FILE", description: "Localizable.strings file to parse.", validator: fileExists)
 ) { output, templateName, templatePath, enumName, parameters, path in
+  // show error for old deprecated option
+  guard enumName.isEmpty else {
+    throw TemplateError.deprecated(option: "enumName", replacement: "Please use '--param enumName=...' instead.")
+  }
   let parser = StringsFileParser()
 
   do {

--- a/SwiftGen.xcodeproj/project.pbxproj
+++ b/SwiftGen.xcodeproj/project.pbxproj
@@ -150,10 +150,10 @@
 				091150301BD31A3300EBC803 /* ArgumentsUtils.swift */,
 				0921FBA01BE7D6B900B488B5 /* templates.swift */,
 				09A87B751BCCC02C00D9B9F5 /* colors.swift */,
+				C24AFD011C91DE33005FE3EF /* fonts.swift */,
 				090141401BCC64FE002E8617 /* images.swift */,
 				0901413E1BCC64C9002E8617 /* storyboards.swift */,
 				09A87B731BCCBE6D00D9B9F5 /* strings.swift */,
-				C24AFD011C91DE33005FE3EF /* fonts.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";


### PR DESCRIPTION
Fixes #244.

Doesn't actually remove the options, but throw an error instead, and showing the user what they should use instead.