### PR TITLE
Remove unneeded file.zip from CocoaPods installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ---
 
+## Master
+
+### Bug Fixes
+
+* When installing SwiftGen via CocoaPods, the unneeded `file.zip` is not kept in `Pods/SwiftGen/` anymore _(freeing ~5MB on each install of SwiftGen made via CocoaPods!)_.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+
 ## 5.1.2
 
 * Allows the SwiftGen source code to be built with Xcode 9.

--- a/SwiftGen.podspec
+++ b/SwiftGen.podspec
@@ -20,4 +20,5 @@ Pod::Spec.new do |s|
 
   s.source = { http: "https://github.com/SwiftGen/SwiftGen/releases/download/#{s.version}/swiftgen-#{s.version}.zip" }
   s.preserve_paths = '*'
+  s.exclude_files = '**/file.zip'
 end


### PR DESCRIPTION
* [X] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself
  * [X] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
  * [X] Add a period and 2 spaces at the end of your short entry description
  * [X] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

When installing SwiftGen via CocoaPods, the `file.zip` file downloaded by CocoaPods containing the SwiftGen release (binary + templates) before unzipping was kept after install. This is because we explicitly used `s.preserve_paths = '*'` in the `.podspec`

The solution (inspired by SwiftLint's podspec) is to explicitly exclude this `file.zip` in the files to keep in the podspec.