### PR TITLE
Improve Install instructions in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ _None_
 
 ### Internal Changes
 
-_None_
+* Improved installation instructions in the README.  
+  [Olivier Halligon](https://github.com/alisoftware)
+  [#303](https://github.com/SwiftGen/SwiftGenKit/issues/303)
 
 ## 4.2.1
 

--- a/README.md
+++ b/README.md
@@ -35,17 +35,44 @@ Also, it's fully customizable thanks to Stencil templates, so even if it comes w
 
 ## Installation
 
+There are multiple possibilities to install SwiftGen on your machine or in your project, depending on your preferences and needs:
+
 <details>
-<summary>Via CocoaPods</summary>
+<summary><strong>Download the ZIP</strong> for the latest release</summary>
+
+* [Go to the GitHub page for the latest release](https://github.com/SwiftGen/SwiftGen/releases/latest)
+* Download the `swiftgen-x.y.z.zip` file associated with that release
+* Extract the content of the zip archive in your project directory
+
+We recommend that you **unarchive the ZIP inside your project directory** and **commit its content** to git. This way, **all coworkers will use the same version of SwiftGen for this project**.
+
+If you unarchived the ZIP file in a folder e.g. called `swiftgen` at the root of your project directory, you can then invoke SwiftGen in your Script Build Phase using:
+
+```sh
+"$PROJECT_DIR"/swiftgen/bin/swiftgen …
+```
+
+---
+</details>
+<details>
+<summary>Via <strong>CocoaPods</strong></summary>
 
 If you're using CocoaPods, you can simply add `pod 'SwiftGen'` to your `Podfile`.
 
-This will download the `SwiftGen` binaries and dependencies in `Pods/` during your next `pod install` execution
-and will allow you to invoke it via `$PODS_ROOT/SwiftGen/bin/swiftgen` in your Script Build Phases.
-</details>
+This will download the `SwiftGen` binaries and dependencies in `Pods/` during your next `pod install` execution.
 
+Given that you can specify an exact version for `SwiftGen` in your `Podfile`, this allows you to ensure **all coworkers will use the same version of SwiftGen for this project**.
+
+You can then invoke SwiftGen in your Script Build Phase using:
+
+```sh
+$PODS_ROOT/SwiftGen/bin/swiftgen …
+```
+
+---
+</details>
 <details>
-<summary>Via Homebrew</summary>
+<summary>Via <strong>Homebrew</strong> <em>(system-wide installation)</em></summary>
 
 To install SwiftGen via [Homebrew](http://brew.sh), simply use:
 
@@ -53,13 +80,22 @@ To install SwiftGen via [Homebrew](http://brew.sh), simply use:
 $ brew update
 $ brew install swiftgen
 ```
+
+This will install SwiftGen **system-wide**. The same version of SwiftGen will be used for all projects on that machine, and you should make sure all your coworkers have the same version of SwiftGen installed on their machine too.
+
+You can then invoke `swiftgen` directly in your Script Build Phase (as it will be in your `$PATH` already):
+
+```sh
+swiftgen … 
+```
+
+---
 </details>
-
 <details>
-<summary>Compile from source</summary>
+<summary><strong>Compile from source</strong> <em>(only recommended if you need features from master or want to test a PR)</em></summary>
 
-Alternatively, you can clone the repository and use `rake install` to build the tool.  
-_With this solution you're sure to build and install the latest version from `master`._
+Alternatively, you can clone the repository and use `rake cli:install` to build the tool.  
+_With this solution you're sure to build and install the latest version from `master` and have access to features which might not have been released yet._
 
 You can install to the default locations (no parameter) or to custom locations:
 
@@ -70,6 +106,16 @@ $ rake cli:install
 # Binary will be installed in `~/swiftgen/bin`, framworks in `~/swiftgen/fmk` and templates in `~/swiftgen/tpl`
 $ rake cli:install[~/swiftgen/bin,~/swiftgen/fmk,~/swiftgen/tpl]
 ```
+
+You can then invoke SwiftGen in your Script Build Phase using the path to the binary where you installed it:
+
+```sh
+~/swiftgen/bin/swiftgen …
+```
+
+Or add the path to the `bin` folder to your `$PATH` and invoke `swiftgen` directly.
+
+---
 </details>
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -94,8 +94,15 @@ swiftgen …
 <details>
 <summary><strong>Compile from source</strong> <em>(only recommended if you need features from master or want to test a PR)</em></summary>
 
-Alternatively, you can clone the repository and use `rake cli:install` to build the tool.  
-_With this solution you're sure to build and install the latest version from `master` and have access to features which might not have been released yet._
+This solution is when you want to build and install the latest version from `master` and have access to features which might not have been released yet.
+
+* If you have `homebrew` installed, you can use the following command to build and install the latest commit:
+
+```sh
+brew install swiftgen --HEAD
+```
+
+* Alternatively, you can clone the repository and use `rake cli:install` to build the tool and install it from any branch, which could be useful to test SwiftGen in a fork or a Pull Request branch.
 
 You can install to the default locations (no parameter) or to custom locations:
 
@@ -103,11 +110,11 @@ You can install to the default locations (no parameter) or to custom locations:
 # Binary is installed in `./swiftgen/bin`, frameworks in `./swiftgen/lib` and templates in `./swiftgen/templates`
 $ rake cli:install
 # - OR -
-# Binary will be installed in `~/swiftgen/bin`, framworks in `~/swiftgen/fmk` and templates in `~/swiftgen/tpl`
+# Binary will be installed in `~/swiftgen/bin`, frameworks in `~/swiftgen/fmk` and templates in `~/swiftgen/tpl`
 $ rake cli:install[~/swiftgen/bin,~/swiftgen/fmk,~/swiftgen/tpl]
 ```
 
-You can then invoke SwiftGen in your Script Build Phase using the path to the binary where you installed it:
+You can then invoke SwiftGen using the path to the binary where you installed it:
 
 ```sh
 ~/swiftgen/bin/swiftgen …


### PR DESCRIPTION
* [x] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself
  * [x] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
  * [x] Add a period and 2 spaces at the end of your short entry description
  * [x] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

## Motivation

I've seen a lot of people preferring downloading the ZIP to install SwiftGen, especially unarchiving it in their project folder and committing it to git, so that every co-worker are assured to use the same version on all their machines for this project. This also allows people to have different versions of SwiftGen for different projects, in case some projects are ready to update but not others.

That's also the installation method that is used by Sourcery, so we'd have some consistency here