### PR TITLE
Update CHANGELOG format for linked CHANGELOGs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,12 @@ _None_
 
 ## 4.2.1
 
-• 🔗 [SwiftGenKit 1.1.0](https://github.com/SwiftGen/SwiftGenKit/blob/1.1.0/CHANGELOG.md)
-• 🔗 [StencilSwiftKit 1.0.2](https://github.com/SwiftGen/StencilSwiftKit/blob/1.0.2/CHANGELOG.md)
-• 🔗 [Stencil 0.9.0](https://github.com/kylef/Stencil/blob/0.9.0/CHANGELOG.md)
-• 🔗 [templates 1.1.0](https://github.com/SwiftGen/templates/blob/1.1.0/CHANGELOG.md)
+### Changes in other SwiftGen modules
+
+* [SwiftGenKit 1.1.0](https://github.com/SwiftGen/SwiftGenKit/blob/1.1.0/CHANGELOG.md)
+* [StencilSwiftKit 1.0.2](https://github.com/SwiftGen/StencilSwiftKit/blob/1.0.2/CHANGELOG.md)
+* [Stencil 0.9.0](https://github.com/kylef/Stencil/blob/0.9.0/CHANGELOG.md)
+* [templates 1.1.0](https://github.com/SwiftGen/templates/blob/1.1.0/CHANGELOG.md)
 
 ### Bug Fixes
 
@@ -55,12 +57,12 @@ _None_
 
 ## 4.2.0
 
-• 🔗 [SwiftGenKit 1.0.1](https://github.com/SwiftGen/SwiftGenKit/blob/1.0.1/CHANGELOG.md)
-• 🔗 [StencilSwiftKit 1.0.0](https://github.com/SwiftGen/StencilSwiftKit/blob/1.0.0/CHANGELOG.md)
-• 🔗 [Stencil 0.8.0](https://github.com/kylef/Stencil/blob/0.8.0/CHANGELOG.md)
-• 🔗 [templates 1.0.0](https://github.com/SwiftGen/templates/blob/1.0.0/CHANGELOG.md)
+### Changes in other SwiftGen modules
 
-ℹ️ Don't forget to look at the CHANGELOGs of the other repositories too (links above) in addition to this one, to see all the changes across all of SwiftGen.
+* [SwiftGenKit 1.0.1](https://github.com/SwiftGen/SwiftGenKit/blob/1.0.1/CHANGELOG.md)
+* [StencilSwiftKit 1.0.0](https://github.com/SwiftGen/StencilSwiftKit/blob/1.0.0/CHANGELOG.md)
+* [Stencil 0.8.0](https://github.com/kylef/Stencil/blob/0.8.0/CHANGELOG.md)
+* [templates 1.0.0](https://github.com/SwiftGen/templates/blob/1.0.0/CHANGELOG.md)
 
 ### Bug Fixes
 

--- a/Rakefile
+++ b/Rakefile
@@ -86,6 +86,36 @@ end
 
 task :default => 'cli:build'
 
+## [ ChangeLog ] ##############################################################
+
+namespace :changelog do
+  LINKS_SECTION_TITLE = 'Changes in other SwiftGen modules'
+
+  desc 'Add links to other CHANGELOGs in the topmost SwiftGen CHANGELOG entry'
+  task :links do
+    changelog = File.read('CHANGELOG.md')
+    abort('Links seems to already exist for latest version entry') if /^### (.*)/.match(changelog)[1] == LINKS_SECTION_TITLE
+    links = linked_changelogs(
+      swiftgenkit: Utils.podfile_lock_version('SwiftGenKit'),
+      stencilswiftkit: Utils.podfile_lock_version('StencilSwiftKit'),
+      stencil: Utils.podfile_lock_version('Stencil'),
+      templates: Dir.chdir('Resources') { `git describe --abbrev=0 --tags`.chomp }
+    )
+    changelog.sub!(/^##[^#].*$\n/, "\\0\n#{links}")
+    File.write('CHANGELOG.md', changelog)
+  end
+
+  def linked_changelogs(swiftgenkit: nil, stencilswiftkit: nil, stencil: nil, templates: nil)
+    return <<-LINKS.gsub(/^\s*\|/,'')
+      |### #{LINKS_SECTION_TITLE}
+      |
+      |* [SwiftGenKit #{swiftgenkit}](https://github.com/SwiftGen/SwiftGenKit/blob/#{swiftgenkit}/CHANGELOG.md)
+      |* [StencilSwiftKit #{stencilswiftkit}](https://github.com/SwiftGen/StencilSwiftKit/blob/#{stencilswiftkit}/CHANGELOG.md)
+      |* [Stencil #{stencil}](https://github.com/kylef/Stencil/blob/#{stencil}/CHANGELOG.md)
+      |* [templates #{templates}](https://github.com/SwiftGen/templates/blob/#{templates}/CHANGELOG.md)
+    LINKS
+  end
+end
 
 ## [ Playground Resources ] ###################################################
 


### PR DESCRIPTION
* [ ] ~I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself~ ➡️  How meta would that be 😄 (Probably not worth mentioning in the CHANGELOG)

---

## Motivation

* The scripts to automate the releases — and copy the content of the CHANGELOG entries for the latest version into the GitHub release text — currently fails because when sending the request to the GitHub API to update the release text, it seems that 🔗  and other characters were creating problems and made the API fail
* But more importantly, with this new format the links to the other CHANGELOGs will be more visible to users, inciting them to actually go and read those CHANGELOGs (the current format was probably _too_ discreet and I think a lot of people didn't read those changes in the other modules) as they are generally _more_ important than the changes done in this repo which is only the CLI part of SwiftGen