### PR TITLE
Print full help when no subcommand used but --help flag set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 * Errors now properly exit with a non-zero exit code.  
   [Olivier Halligon](https://github.com/AliSoftware)
   [#348](https://github.com/SwiftGen/SwiftGen/pull/348)
+* `swiftgen --help` prints the full help back again
+  (and not just the help of the default `config run` subcommand).  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#349](https://github.com/SwiftGen/SwiftGen/pull/349)
 
 ### Breaking Changes
 

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -20,8 +20,13 @@ let outputOption = Option(
 // MARK: - Main
 
 let main = Group {
-  $0.noCommand = { (_, _, parser) in
-    try configRunCommand.run(parser)
+  $0.noCommand = { (path, group, parser) in
+    if parser.hasOption("help") {
+      logMessage(.info, "Note: If you invoke swiftgen with no subcommand, it will default to `swiftgen config run`\n")
+      throw GroupError.noCommand(path, group)
+    } else {
+      try configRunCommand.run(parser)
+    }
   }
   $0.group("config", "manage and run configuration files") {
     $0.addCommand("lint", "Lint the configuration file", configLintCommand)

--- a/SwiftGen.xcodeproj/xcshareddata/xcschemes/swiftgen.xcscheme
+++ b/SwiftGen.xcodeproj/xcshareddata/xcschemes/swiftgen.xcscheme
@@ -114,6 +114,10 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "config lint --config $(PROJECT_DIR)/Tests/SwiftGenTests/fixtures/config-missing-paths.yml"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--help"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument


### PR DESCRIPTION
Otherwise the default behavior of commander is that when you invoke

`$ swiftgen --help`

It will print the help of `swiftgen config run --help`
