### PR TITLE
Templates in subdirectories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ _None_
 * Removed deprecated CLI options. Should you still use them, SwiftGen will return an error and show the new recommended CLI option to use instead.
   [David Jennes](https://github.com/djbe)
   [#301](https://github.com/SwiftGen/SwiftGenKit/issues/301)
+* Templates are now grouped by subcommand on the filesystem. This is only important if you had custom templates in the `Application Support` directory. To migrate your templates, place them in a subfolder with the name of the subcommand, and remove the prefix of the template filename.
+  [David Jennes](https://github.com/djbe)
+  [#304](https://github.com/SwiftGen/SwiftGenKit/issues/304)
 
 ### New Features
 

--- a/Sources/ArgumentsUtils.swift
+++ b/Sources/ArgumentsUtils.swift
@@ -114,21 +114,21 @@ let bundledTemplatesPath = Path(ProcessInfo.processInfo.arguments[0]).parent() +
 /**
  Returns the path of a template given its prefix and short name, or its full path.
  * If `templateFullPath` is not empty, check that the path exists and return it (throws if it isn't an existing file)
- * If `templateFullPath` is empty `""`, search the template named `prefix-templateShortName`
+ * If `templateFullPath` is empty `""`, search the template named `templateShortName` in the folder `subcommand`
    in the Application Support directory first, then in the bundled templates,
    and returns the path if found (throws if none is found)
 
- - parameter prefix:            the prefix for the template, typically name of one of the SwiftGen subcommand
+ - parameter subcommand         the folder for the template, typically name of one of the SwiftGen subcommand
                                 like `strings`, `colors`, etc
  - parameter templateShortName: the short name of the template, might be `"default"` or any custom name
  - parameter templateFullPath:  the full path of the template to find. If this is set to an existing file, it
-                                returns that Path without even using `prefix` and `templateShortName` parameters.
+                                returns that Path without even using `subcommand` and `templateShortName` parameters.
 
  - throws: TemplateError
 
  - returns: The Path matching the template to find
  */
-func findTemplate(prefix: String, templateShortName: String, templateFullPath: String) throws -> Path {
+func findTemplate(subcommand: String, templateShortName: String, templateFullPath: String) throws -> Path {
   guard templateFullPath.isEmpty else {
     let fullPath = Path(templateFullPath)
     guard fullPath.isFile else {
@@ -137,9 +137,9 @@ func findTemplate(prefix: String, templateShortName: String, templateFullPath: S
     return fullPath
   }
 
-  var path = appSupportTemplatesPath + "\(prefix)-\(templateShortName).stencil"
+  var path = appSupportTemplatesPath + subcommand + "\(templateShortName).stencil"
   if !path.isFile {
-    path = bundledTemplatesPath + "\(prefix)-\(templateShortName).stencil"
+    path = bundledTemplatesPath + subcommand + "\(templateShortName).stencil"
   }
   guard path.isFile else {
     throw TemplateError.namedTemplateNotFound(name: templateShortName)

--- a/Sources/colors.swift
+++ b/Sources/colors.swift
@@ -11,12 +11,10 @@ import StencilSwiftKit
 import SwiftGenKit
 
 let colorsCommand = command(
-  outputOption,
-  templateOption(prefix: "colors"), templatePathOption,
+  outputOption, templateNameOption, templatePathOption, paramsOption,
   Option<String>("enumName", "", flag: "e", description: "The name of the enum to generate (DEPRECATED)"),
-  VariadicOption<String>("param", [], description: "List of template parameters"),
   Argument<Path>("FILE", description: "Colors.txt|.clr|.xml|.json file to parse.", validator: fileExists)
-) { output, templateName, templatePath, enumName, parameters, path in
+) { output, templateName, templatePath, parameters, enumName, path in
   // show error for old deprecated option
   guard enumName.isEmpty else {
     throw TemplateError.deprecated(option: "enumName", replacement: "Please use '--param enumName=...' instead.")

--- a/Sources/colors.swift
+++ b/Sources/colors.swift
@@ -46,7 +46,7 @@ let colorsCommand = command(
 
   do {
     let templateRealPath = try findTemplate(
-      prefix: "colors", templateShortName: templateName, templateFullPath: templatePath
+      subcommand: "colors", templateShortName: templateName, templateFullPath: templatePath
     )
     let template = try StencilSwiftTemplate(templateString: templateRealPath.read(),
                                             environment: stencilSwiftEnvironment())

--- a/Sources/fonts.swift
+++ b/Sources/fonts.swift
@@ -28,7 +28,7 @@ let fontsCommand = command(
       }
 
       let templateRealPath = try findTemplate(
-        prefix: "fonts", templateShortName: templateName, templateFullPath: templatePath
+        subcommand: "fonts", templateShortName: templateName, templateFullPath: templatePath
       )
 
       let template = try StencilSwiftTemplate(templateString: templateRealPath.read(),

--- a/Sources/fonts.swift
+++ b/Sources/fonts.swift
@@ -11,12 +11,10 @@ import StencilSwiftKit
 import SwiftGenKit
 
 let fontsCommand = command(
-  outputOption,
-  templateOption(prefix: "fonts"), templatePathOption,
+  outputOption, templateNameOption, templatePathOption, paramsOption,
   Option<String>("enumName", "", flag: "e", description: "The name of the enum to generate (DEPRECATED)"),
-  VariadicOption<String>("param", [], description: "List of template parameters"),
   VariadicArgument<Path>("DIR", description: "Directory to parse.", validator: dirsExist)
-  ) { output, templateName, templatePath, enumName, parameters, paths in
+  ) { output, templateName, templatePath, parameters, enumName, paths in
     // show error for old deprecated option
     guard enumName.isEmpty else {
       throw TemplateError.deprecated(option: "enumName", replacement: "Please use '--param enumName=...' instead.")

--- a/Sources/images.swift
+++ b/Sources/images.swift
@@ -32,7 +32,7 @@ let imagesCommand = command(
 
   do {
     let templateRealPath = try findTemplate(
-      prefix: "images", templateShortName: templateName, templateFullPath: templatePath
+      subcommand: "images", templateShortName: templateName, templateFullPath: templatePath
     )
     let template = try StencilSwiftTemplate(templateString: templateRealPath.read(),
                                             environment: stencilSwiftEnvironment())

--- a/Sources/images.swift
+++ b/Sources/images.swift
@@ -10,12 +10,10 @@ import StencilSwiftKit
 import SwiftGenKit
 
 let imagesCommand = command(
-  outputOption,
-  templateOption(prefix: "images"), templatePathOption,
+  outputOption, templateNameOption, templatePathOption, paramsOption,
   Option<String>("enumName", "", flag: "e", description: "The name of the enum to generate (DEPRECATED)"),
-  VariadicOption<String>("param", [], description: "List of template parameters"),
   VariadicArgument<Path>("PATHS", description: "Asset Catalog file(s)", validator: dirsExist)
-) { output, templateName, templatePath, enumName, parameters, paths in
+) { output, templateName, templatePath, parameters, enumName, paths in
   // show error for old deprecated option
   guard enumName.isEmpty else {
     throw TemplateError.deprecated(option: "enumName", replacement: "Please use '--param enumName=...' instead.")

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -21,13 +21,11 @@ if let path = Bundle.main.object(forInfoDictionaryKey: "TemplatePath") as? Strin
   templatesRelativePath = "../templates"
 }
 
-func templateOption(prefix: String) -> Option<String> {
-  return Option<String>(
-    "template", "default", flag: "t",
-    description: "The name of the template to use for code generation " +
-      "(without the \"\(prefix)\" prefix nor extension)."
-  )
-}
+let templateNameOption = Option<String>(
+  "template", "default", flag: "t",
+  description: "The name of the template to use for code generation " +
+    "(without the extension)."
+)
 
 let templatePathOption = Option<String>(
   "templatePath", "", flag: "p",
@@ -37,6 +35,11 @@ let templatePathOption = Option<String>(
 let outputOption = Option(
   "output", OutputDestination.console, flag: "o",
   description: "The path to the file to generate (Omit to generate to stdout)"
+)
+
+let paramsOption = VariadicOption<String>(
+  "param", [],
+  description: "List of template parameters"
 )
 
 // MARK: - Main

--- a/Sources/storyboards.swift
+++ b/Sources/storyboards.swift
@@ -45,7 +45,7 @@ let storyboardsCommand = command(
     }
 
     let templateRealPath = try findTemplate(
-      prefix: "storyboards",
+      subcommand: "storyboards",
       templateShortName: templateName,
       templateFullPath: templatePath
     )

--- a/Sources/storyboards.swift
+++ b/Sources/storyboards.swift
@@ -10,8 +10,7 @@ import StencilSwiftKit
 import SwiftGenKit
 
 let storyboardsCommand = command(
-  outputOption,
-  templateOption(prefix: "storyboards"), templatePathOption,
+  outputOption, templateNameOption, templatePathOption, paramsOption,
   Option<String>("sceneEnumName", "", flag: "e",
     description: "The name of the enum to generate for Scenes (DEPRECATED)"),
   Option<String>("segueEnumName", "", flag: "g",
@@ -19,11 +18,10 @@ let storyboardsCommand = command(
   // Note: import option is deprecated.
   VariadicOption<String>("import", [],
     description: "Additional imports to be added to the generated file (DEPRECATED)"),
-  VariadicOption<String>("param", [], description: "List of template parameters"),
   VariadicArgument<Path>("PATH",
     description: "Directory to scan for .storyboard files. Can also be a path to a single .storyboard",
     validator: pathsExist)
-) { output, templateName, templatePath, sceneEnumName, segueEnumName, _, parameters, paths in
+) { output, templateName, templatePath, parameters, sceneEnumName, segueEnumName, _, paths in
   // show error for old deprecated option
   guard sceneEnumName.isEmpty else {
     throw TemplateError.deprecated(option: "sceneEnumName",

--- a/Sources/strings.swift
+++ b/Sources/strings.swift
@@ -26,7 +26,7 @@ let stringsCommand = command(
     try parser.parseFile(at: path)
 
     let templateRealPath = try findTemplate(
-      prefix: "strings", templateShortName: templateName, templateFullPath: templatePath
+      subcommand: "strings", templateShortName: templateName, templateFullPath: templatePath
     )
     let template = try StencilSwiftTemplate(templateString: templateRealPath.read(),
                                             environment: stencilSwiftEnvironment())

--- a/Sources/strings.swift
+++ b/Sources/strings.swift
@@ -10,12 +10,10 @@ import StencilSwiftKit
 import SwiftGenKit
 
 let stringsCommand = command(
-  outputOption,
-  templateOption(prefix: "strings"), templatePathOption,
+  outputOption, templateNameOption, templatePathOption, paramsOption,
   Option<String>("enumName", "", flag: "e", description: "The name of the enum to generate (DEPRECATED)"),
-  VariadicOption<String>("param", [], description: "List of template parameters"),
   Argument<Path>("FILE", description: "Localizable.strings file to parse.", validator: fileExists)
-) { output, templateName, templatePath, enumName, parameters, path in
+) { output, templateName, templatePath, parameters, enumName, path in
   // show error for old deprecated option
   guard enumName.isEmpty else {
     throw TemplateError.deprecated(option: "enumName", replacement: "Please use '--param enumName=...' instead.")

--- a/Sources/templates.swift
+++ b/Sources/templates.swift
@@ -19,32 +19,33 @@ let templatesListCommand = command(
   },
   outputOption
 ) { onlySubcommand, output in
-  let customTemplates = (try? appSupportTemplatesPath.children()) ?? []
-  let bundledTemplates = (try? bundledTemplatesPath.children()) ?? []
   var outputLines = [String]()
 
-  let printTemplates = { (prefix: String, list: [Path]) in
-    for file in list where file.lastComponent.hasPrefix("\(prefix)-") && file.extension == "stencil" {
+  let printTemplates = { (subcommand: String, path: Path) in
+    guard let files = try? (path + subcommand).children() else { return }
+
+    for file in files where file.extension == "stencil" {
       let basename = file.lastComponentWithoutExtension
-      let idx = basename.index(basename.startIndex, offsetBy: prefix.characters.count+1)
-      let name = basename[idx..<basename.endIndex]
-      outputLines.append("   - \(name)")
+      outputLines.append("   - \(basename)")
     }
   }
 
   let subcommandsToList = onlySubcommand.isEmpty ? allSubcommands : [onlySubcommand]
-  for prefix in subcommandsToList {
-    outputLines.append("\(prefix):")
+  for subcommand in subcommandsToList {
+    outputLines.append("\(subcommand):")
     outputLines.append("  custom:")
-    printTemplates(prefix, customTemplates)
+    printTemplates(subcommand, appSupportTemplatesPath)
     outputLines.append("  bundled:")
-    printTemplates(prefix, bundledTemplates)
+    printTemplates(subcommand, bundledTemplatesPath)
   }
 
   outputLines.append("---")
   outputLines.append("You can add custom templates in \(appSupportTemplatesPath).")
-  outputLines.append("Simply name them 'subcmd-customname.stencil' where subcmd is one of the swiftgen subcommand,")
-  outputLines.append("namely " + allSubcommands.map({"\($0)-xxx.stencil"}).joined(separator: ", ") + ".")
+  outputLines.append("Simply place them in a subfolder of this path with as name one of the swiftgen subcommands,")
+  outputLines.append("namely " + allSubcommands.map({"'\($0)'"}).joined(separator: ", ") + ". Your template must be")
+  outputLines.append("in the right subfolder, and must have as extension '.stencil'. For example, if you created a")
+  outputLines.append("custom template for the strings command, place it in the following path:")
+  outputLines.append("strings/customname.stencil")
   outputLines.append("")
 
   output.write(content: outputLines.joined(separator: "\n"))
@@ -52,21 +53,14 @@ let templatesListCommand = command(
 
 private func templatePathCommandGenerator(execute: @escaping (Path, OutputDestination) throws -> Void) -> CommandType {
   return command(
-    Argument<String>("name",
-      description: "the name of the template to find, like `colors` for the default one" +
-      " or `colors-rawValue' for a specific one"),
+    Argument<String>("subcommand",
+      description: "the name of the subcommand for the template, like `colors`"),
+    Argument<String>("template",
+      description: "the name of the template to find, like `swift3` or `dot-syntax`"),
     outputOption
-  ) { name, output in
+  ) { subcommand, name, output in
     do {
-      let (prefix, shortName): (String, String)
-      if let hyphenPos = name.characters.index(of: "-") {
-        prefix = String(name.characters[name.characters.startIndex..<hyphenPos])
-        shortName = String(name.characters[name.characters.index(after: hyphenPos)..<name.characters.endIndex])
-      } else {
-        prefix = name
-        shortName = "default"
-      }
-      let path = try findTemplate(subcommand: prefix, templateShortName: shortName, templateFullPath: "")
+      let path = try findTemplate(subcommand: subcommand, templateShortName: name, templateFullPath: "")
       try execute(path, output)
     } catch {
       printError(string: "error: failed to read template: \(error)")

--- a/Sources/templates.swift
+++ b/Sources/templates.swift
@@ -66,7 +66,7 @@ private func templatePathCommandGenerator(execute: @escaping (Path, OutputDestin
         prefix = name
         shortName = "default"
       }
-      let path = try findTemplate(prefix: prefix, templateShortName: shortName, templateFullPath: "")
+      let path = try findTemplate(subcommand: prefix, templateShortName: shortName, templateFullPath: "")
       try execute(path, output)
     } catch {
       printError(string: "error: failed to read template: \(error)")

--- a/Sources/templates.swift
+++ b/Sources/templates.swift
@@ -46,7 +46,7 @@ let templatesListCommand = command(
   outputLines.append("template must be in the right subfolder, and must have the extension `.stencil`.")
   outputLines.append("")
   outputLines.append("For example, if you want to create a custom template named \"customname\" for the strings")
-  outputLines.append("command, place it in \"'(appSupportTemplatesPath)/strings/customname.stencil)\".")
+  outputLines.append("command, place it in \"\(appSupportTemplatesPath)/strings/customname.stencil\".")
   outputLines.append("")
 
   output.write(content: outputLines.joined(separator: "\n"))

--- a/Sources/templates.swift
+++ b/Sources/templates.swift
@@ -41,16 +41,22 @@ let templatesListCommand = command(
 
   outputLines.append("---")
   outputLines.append("You can add custom templates in \(appSupportTemplatesPath).")
-  outputLines.append("Simply place them in a subfolder of this path with as name one of the swiftgen subcommands,")
-  outputLines.append("namely " + allSubcommands.map({"'\($0)'"}).joined(separator: ", ") + ". Your template must be")
-  outputLines.append("in the right subfolder, and must have as extension '.stencil'. For example, if you created a")
-  outputLines.append("custom template for the strings command, place it in the following path:")
-  outputLines.append("strings/customname.stencil")
+  outputLines.append("Simply place them in a subfolder of this path named after the corresponding swiftgen")
+  outputLines.append("subcommand, namely " + allSubcommands.map({"'\($0)'"}).joined(separator: ", ") + ". Your")
+  outputLines.append("template must be in the right subfolder, and must have the extension `.stencil`.")
+  outputLines.append("")
+  outputLines.append("For example, if you want to create a custom template named \"customname\" for the strings")
+  outputLines.append("command, place it in \"'(appSupportTemplatesPath)/strings/customname.stencil)\".")
   outputLines.append("")
 
   output.write(content: outputLines.joined(separator: "\n"))
 }
 
+// Defines a 'generic' command for doing an operation on a named template. It'll receive the following
+// arguments from the user:
+// - 'subcommand'
+// - 'template'
+// These will then be converted into an actual template path, and passed to the result closure.
 private func templatePathCommandGenerator(execute: @escaping (Path, OutputDestination) throws -> Void) -> CommandType {
   return command(
     Argument<String>("subcommand",


### PR DESCRIPTION
Implements the SwiftGen CLI side of https://github.com/SwiftGen/templates/issues/1.
Related PR: https://github.com/SwiftGen/templates/pull/13

I'd like some feedback on the rewritten text in the `templates` command, as well as the changelog entry with migration instructions (really barebones for now).