### PR TITLE
Errors now always throw and thus exit with non-zero exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 * Fix SwiftGen no longer working using CLI parameters (instead of config file).  
   [David Jennes](https://github.com/djbe) 
   [#347](https://github.com/SwiftGen/SwiftGen/pull/347)
+* Errors now properly exit with a non-zero exit code.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#348](https://github.com/SwiftGen/SwiftGen/pull/348)
 
 ### Breaking Changes
 

--- a/Sources/Commander/ConfigCommands.swift
+++ b/Sources/Commander/ConfigCommands.swift
@@ -25,24 +25,18 @@ extension Config.Entry {
 
   func run(parserCommand: ParserCLI) throws {
     let parser = try parserCommand.parserType.init(options: [:], warningHandler: { (msg, _, _) in
-      logMessage(.error, msg)
+      logMessage(.warning, msg)
     })
     try parser.parse(paths: self.paths)
-    do {
-      let templateRealPath = try self.template.resolvePath(forSubcommand: parserCommand.name)
-      let template = try StencilSwiftTemplate(templateString: templateRealPath.read(),
-                                              environment: stencilSwiftEnvironment())
+    let templateRealPath = try self.template.resolvePath(forSubcommand: parserCommand.name)
+    let template = try StencilSwiftTemplate(templateString: templateRealPath.read(),
+                                            environment: stencilSwiftEnvironment())
 
-      let context = parser.stencilContext()
-      let enriched = try StencilContext.enrich(context: context, parameters: self.parameters)
-      let rendered = try template.render(enriched)
-      let output = OutputDestination.file(self.output)
-      output.write(content: rendered, onlyIfChanged: true)
-    } catch let error as TemplateRef.Error {
-      logMessage(.error, error)
-    } catch let error {
-      logMessage(.error, "failed to render template: \(error)")
-    }
+    let context = parser.stencilContext()
+    let enriched = try StencilContext.enrich(context: context, parameters: self.parameters)
+    let rendered = try template.render(enriched)
+    let output = OutputDestination.file(self.output)
+    try output.write(content: rendered, onlyIfChanged: true)
   }
 }
 
@@ -55,9 +49,11 @@ let configLintCommand = command(
                description: "Path to the configuration file to use",
                validator: checkPath(type: "config file") { $0.isFile })
 ) { file in
-  logMessage(.info, "Linting \(file)")
-  let config = try Config(file: file)
-  config.lint { level, msg in logMessage(level, msg) }
+  try ErrorPrettifier.execute {
+    logMessage(.info, "Linting \(file)")
+    let config = try Config(file: file)
+    config.lint { level, msg in logMessage(level, msg) }
+  }
 }
 
 // MARK: Run
@@ -69,26 +65,24 @@ let configRunCommand = command(
   Flag("verbose", default: false, flag: "v",
        description: "Print each command being executed")
 ) { file, verbose in
-  let config = try Config(file: file)
+  try ErrorPrettifier.execute {
+    let config = try Config(file: file)
 
-  if verbose {
-    logMessage(.info, "Executing configuration file \(file)")
-  }
-  try file.parent().chdir {
-    for (cmd, entries) in config.commands {
-      for var entry in entries {
-        guard let parserCmd = allParserCommands.first(where: { $0.name == cmd }) else {
-          throw Config.Error.missingEntry(key: cmd)
-        }
-        entry.makeRelativeTo(inputDir: config.inputDir, outputDir: config.outputDir)
-        do {
+    if verbose {
+      logMessage(.info, "Executing configuration file \(file)")
+    }
+    try file.parent().chdir {
+      for (cmd, entries) in config.commands {
+        for var entry in entries {
+          guard let parserCmd = allParserCommands.first(where: { $0.name == cmd }) else {
+            throw Config.Error.missingEntry(key: cmd)
+          }
+          entry.makeRelativeTo(inputDir: config.inputDir, outputDir: config.outputDir)
           if verbose {
             logMessage(.info, " $ " + entry.commandLine(forCommand: cmd))
           }
           try entry.checkPaths()
           try entry.run(parserCommand: parserCmd)
-        } catch let e {
-          logMessage(.error, String(describing: e))
         }
       }
     }

--- a/Sources/Commander/OutputDestination.swift
+++ b/Sources/Commander/OutputDestination.swift
@@ -27,21 +27,17 @@ enum OutputDestination: ArgumentConvertible {
     }
   }
 
-  func write(content: String, onlyIfChanged: Bool = false) {
+  func write(content: String, onlyIfChanged: Bool = false) throws {
     switch self {
     case .console:
       print(content)
     case .file(let path):
-      do {
-        if try onlyIfChanged && path.exists && path.read(.utf8) == content {
-          logMessage(.info, "Not writing the file as content is unchanged")
-          return
-        }
-        try path.write(content)
-        logMessage(.info, "File written: \(path)")
-      } catch let e as NSError {
-        logMessage(.error, e)
+      if try onlyIfChanged && path.exists && path.read(.utf8) == content {
+        logMessage(.info, "Not writing the file as content is unchanged")
+        return
       }
+      try path.write(content)
+      logMessage(.info, "File written: \(path)")
     }
   }
 }

--- a/Sources/Commander/ParserCLICommands.swift
+++ b/Sources/Commander/ParserCLICommands.swift
@@ -34,12 +34,12 @@ extension ParserCLI {
       paramsOption,
       VariadicArgument<Path>("PATH", description: self.pathDescription, validator: pathsExist)
     ) { output, templateName, templatePath, parameters, paths in
-      let parser = try self.parserType.init(options: [:]) { msg, _, _ in
-        logMessage(.warning, msg)
-      }
-      try parser.parse(paths: paths)
+      try ErrorPrettifier.execute {
+        let parser = try self.parserType.init(options: [:]) { msg, _, _ in
+          logMessage(.warning, msg)
+        }
+        try parser.parse(paths: paths)
 
-      do {
         let templateRef = try TemplateRef(templateShortName: templateName,
                                           templateFullPath: templatePath)
         let templateRealPath = try templateRef.resolvePath(forSubcommand: self.name)
@@ -50,11 +50,7 @@ extension ParserCLI {
         let context = parser.stencilContext()
         let enriched = try StencilContext.enrich(context: context, parameters: parameters)
         let rendered = try template.render(enriched)
-        output.write(content: rendered, onlyIfChanged: true)
-      } catch let error as TemplateRef.Error {
-        logMessage(.error, error)
-      } catch let error {
-        logMessage(.error, "failed to render template: \(error)")
+        try output.write(content: rendered, onlyIfChanged: true)
       }
     }
   }

--- a/Sources/Logs.swift
+++ b/Sources/Logs.swift
@@ -51,3 +51,18 @@ func logMessage(_ level: LogLevel, _ string: CustomStringConvertible) {
     fputs(ANSIColor.red.format("Error: \(string)\n"), stderr)
   }
 }
+
+struct ErrorPrettifier: Error, CustomStringConvertible {
+  let nsError: NSError
+  var description: String {
+    return "\(nsError.localizedDescription) (\(nsError.domain) code \(nsError.code))"
+  }
+
+  static func execute(closure: () throws -> Void ) rethrows {
+    do {
+      try closure()
+    } catch let e as NSError where e.domain == NSCocoaErrorDomain {
+      throw ErrorPrettifier(nsError: e)
+    }
+  }
+}


### PR DESCRIPTION
Fixes the second part of #346 (\cc @NachoSoto)

Basically, I've removed all `logMessage(.error, …)` calls and replaced intermediate `do { } catch { }` blocks with `ErrorPrettifier.execute { }`, which rethrows the error (and let it bubble up all the way to `Commander.main`) — just prettifying non-SwifGen, generic `NSCocoaErrors` thrown in that closure before rethrowing them, so that "Permission denied" errors and such are not printed in an ugly message in `stderr` but are presented in a nicer way.

@djbe this PR is meant to be merged after #347 so I've made the request to merge into your fix/templateref-empty-path branch. We can either merge #347 first then this one next, or merge this one first into #347 then merge #347 to merge it all to master.