### PR TITLE
Interface Builder: Typed segues on a per scene basis

### DIFF
--- a/Sources/SwiftGenCLI/templates/ib/scenes-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/ib/scenes-swift4.stencil
@@ -42,7 +42,7 @@ import {{module}}
     {% set sceneClass %}{% call className storyboard.initialScene %}{% endset %}
     {{accessModifier}} static let initialScene = InitialSceneType<{{sceneClass}}>(storyboard: {{storyboardName}}.self)
     {% endif %}
-    {% for scene in storyboard.scenes %}
+    {% for scene in storyboard.scenes where scene.identifier %}
 
     {% set sceneID %}{{scene.identifier|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset %}
     {% set sceneClass %}{% call className scene %}{% endset %}

--- a/Sources/SwiftGenCLI/templates/ib/scenes-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/ib/scenes-swift5.stencil
@@ -42,7 +42,7 @@ import {{module}}
     {% set sceneClass %}{% call className storyboard.initialScene %}{% endset %}
     {{accessModifier}} static let initialScene = InitialSceneType<{{sceneClass}}>(storyboard: {{storyboardName}}.self)
     {% endif %}
-    {% for scene in storyboard.scenes %}
+    {% for scene in storyboard.scenes where scene.identifier %}
 
     {% set sceneID %}{{scene.identifier|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset %}
     {% set sceneClass %}{% call className scene %}{% endset %}

--- a/Sources/SwiftGenCLI/templates/ib/segues-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/ib/segues-swift4.stencil
@@ -16,10 +16,100 @@ import {{module}}
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
-{{accessModifier}} enum {{param.enumName|default:"StoryboardSegue"}} {
+{% macro moduleName item %}{% filter removeNewlines %}
+  {% if item.moduleIsPlaceholder %}
+    {{ env.PRODUCT_MODULE_NAME|default:param.module }}
+  {% else %}
+    {{ item.module }}
+  {% endif %}
+{% endfilter %}{% endmacro %}
+{% macro className item %}{% filter removeNewlines %}
+  {% set module %}{% call moduleName item %}{% endset %}
+  {% if module and ( not param.ignoreTargetModule or module != env.PRODUCT_MODULE_NAME and module != param.module ) %}
+    {{module}}.
+  {% endif %}
+  {{item.type}}
+{% endfilter %}{% endmacro %}
+{% set enumName %}{{param.enumName|default:"StoryboardSegue"}}{% endset %}
+{% set unnamedSegue %}{{param.unnamedSegueCaseName|default:"unnamedSegue"}}{% endset %}
+{% for scene in customSceneTypes where scene.segues %}
+{% set sceneClass %}{% call className scene %}{% endset %}
+{{accessModifier}} extension {{sceneClass}} {
+  {{accessModifier}} enum {{enumName}}: String {
+    {% for segue in scene.segues where segue.identifier %}
+    {% set segueID %}{{segue.identifier|swiftIdentifier:"pretty"|lowerFirstWord}}{% endset %}
+    case {{segueID|escapeReservedKeywords}}{% if segueID != segue.identifier %} = "{{segue.identifier}}"{% endif %}
+    {% endfor %}
+  }
+
+  {{accessModifier}} func perform(segue: {{enumName}}, sender: Any? = nil) {
+    let identifier = {% if isAppKit %}NSStoryboardSegue.Identifier({% endif %}segue.rawValue{% if isAppKit %}){% endif %}
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  {{accessModifier}} enum Typed{{enumName}} {
+    {% set hasUnnamedSegue %}{% for segue in scene.segues where not scene.identifier %}1{% endfor %}{% endset %}
+    {% for segue in scene.segues where segue.identifier %}
+    {% set segueID %}{{segue.identifier|swiftIdentifier:"pretty"|lowerFirstWord}}{% endset %}
+    case {{segueID|escapeReservedKeywords}}{% filter removeNewlines:"leading" %}
+      {% if segue.customClass or segue.destination %}(
+        {% if segue.destination %}destination: {% call className segue.destination %}{% endif %}
+        {% if segue.customClass and segue.destination %}, {% endif %}
+        {% if segue.customClass %}segue: {% call className segue %}{% endif %}
+      ){% endif %}
+    {% endfilter %}
+    {% endfor %}
+    {% if hasUnnamedSegue %}
+    case {{unnamedSegue}}
+    {% endif %}
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: {{prefix}}StoryboardSegue) {
+      switch segue.identifier{% if isAppKit %}?.rawValue{% endif %} ?? "" {
+      {% for segue in scene.segues where segue.identifier %}
+      case "{{segue.identifier}}":
+        {% if segue.customClass %}
+        {% set segueClass %}{% call className segue %}{% endset %}
+        guard let segue = segue as? {{segueClass}} else {
+          fatalError("Segue '{{segue.identifier}}' is not of the expected type {{segueClass}}.")
+        }
+        {% endif %}
+        {% if segue.destination %}
+        {% set destinationClass %}{% call className segue.destination %}{% endset %}
+        {% if destinationClass != "UIKit.UIViewController" %}
+        guard let vc = segue.destination{% if isAppKit %}Controller{% endif %} as? {{destinationClass}} else {
+          fatalError("Destination of segue '{{segue.identifier}}' is not of the expected type {{destinationClass}}.")
+        }
+        {% else %}
+        let vc = segue.destination{% if isAppKit %}Controller{% endif %}
+        {% endif %}
+        {% endif %}
+        {% set segueID %}{{segue.identifier|swiftIdentifier:"pretty"|lowerFirstWord}}{% endset %}
+        self = .{{segueID|escapeReservedKeywords}}{% filter removeNewlines:"leading" %}
+          {% if segue.customClass or segue.destination %}(
+            {% if segue.destination %}destination: vc{% endif %}
+            {% if segue.customClass and segue.destination %}, {% endif %}
+            {% if segue.customClass %}segue: segue{% endif %}
+          ){%endif %}
+        {% endfilter %}
+      {% endfor %}
+      {% if hasUnnamedSegue %}
+      case "":
+        self = .{{unnamedSegue}}
+      {% endif %}
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier{% if isAppKit %}?.rawValue{% endif %} ?? "")' in {{sceneClass}}")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+{% endfor %}
+{{accessModifier}} enum {{enumName}} {
   {% for storyboard in storyboards where storyboard.segues %}
   {{accessModifier}} enum {{storyboard.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}: String, SegueType {
-    {% for segue in storyboard.segues %}
+    {% for segue in storyboard.segues where segue.identifier %}
     {% set segueID %}{{segue.identifier|swiftIdentifier:"pretty"|lowerFirstWord}}{% endset %}
     case {{segueID|escapeReservedKeywords}}{% if segueID != segue.identifier %} = "{{segue.identifier}}"{% endif %}
     {% endfor %}

--- a/Sources/SwiftGenCLI/templates/ib/segues-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/ib/segues-swift5.stencil
@@ -16,10 +16,99 @@ import {{module}}
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
-{{accessModifier}} enum {{param.enumName|default:"StoryboardSegue"}} {
+{% macro moduleName item %}{% filter removeNewlines %}
+  {% if item.moduleIsPlaceholder %}
+    {{ env.PRODUCT_MODULE_NAME|default:param.module }}
+  {% else %}
+    {{ item.module }}
+  {% endif %}
+{% endfilter %}{% endmacro %}
+{% macro className item %}{% filter removeNewlines %}
+  {% set module %}{% call moduleName item %}{% endset %}
+  {% if module and ( not param.ignoreTargetModule or module != env.PRODUCT_MODULE_NAME and module != param.module ) %}
+    {{module}}.
+  {% endif %}
+  {{item.type}}
+{% endfilter %}{% endmacro %}
+{% set enumName %}{{param.enumName|default:"StoryboardSegue"}}{% endset %}
+{% set unnamedSegue %}{{param.unnamedSegueCaseName|default:"unnamedSegue"}}{% endset %}
+{% for scene in customSceneTypes where scene.segues %}
+{% set sceneClass %}{% call className scene %}{% endset %}
+{{accessModifier}} extension {{sceneClass}} {
+  {{accessModifier}} enum {{enumName}}: String {
+    {% for segue in scene.segues where segue.identifier %}
+    {% set segueID %}{{segue.identifier|swiftIdentifier:"pretty"|lowerFirstWord}}{% endset %}
+    case {{segueID|escapeReservedKeywords}}{% if segueID != segue.identifier %} = "{{segue.identifier}}"{% endif %}
+    {% endfor %}
+  }
+
+  {{accessModifier}} func perform(segue: {{enumName}}, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  {{accessModifier}} enum Typed{{enumName}} {
+    {% set hasUnnamedSegue %}{% for segue in scene.segues where not scene.identifier %}1{% endfor %}{% endset %}
+    {% for segue in scene.segues where segue.identifier %}
+    {% set segueID %}{{segue.identifier|swiftIdentifier:"pretty"|lowerFirstWord}}{% endset %}
+    case {{segueID|escapeReservedKeywords}}{% filter removeNewlines:"leading" %}
+      {% if segue.customClass or segue.destination %}(
+        {% if segue.destination %}destination: {% call className segue.destination %}{% endif %}
+        {% if segue.customClass and segue.destination %}, {% endif %}
+        {% if segue.customClass %}segue: {% call className segue %}{% endif %}
+      ){% endif %}
+    {% endfilter %}
+    {% endfor %}
+    {% if hasUnnamedSegue %}
+    case {{unnamedSegue}}
+    {% endif %}
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: {{prefix}}StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      {% for segue in scene.segues where segue.identifier %}
+      case "{{segue.identifier}}":
+        {% if segue.customClass %}
+        {% set segueClass %}{% call className segue %}{% endset %}
+        guard let segue = segue as? {{segueClass}} else {
+          fatalError("Segue '{{segue.identifier}}' is not of the expected type {{segueClass}}.")
+        }
+        {% endif %}
+        {% if segue.destination %}
+        {% set destinationClass %}{% call className segue.destination %}{% endset %}
+        {% if destinationClass != "UIKit.UIViewController" %}
+        guard let vc = segue.destination{% if isAppKit %}Controller{% endif %} as? {{destinationClass}} else {
+          fatalError("Destination of segue '{{segue.identifier}}' is not of the expected type {{destinationClass}}.")
+        }
+        {% else %}
+        let vc = segue.destination{% if isAppKit %}Controller{% endif %}
+        {% endif %}
+        {% endif %}
+        {% set segueID %}{{segue.identifier|swiftIdentifier:"pretty"|lowerFirstWord}}{% endset %}
+        self = .{{segueID|escapeReservedKeywords}}{% filter removeNewlines:"leading" %}
+          {% if segue.customClass or segue.destination %}(
+            {% if segue.destination %}destination: vc{% endif %}
+            {% if segue.customClass and segue.destination %}, {% endif %}
+            {% if segue.customClass %}segue: segue{% endif %}
+          ){%endif %}
+        {% endfilter %}
+      {% endfor %}
+      {% if hasUnnamedSegue %}
+      case "":
+        self = .{{unnamedSegue}}
+      {% endif %}
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in {{sceneClass}}")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+{% endfor %}
+{{accessModifier}} enum {{enumName}} {
   {% for storyboard in storyboards where storyboard.segues %}
   {{accessModifier}} enum {{storyboard.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}: String, SegueType {
-    {% for segue in storyboard.segues %}
+    {% for segue in storyboard.segues where segue.identifier %}
     {% set segueID %}{{segue.identifier|swiftIdentifier:"pretty"|lowerFirstWord}}{% endset %}
     case {{segueID|escapeReservedKeywords}}{% if segueID != segue.identifier %} = "{{segue.identifier}}"{% endif %}
     {% endfor %}

--- a/Sources/SwiftGenKit/Parsers/InterfaceBuilder/CustomType.swift
+++ b/Sources/SwiftGenKit/Parsers/InterfaceBuilder/CustomType.swift
@@ -1,0 +1,77 @@
+//
+// SwiftGenKit
+// Copyright © 2020 SwiftGen
+// MIT Licence
+//
+
+import Foundation
+
+extension InterfaceBuilder {
+  struct CustomType: InterfaceBuilderSwiftType {
+    let type: String
+    let module: String?
+    let moduleIsPlaceholder: Bool
+    var segues = Set<Segue>()
+    var destinations = [Segue: Scene]()
+
+    init(scene: Scene) {
+      type = scene.type
+      module = scene.moduleIsPlaceholder ? "<placeholder>" : scene.module
+      moduleIsPlaceholder = scene.moduleIsPlaceholder
+    }
+
+    mutating func add(segue: Segue, destination: Scene?, warningHandler: Parser.MessageHandler?) {
+      segues.insert(segue)
+
+      // store destination, or check it's at least the same type
+      if let destination = destination {
+        if let current = destinations[segue] {
+          if !areEqual(current, destination) {
+            let message = "warning: The segue with identifier '\(segue.identifier)' in \(module ?? "").\(type) has " +
+              "multiple destination types: \(destination.module ?? "").\(destination.type) and " +
+              "\(destination.module ?? "").\(destination.type)."
+            warningHandler?(message, #file, #line)
+          }
+        } else {
+          destinations[segue] = destination
+        }
+      }
+    }
+
+    private func areEqual(_ lhs: Scene, _ rhs: Scene) -> Bool {
+      lhs.tag != rhs.tag ||
+        lhs.customClass != rhs.customClass ||
+        lhs.customModule != rhs.customModule
+    }
+  }
+}
+
+extension InterfaceBuilder.Parser {
+  var customSceneTypes: [InterfaceBuilder.CustomType] {
+    var result: [String: InterfaceBuilder.CustomType] = [:]
+
+    // collect scenes by custom type
+    for storyboard in storyboards {
+      for scene in storyboard.scenes where scene.customClass != nil {
+        let key = InterfaceBuilder.Parser.identifier(for: scene)
+        var customType = result[key] ?? InterfaceBuilder.CustomType(scene: scene)
+
+        for segue in scene.segues {
+          let destination = self.destination(for: segue.destination, in: storyboard)
+          customType.add(segue: segue, destination: destination, warningHandler: warningHandler)
+        }
+
+        result[key] = customType
+      }
+    }
+
+    return result
+      .sorted { $0.0 < $1.0 }
+      .map { _, value in value }
+  }
+
+  private static func identifier(for scene: InterfaceBuilder.Scene) -> String {
+    let module = scene.moduleIsPlaceholder ? "<placeholder>" : scene.module
+    return "\(module ?? "").\(scene.type)"
+  }
+}

--- a/Sources/SwiftGenKit/Parsers/InterfaceBuilder/InterfaceBuilderParser.swift
+++ b/Sources/SwiftGenKit/Parsers/InterfaceBuilder/InterfaceBuilderParser.swift
@@ -64,5 +64,26 @@ public enum InterfaceBuilder {
         return platforms.first
       }
     }
+
+    func destination(for sceneID: String, in storyboard: Storyboard) -> Scene? {
+      // directly to a scene
+      if let scene = storyboard.scenes.first(where: { $0.sceneID == sceneID }) {
+        return scene
+      }
+
+      // to a scene placeholder
+      if let placeholder = storyboard.placeholders.first(where: { $0.sceneID == sceneID }),
+        let storyboard = storyboards.first(where: { $0.name == placeholder.storyboardName }) {
+        // can be either a scene by identifier, or the initial scene
+        if let referencedIdentifier = placeholder.referencedIdentifier,
+          let scene = storyboard.scenes.first(where: { $0.identifier == referencedIdentifier }) {
+          return scene
+        } else if placeholder.referencedIdentifier == nil {
+          return storyboard.initialScene
+        }
+      }
+
+      return nil
+    }
   }
 }

--- a/Sources/SwiftGenKit/Parsers/InterfaceBuilder/InterfaceBuilderSwiftType.swift
+++ b/Sources/SwiftGenKit/Parsers/InterfaceBuilder/InterfaceBuilderSwiftType.swift
@@ -1,0 +1,13 @@
+//
+// SwiftGenKit
+// Copyright © 2020 SwiftGen
+// MIT Licence
+//
+
+import Foundation
+
+protocol InterfaceBuilderSwiftType {
+  var type: String { get }
+  var module: String? { get }
+  var moduleIsPlaceholder: Bool { get }
+}

--- a/Sources/SwiftGenKit/Parsers/InterfaceBuilder/Scene.swift
+++ b/Sources/SwiftGenKit/Parsers/InterfaceBuilder/Scene.swift
@@ -9,39 +9,45 @@ import Kanna
 
 extension InterfaceBuilder {
   struct Scene {
+    let sceneID: String
     let identifier: String
     let tag: String
     let customClass: String?
     let customModule: String?
     let moduleIsPlaceholder: Bool
+    let segues: Set<Segue>
     let platform: Platform
+  }
+}
 
-    private static let tagTypeMap = [
-      "avPlayerViewController": (type: "AVPlayerViewController", module: "AVKit"),
-      "glkViewController": (type: "GLKViewController", module: "GLKit"),
-      "pagecontroller": (type: "NSPageController", module: nil)
-    ]
+// MARK: - SwiftType
 
-    var type: String {
-      if let customClass = customClass {
-        return customClass
-      } else if let type = Scene.tagTypeMap[tag]?.type {
-        return type
-      } else {
-        return "\(platform.prefix)\(tag.uppercasedFirst())"
-      }
+extension InterfaceBuilder.Scene: InterfaceBuilderSwiftType {
+  private static let tagTypeMap = [
+    "avPlayerViewController": (type: "AVPlayerViewController", module: "AVKit"),
+    "glkViewController": (type: "GLKViewController", module: "GLKit"),
+    "pagecontroller": (type: "NSPageController", module: nil)
+  ]
+
+  var type: String {
+    if let customClass = customClass {
+      return customClass
+    } else if let type = InterfaceBuilder.Scene.tagTypeMap[tag]?.type {
+      return type
+    } else {
+      return "\(platform.prefix)\(tag.uppercasedFirst())"
     }
+  }
 
-    var module: String? {
-      if let customModule = customModule {
-        return customModule
-      } else if let type = Scene.tagTypeMap[tag]?.module {
-        return type
-      } else if customClass == nil {
-        return platform.module
-      } else {
-        return nil
-      }
+  var module: String? {
+    if let customModule = customModule {
+      return customModule
+    } else if let type = InterfaceBuilder.Scene.tagTypeMap[tag]?.module {
+      return type
+    } else if customClass == nil {
+      return platform.module
+    } else {
+      return nil
     }
   }
 }
@@ -49,6 +55,8 @@ extension InterfaceBuilder {
 // MARK: - XML
 
 private enum XML {
+  static let segueXPath = "//connections/segue"
+  static let idAttribute = "id"
   static let customClassAttribute = "customClass"
   static let customModuleAttribute = "customModule"
   static let customModuleProviderAttribute = "customModuleProvider"
@@ -58,16 +66,31 @@ private enum XML {
 
 extension InterfaceBuilder.Scene {
   init(with object: Kanna.XMLElement, platform: InterfaceBuilder.Platform) {
+    sceneID = object[XML.idAttribute] ?? ""
     identifier = object[XML.storyboardIdentifierAttribute] ?? ""
     tag = object.tagName ?? ""
     customClass = object[XML.customClassAttribute]
     customModule = object[XML.customModuleAttribute]
     moduleIsPlaceholder = object[XML.customModuleProviderAttribute] == XML.targetValue
+    segues = Set(
+      object.xpath(XML.segueXPath).map {
+        InterfaceBuilder.Segue(with: $0, platform: platform)
+      }
+    )
     self.platform = platform
   }
 }
 
 // MARK: - Hashable
 
-extension InterfaceBuilder.Scene: Equatable {}
-extension InterfaceBuilder.Scene: Hashable {}
+extension InterfaceBuilder.Scene: Equatable {
+  static func == (lhs: InterfaceBuilder.Scene, rhs: InterfaceBuilder.Scene) -> Bool {
+    lhs.sceneID == rhs.sceneID
+  }
+}
+
+extension InterfaceBuilder.Scene: Hashable {
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(sceneID)
+  }
+}

--- a/Sources/SwiftGenKit/Parsers/InterfaceBuilder/ScenePlaceholder.swift
+++ b/Sources/SwiftGenKit/Parsers/InterfaceBuilder/ScenePlaceholder.swift
@@ -1,0 +1,46 @@
+//
+// SwiftGenKit
+// Copyright © 2020 SwiftGen
+// MIT Licence
+//
+
+import Foundation
+import Kanna
+
+extension InterfaceBuilder {
+  struct ScenePlaceholder {
+    let sceneID: String
+    let storyboardName: String
+    let referencedIdentifier: String?
+  }
+}
+
+// MARK: - XML
+
+private enum XML {
+  static let idAttribute = "id"
+  static let storyboardNameAttribute = "storyboardName"
+  static let referencedIdentifierAttribute = "referencedIdentifier"
+}
+
+extension InterfaceBuilder.ScenePlaceholder {
+  init(with object: Kanna.XMLElement, storyboard: String) {
+    sceneID = object[XML.idAttribute] ?? ""
+    storyboardName = object[XML.storyboardNameAttribute] ?? storyboard
+    referencedIdentifier = object[XML.referencedIdentifierAttribute]
+  }
+}
+
+// MARK: - Hashable
+
+extension InterfaceBuilder.ScenePlaceholder: Equatable {
+  static func == (lhs: InterfaceBuilder.ScenePlaceholder, rhs: InterfaceBuilder.ScenePlaceholder) -> Bool {
+    lhs.sceneID == rhs.sceneID
+  }
+}
+
+extension InterfaceBuilder.ScenePlaceholder: Hashable {
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(sceneID)
+  }
+}

--- a/Sources/SwiftGenKit/Parsers/InterfaceBuilder/Segue.swift
+++ b/Sources/SwiftGenKit/Parsers/InterfaceBuilder/Segue.swift
@@ -10,27 +10,33 @@ import Kanna
 extension InterfaceBuilder {
   struct Segue {
     let identifier: String
+    let kind: String
     let customClass: String?
     let customModule: String?
     let moduleIsPlaceholder: Bool
+    let destination: String
     let platform: Platform
+  }
+}
 
-    var type: String {
-      if let customClass = customClass {
-        return customClass
-      } else {
-        return "\(platform.prefix)StoryboardSegue"
-      }
+// MARK: - SwiftType
+
+extension InterfaceBuilder.Segue: InterfaceBuilderSwiftType {
+  var type: String {
+    if let customClass = customClass {
+      return customClass
+    } else {
+      return "\(platform.prefix)StoryboardSegue"
     }
+  }
 
-    var module: String? {
-      if let customModule = customModule {
-        return customModule
-      } else if customClass == nil {
-        return platform.module
-      } else {
-        return nil
-      }
+  var module: String? {
+    if let customModule = customModule {
+      return customModule
+    } else if customClass == nil {
+      return platform.module
+    } else {
+      return nil
     }
   }
 }
@@ -39,18 +45,22 @@ extension InterfaceBuilder {
 
 private enum XML {
   static let identifierAttribute = "identifier"
+  static let kindAttribute = "kind"
   static let customClassAttribute = "customClass"
   static let customModuleAttribute = "customModule"
   static let customModuleProviderAttribute = "customModuleProvider"
   static let targetValue = "target"
+  static let destinationAttribute = "destination"
 }
 
 extension InterfaceBuilder.Segue {
   init(with object: Kanna.XMLElement, platform: InterfaceBuilder.Platform) {
     identifier = object[XML.identifierAttribute] ?? ""
+    kind = object[XML.kindAttribute] ?? ""
     customClass = object[XML.customClassAttribute]
     customModule = object[XML.customModuleAttribute]
     moduleIsPlaceholder = object[XML.customModuleProviderAttribute] == XML.targetValue
+    destination = object[XML.destinationAttribute] ?? ""
     self.platform = platform
   }
 }

--- a/Sources/SwiftGenKit/Parsers/InterfaceBuilder/Storyboard.swift
+++ b/Sources/SwiftGenKit/Parsers/InterfaceBuilder/Storyboard.swift
@@ -14,6 +14,7 @@ extension InterfaceBuilder {
     let initialScene: Scene?
     let scenes: Set<Scene>
     let segues: Set<Segue>
+    let placeholders: Set<ScenePlaceholder>
 
     var modules: Set<String> {
       var result: [String] = [platform.module] +
@@ -38,10 +39,7 @@ private enum XML {
   static func initialSceneXPath(identifier: String) -> String {
     "/document/scenes/scene/objects/*[@sceneMemberID=\"viewController\" and @id=\"\(identifier)\"]"
   }
-  static let sceneXPath = """
-    /document/scenes/scene/objects/*[@sceneMemberID=\"viewController\" and \
-    string-length(@storyboardIdentifier) > 0]
-    """
+  static let sceneXPath = "/document/scenes/scene/objects/*[@sceneMemberID=\"viewController\"]"
   static let segueXPath = "/document/scenes/scene//connections/segue[string(@identifier)]"
 
   static let placeholderTags = ["controllerPlaceholder", "viewControllerPlaceholder"]
@@ -67,12 +65,17 @@ extension InterfaceBuilder.Storyboard {
     }
 
     // Scenes
-    scenes = Set<InterfaceBuilder.Scene>(
-      document.xpath(XML.sceneXPath).compactMap {
-        guard !XML.placeholderTags.contains($0.tagName ?? "") else { return nil }
-        return InterfaceBuilder.Scene(with: $0, platform: platform)
+    var scenes = Set<InterfaceBuilder.Scene>()
+    var placeholders = Set<InterfaceBuilder.ScenePlaceholder>()
+    for node in document.xpath(XML.sceneXPath) {
+      if XML.placeholderTags.contains(node.tagName ?? "") {
+        placeholders.insert(InterfaceBuilder.ScenePlaceholder(with: node, storyboard: name))
+      } else {
+        scenes.insert(InterfaceBuilder.Scene(with: node, platform: platform))
       }
-    )
+    }
+    self.scenes = scenes
+    self.placeholders = placeholders
 
     // Segues
     segues = Set<InterfaceBuilder.Segue>(

--- a/Sources/SwiftGenKit/Stencil/InterfaceBuilderParser+Context.swift
+++ b/Sources/SwiftGenKit/Stencil/InterfaceBuilderParser+Context.swift
@@ -6,6 +6,14 @@
 
 import Foundation
 
+extension Dictionary {
+  fileprivate func merging(_ other: [Key: Value]) -> [Key: Value] {
+    merging(other) { current, _ in
+      current
+    }
+  }
+}
+
 //
 // See the documentation file for a full description of this context's structure:
 // Documentation/SwiftGenKit Contexts/ib.md
@@ -16,9 +24,12 @@ extension InterfaceBuilder.Parser {
     let storyboards = self.storyboards
       .sorted { lhs, rhs in lhs.name < rhs.name }
       .map(map(storyboard:))
+
     return [
       "modules": modules.sorted(),
       "storyboards": storyboards,
+      "customSceneTypes": customSceneTypes
+        .map { map(customType: $0) },
       "platform": platform ?? ""
     ]
   }
@@ -26,12 +37,14 @@ extension InterfaceBuilder.Parser {
   private func map(storyboard: InterfaceBuilder.Storyboard) -> [String: Any] {
     var result: [String: Any] = [
       "name": storyboard.name,
-      "scenes": storyboard.scenes
+      "scenes": Array(storyboard.scenes)
+        .filter { !$0.identifier.isEmpty }
         .sorted { $0.identifier < $1.identifier }
-        .map(map(scene:)),
-      "segues": storyboard.segues
+        .map { map(scene: $0) },
+      "segues": Array(storyboard.segues)
+        .filter { !$0.identifier.isEmpty }
         .sorted { $0.identifier < $1.identifier }
-        .map(map(segue:)),
+        .map { map(segue: $0, in: storyboard) },
       "platform": storyboard.platform.name
     ]
 
@@ -43,34 +56,64 @@ extension InterfaceBuilder.Parser {
   }
 
   private func map(scene: InterfaceBuilder.Scene) -> [String: Any] {
+    let result = map(swiftType: scene)
+
     if let customClass = scene.customClass {
-      return [
-        "identifier": scene.identifier,
-        "customClass": customClass,
-        "customModule": scene.customModule ?? "",
-        "type": scene.type,
-        "module": scene.module ?? "",
-        "moduleIsPlaceholder": scene.moduleIsPlaceholder
-      ]
+      return result.merging(
+        [
+          "identifier": scene.identifier,
+          "customClass": customClass,
+          "customModule": scene.customModule ?? ""
+        ]
+      )
     } else {
-      return [
-        "identifier": scene.identifier,
-        "baseType": scene.tag.uppercasedFirst(),
-        "type": scene.type,
-        "module": scene.module ?? "",
-        "moduleIsPlaceholder": scene.moduleIsPlaceholder
-      ]
+      return result.merging(
+        [
+          "identifier": scene.identifier,
+          "baseType": scene.tag.uppercasedFirst()
+        ]
+      )
     }
   }
 
-  private func map(segue: InterfaceBuilder.Segue) -> [String: Any] {
+  private func map(segue: InterfaceBuilder.Segue, in storyboard: InterfaceBuilder.Storyboard) -> [String: Any] {
+    let scene = destination(for: segue.destination, in: storyboard)
+    return map(segue: segue, destination: scene)
+  }
+
+  private func map(segue: InterfaceBuilder.Segue, destination: InterfaceBuilder.Scene?) -> [String: Any] {
+    var result = map(swiftType: segue).merging(
+      [
+        "identifier": segue.identifier,
+        "kind": segue.kind,
+        "customClass": segue.customClass ?? "",
+        "customModule": segue.customModule ?? ""
+      ]
+    )
+
+    if let destination = destination {
+      result["destination"] = map(scene: destination)
+    }
+
+    return result
+  }
+
+  private func map(customType: InterfaceBuilder.CustomType) -> [String: Any] {
+    let sortedSegues = customType.segues
+      .sorted { $0.identifier < $1.identifier }
+      .map { segue -> Any in
+        let destination = customType.destinations[segue]
+        return map(segue: segue, destination: destination)
+      }
+
+    return map(swiftType: customType).merging(["segues": sortedSegues])
+  }
+
+  private func map(swiftType: InterfaceBuilderSwiftType) -> [String: Any] {
     [
-      "identifier": segue.identifier,
-      "customClass": segue.customClass ?? "",
-      "customModule": segue.customModule ?? "",
-      "type": segue.type,
-      "module": segue.module ?? "",
-      "moduleIsPlaceholder": segue.moduleIsPlaceholder
+      "type": swiftType.type,
+      "module": swiftType.module ?? "",
+      "moduleIsPlaceholder": swiftType.moduleIsPlaceholder
     ]
   }
 }

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all-customName.swift
@@ -22,6 +22,10 @@ internal enum XCTStoryboardCustom {
 
     internal static let initialScene = InitialSceneType<LocationPicker.LocationPickerViewController>(storyboard: AdditionalImport.self)
 
+    internal static let `internal` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "internal")
+
+    internal static let `private` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "private")
+
     internal static let `public` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "public")
   }
   internal enum Anonymous: StoryboardType {

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all-ignoreTargetModule-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all-ignoreTargetModule-withExtraModule.swift
@@ -21,6 +21,10 @@ internal enum StoryboardScene {
 
     internal static let initialScene = InitialSceneType<LocationPicker.LocationPickerViewController>(storyboard: AdditionalImport.self)
 
+    internal static let `internal` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "internal")
+
+    internal static let `private` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "private")
+
     internal static let `public` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "public")
   }
   internal enum Anonymous: StoryboardType {

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all-ignoreTargetModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all-ignoreTargetModule.swift
@@ -22,6 +22,10 @@ internal enum StoryboardScene {
 
     internal static let initialScene = InitialSceneType<LocationPicker.LocationPickerViewController>(storyboard: AdditionalImport.self)
 
+    internal static let `internal` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "internal")
+
+    internal static let `private` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "private")
+
     internal static let `public` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "public")
   }
   internal enum Anonymous: StoryboardType {

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all-noDefinedModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all-noDefinedModule.swift
@@ -23,6 +23,10 @@ internal enum StoryboardScene {
 
     internal static let initialScene = InitialSceneType<LocationPicker.LocationPickerViewController>(storyboard: AdditionalImport.self)
 
+    internal static let `internal` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "internal")
+
+    internal static let `private` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "private")
+
     internal static let `public` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "public")
   }
   internal enum Anonymous: StoryboardType {

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all-publicAccess.swift
@@ -22,6 +22,10 @@ public enum StoryboardScene {
 
     public static let initialScene = InitialSceneType<LocationPicker.LocationPickerViewController>(storyboard: AdditionalImport.self)
 
+    public static let `internal` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "internal")
+
+    public static let `private` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "private")
+
     public static let `public` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "public")
   }
   public enum Anonymous: StoryboardType {

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all-withExtraModule.swift
@@ -21,6 +21,10 @@ internal enum StoryboardScene {
 
     internal static let initialScene = InitialSceneType<LocationPicker.LocationPickerViewController>(storyboard: AdditionalImport.self)
 
+    internal static let `internal` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "internal")
+
+    internal static let `private` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "private")
+
     internal static let `public` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "public")
   }
   internal enum Anonymous: StoryboardType {

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all.swift
@@ -22,6 +22,10 @@ internal enum StoryboardScene {
 
     internal static let initialScene = InitialSceneType<LocationPicker.LocationPickerViewController>(storyboard: AdditionalImport.self)
 
+    internal static let `internal` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "internal")
+
+    internal static let `private` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "private")
+
     internal static let `public` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "public")
   }
   internal enum Anonymous: StoryboardType {

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all-customName.swift
@@ -22,6 +22,10 @@ internal enum XCTStoryboardCustom {
 
     internal static let initialScene = InitialSceneType<LocationPicker.LocationPickerViewController>(storyboard: AdditionalImport.self)
 
+    internal static let `internal` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "internal")
+
+    internal static let `private` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "private")
+
     internal static let `public` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "public")
   }
   internal enum Anonymous: StoryboardType {

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all-ignoreTargetModule-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all-ignoreTargetModule-withExtraModule.swift
@@ -21,6 +21,10 @@ internal enum StoryboardScene {
 
     internal static let initialScene = InitialSceneType<LocationPicker.LocationPickerViewController>(storyboard: AdditionalImport.self)
 
+    internal static let `internal` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "internal")
+
+    internal static let `private` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "private")
+
     internal static let `public` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "public")
   }
   internal enum Anonymous: StoryboardType {

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all-ignoreTargetModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all-ignoreTargetModule.swift
@@ -22,6 +22,10 @@ internal enum StoryboardScene {
 
     internal static let initialScene = InitialSceneType<LocationPicker.LocationPickerViewController>(storyboard: AdditionalImport.self)
 
+    internal static let `internal` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "internal")
+
+    internal static let `private` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "private")
+
     internal static let `public` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "public")
   }
   internal enum Anonymous: StoryboardType {

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all-noDefinedModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all-noDefinedModule.swift
@@ -23,6 +23,10 @@ internal enum StoryboardScene {
 
     internal static let initialScene = InitialSceneType<LocationPicker.LocationPickerViewController>(storyboard: AdditionalImport.self)
 
+    internal static let `internal` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "internal")
+
+    internal static let `private` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "private")
+
     internal static let `public` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "public")
   }
   internal enum Anonymous: StoryboardType {

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all-publicAccess.swift
@@ -22,6 +22,10 @@ public enum StoryboardScene {
 
     public static let initialScene = InitialSceneType<LocationPicker.LocationPickerViewController>(storyboard: AdditionalImport.self)
 
+    public static let `internal` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "internal")
+
+    public static let `private` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "private")
+
     public static let `public` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "public")
   }
   public enum Anonymous: StoryboardType {

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all-withExtraModule.swift
@@ -21,6 +21,10 @@ internal enum StoryboardScene {
 
     internal static let initialScene = InitialSceneType<LocationPicker.LocationPickerViewController>(storyboard: AdditionalImport.self)
 
+    internal static let `internal` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "internal")
+
+    internal static let `private` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "private")
+
     internal static let `public` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "public")
   }
   internal enum Anonymous: StoryboardType {

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all.swift
@@ -22,6 +22,10 @@ internal enum StoryboardScene {
 
     internal static let initialScene = InitialSceneType<LocationPicker.LocationPickerViewController>(storyboard: AdditionalImport.self)
 
+    internal static let `internal` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "internal")
+
+    internal static let `private` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "private")
+
     internal static let `public` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "public")
   }
   internal enum Anonymous: StoryboardType {

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/all-customName.swift
@@ -16,6 +16,253 @@ import UIKit
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+internal extension SwiftGen.PickerViewController {
+  internal enum XCTStoryboardCustom: String {
+    case customBack = "CustomBack"
+    case embed = "Embed"
+    case nonCustom = "NonCustom"
+    case showNavCtrl = "Show-NavCtrl"
+  }
+
+  internal func perform(segue: XCTStoryboardCustom, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedXCTStoryboardCustom {
+    case customBack(destination: UIKit.UIViewController, segue: SwiftGen.SlideLeftSegue)
+    case embed(destination: UIKit.UIViewController)
+    case nonCustom(destination: UIKit.UIViewController)
+    case showNavCtrl(destination: UIKit.UINavigationController, segue: SwiftGen.CustomSegueClass)
+    case customUnnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "CustomBack":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'CustomBack' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        let vc = segue.destination
+        self = .customBack(destination: vc, segue: segue)
+      case "Embed":
+        let vc = segue.destination
+        self = .embed(destination: vc)
+      case "NonCustom":
+        let vc = segue.destination
+        self = .nonCustom(destination: vc)
+      case "Show-NavCtrl":
+        guard let segue = segue as? SwiftGen.CustomSegueClass else {
+          fatalError("Segue 'Show-NavCtrl' is not of the expected type SwiftGen.CustomSegueClass.")
+        }
+        guard let vc = segue.destination as? UIKit.UINavigationController else {
+          fatalError("Destination of segue 'Show-NavCtrl' is not of the expected type UIKit.UINavigationController.")
+        }
+        self = .showNavCtrl(destination: vc, segue: segue)
+      case "":
+        self = .customUnnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SwiftGen.PickerViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension ExtraModule.ValidatePasswordViewController {
+  internal enum XCTStoryboardCustom: String {
+    case showPassword = "ShowPassword"
+  }
+
+  internal func perform(segue: XCTStoryboardCustom, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedXCTStoryboardCustom {
+    case showPassword(destination: ExtraModule.ValidatePasswordViewController)
+    case customUnnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "ShowPassword":
+        guard let vc = segue.destination as? ExtraModule.ValidatePasswordViewController else {
+          fatalError("Destination of segue 'ShowPassword' is not of the expected type ExtraModule.ValidatePasswordViewController.")
+        }
+        self = .showPassword(destination: vc)
+      case "":
+        self = .customUnnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in ExtraModule.ValidatePasswordViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension LocationPicker.LocationPickerViewController {
+  internal enum XCTStoryboardCustom: String {
+    case afterDelay = "After Delay"
+    case `open`
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: XCTStoryboardCustom, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedXCTStoryboardCustom {
+    case afterDelay(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideLeftSegue)
+    case `open`(destination: SlackTextViewController.SLKTextViewController, segue: SlackTextViewController.SLKCrossoverSegue)
+    case `private`(destination: SlackTextViewController.SLKTextViewController, segue: ExtraModule.SlideDownSegue)
+    case `public`(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideUpSegue)
+    case customUnnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "After Delay":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'After Delay' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'After Delay' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .afterDelay(destination: vc, segue: segue)
+      case "open":
+        guard let segue = segue as? SlackTextViewController.SLKCrossoverSegue else {
+          fatalError("Segue 'open' is not of the expected type SlackTextViewController.SLKCrossoverSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'open' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`open`(destination: vc, segue: segue)
+      case "private":
+        guard let segue = segue as? ExtraModule.SlideDownSegue else {
+          fatalError("Segue 'private' is not of the expected type ExtraModule.SlideDownSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.SlideUpSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.SlideUpSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .customUnnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in LocationPicker.LocationPickerViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension SlackTextViewController.SLKTextViewController {
+  internal enum XCTStoryboardCustom: String {
+    case afterDelay = "After Delay"
+    case `open`
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: XCTStoryboardCustom, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedXCTStoryboardCustom {
+    case afterDelay(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideLeftSegue)
+    case `open`(destination: SlackTextViewController.SLKTextViewController, segue: SlackTextViewController.SLKCrossoverSegue)
+    case `private`(destination: SlackTextViewController.SLKTextViewController, segue: ExtraModule.SlideDownSegue)
+    case `public`(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideUpSegue)
+    case customUnnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "After Delay":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'After Delay' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'After Delay' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .afterDelay(destination: vc, segue: segue)
+      case "open":
+        guard let segue = segue as? SlackTextViewController.SLKCrossoverSegue else {
+          fatalError("Segue 'open' is not of the expected type SlackTextViewController.SLKCrossoverSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'open' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`open`(destination: vc, segue: segue)
+      case "private":
+        guard let segue = segue as? ExtraModule.SlideDownSegue else {
+          fatalError("Segue 'private' is not of the expected type ExtraModule.SlideDownSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.SlideUpSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.SlideUpSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .customUnnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SlackTextViewController.SLKTextViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension SwiftGen.CreateAccViewController {
+  internal enum XCTStoryboardCustom: String {
+    case showPassword = "ShowPassword"
+  }
+
+  internal func perform(segue: XCTStoryboardCustom, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedXCTStoryboardCustom {
+    case showPassword(destination: ExtraModule.ValidatePasswordViewController)
+    case customUnnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "ShowPassword":
+        guard let vc = segue.destination as? ExtraModule.ValidatePasswordViewController else {
+          fatalError("Destination of segue 'ShowPassword' is not of the expected type ExtraModule.ValidatePasswordViewController.")
+        }
+        self = .showPassword(destination: vc)
+      case "":
+        self = .customUnnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SwiftGen.CreateAccViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
 internal enum XCTStoryboardCustom {
   internal enum AdditionalImport: String, SegueType {
     case afterDelay = "After Delay"

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/all-ignoreTargetModule-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/all-ignoreTargetModule-withExtraModule.swift
@@ -15,6 +15,253 @@ import UIKit
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+internal extension PickerViewController {
+  internal enum StoryboardSegue: String {
+    case customBack = "CustomBack"
+    case embed = "Embed"
+    case nonCustom = "NonCustom"
+    case showNavCtrl = "Show-NavCtrl"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case customBack(destination: UIKit.UIViewController, segue: SlideLeftSegue)
+    case embed(destination: UIKit.UIViewController)
+    case nonCustom(destination: UIKit.UIViewController)
+    case showNavCtrl(destination: UIKit.UINavigationController, segue: CustomSegueClass)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "CustomBack":
+        guard let segue = segue as? SlideLeftSegue else {
+          fatalError("Segue 'CustomBack' is not of the expected type SlideLeftSegue.")
+        }
+        let vc = segue.destination
+        self = .customBack(destination: vc, segue: segue)
+      case "Embed":
+        let vc = segue.destination
+        self = .embed(destination: vc)
+      case "NonCustom":
+        let vc = segue.destination
+        self = .nonCustom(destination: vc)
+      case "Show-NavCtrl":
+        guard let segue = segue as? CustomSegueClass else {
+          fatalError("Segue 'Show-NavCtrl' is not of the expected type CustomSegueClass.")
+        }
+        guard let vc = segue.destination as? UIKit.UINavigationController else {
+          fatalError("Destination of segue 'Show-NavCtrl' is not of the expected type UIKit.UINavigationController.")
+        }
+        self = .showNavCtrl(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in PickerViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension ValidatePasswordViewController {
+  internal enum StoryboardSegue: String {
+    case showPassword = "ShowPassword"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case showPassword(destination: ValidatePasswordViewController)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "ShowPassword":
+        guard let vc = segue.destination as? ValidatePasswordViewController else {
+          fatalError("Destination of segue 'ShowPassword' is not of the expected type ValidatePasswordViewController.")
+        }
+        self = .showPassword(destination: vc)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in ValidatePasswordViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension LocationPicker.LocationPickerViewController {
+  internal enum StoryboardSegue: String {
+    case afterDelay = "After Delay"
+    case `open`
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case afterDelay(destination: SlackTextViewController.SLKTextViewController, segue: SlideLeftSegue)
+    case `open`(destination: SlackTextViewController.SLKTextViewController, segue: SlackTextViewController.SLKCrossoverSegue)
+    case `private`(destination: SlackTextViewController.SLKTextViewController, segue: SlideDownSegue)
+    case `public`(destination: SlackTextViewController.SLKTextViewController, segue: SlideUpSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "After Delay":
+        guard let segue = segue as? SlideLeftSegue else {
+          fatalError("Segue 'After Delay' is not of the expected type SlideLeftSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'After Delay' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .afterDelay(destination: vc, segue: segue)
+      case "open":
+        guard let segue = segue as? SlackTextViewController.SLKCrossoverSegue else {
+          fatalError("Segue 'open' is not of the expected type SlackTextViewController.SLKCrossoverSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'open' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`open`(destination: vc, segue: segue)
+      case "private":
+        guard let segue = segue as? SlideDownSegue else {
+          fatalError("Segue 'private' is not of the expected type SlideDownSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SlideUpSegue else {
+          fatalError("Segue 'public' is not of the expected type SlideUpSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in LocationPicker.LocationPickerViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension SlackTextViewController.SLKTextViewController {
+  internal enum StoryboardSegue: String {
+    case afterDelay = "After Delay"
+    case `open`
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case afterDelay(destination: SlackTextViewController.SLKTextViewController, segue: SlideLeftSegue)
+    case `open`(destination: SlackTextViewController.SLKTextViewController, segue: SlackTextViewController.SLKCrossoverSegue)
+    case `private`(destination: SlackTextViewController.SLKTextViewController, segue: SlideDownSegue)
+    case `public`(destination: SlackTextViewController.SLKTextViewController, segue: SlideUpSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "After Delay":
+        guard let segue = segue as? SlideLeftSegue else {
+          fatalError("Segue 'After Delay' is not of the expected type SlideLeftSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'After Delay' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .afterDelay(destination: vc, segue: segue)
+      case "open":
+        guard let segue = segue as? SlackTextViewController.SLKCrossoverSegue else {
+          fatalError("Segue 'open' is not of the expected type SlackTextViewController.SLKCrossoverSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'open' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`open`(destination: vc, segue: segue)
+      case "private":
+        guard let segue = segue as? SlideDownSegue else {
+          fatalError("Segue 'private' is not of the expected type SlideDownSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SlideUpSegue else {
+          fatalError("Segue 'public' is not of the expected type SlideUpSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SlackTextViewController.SLKTextViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension CreateAccViewController {
+  internal enum StoryboardSegue: String {
+    case showPassword = "ShowPassword"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case showPassword(destination: ValidatePasswordViewController)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "ShowPassword":
+        guard let vc = segue.destination as? ValidatePasswordViewController else {
+          fatalError("Destination of segue 'ShowPassword' is not of the expected type ValidatePasswordViewController.")
+        }
+        self = .showPassword(destination: vc)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in CreateAccViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
 internal enum StoryboardSegue {
   internal enum AdditionalImport: String, SegueType {
     case afterDelay = "After Delay"

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/all-ignoreTargetModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/all-ignoreTargetModule.swift
@@ -16,6 +16,253 @@ import UIKit
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+internal extension PickerViewController {
+  internal enum StoryboardSegue: String {
+    case customBack = "CustomBack"
+    case embed = "Embed"
+    case nonCustom = "NonCustom"
+    case showNavCtrl = "Show-NavCtrl"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case customBack(destination: UIKit.UIViewController, segue: SlideLeftSegue)
+    case embed(destination: UIKit.UIViewController)
+    case nonCustom(destination: UIKit.UIViewController)
+    case showNavCtrl(destination: UIKit.UINavigationController, segue: CustomSegueClass)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "CustomBack":
+        guard let segue = segue as? SlideLeftSegue else {
+          fatalError("Segue 'CustomBack' is not of the expected type SlideLeftSegue.")
+        }
+        let vc = segue.destination
+        self = .customBack(destination: vc, segue: segue)
+      case "Embed":
+        let vc = segue.destination
+        self = .embed(destination: vc)
+      case "NonCustom":
+        let vc = segue.destination
+        self = .nonCustom(destination: vc)
+      case "Show-NavCtrl":
+        guard let segue = segue as? CustomSegueClass else {
+          fatalError("Segue 'Show-NavCtrl' is not of the expected type CustomSegueClass.")
+        }
+        guard let vc = segue.destination as? UIKit.UINavigationController else {
+          fatalError("Destination of segue 'Show-NavCtrl' is not of the expected type UIKit.UINavigationController.")
+        }
+        self = .showNavCtrl(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in PickerViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension ExtraModule.ValidatePasswordViewController {
+  internal enum StoryboardSegue: String {
+    case showPassword = "ShowPassword"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case showPassword(destination: ExtraModule.ValidatePasswordViewController)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "ShowPassword":
+        guard let vc = segue.destination as? ExtraModule.ValidatePasswordViewController else {
+          fatalError("Destination of segue 'ShowPassword' is not of the expected type ExtraModule.ValidatePasswordViewController.")
+        }
+        self = .showPassword(destination: vc)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in ExtraModule.ValidatePasswordViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension LocationPicker.LocationPickerViewController {
+  internal enum StoryboardSegue: String {
+    case afterDelay = "After Delay"
+    case `open`
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case afterDelay(destination: SlackTextViewController.SLKTextViewController, segue: SlideLeftSegue)
+    case `open`(destination: SlackTextViewController.SLKTextViewController, segue: SlackTextViewController.SLKCrossoverSegue)
+    case `private`(destination: SlackTextViewController.SLKTextViewController, segue: ExtraModule.SlideDownSegue)
+    case `public`(destination: SlackTextViewController.SLKTextViewController, segue: SlideUpSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "After Delay":
+        guard let segue = segue as? SlideLeftSegue else {
+          fatalError("Segue 'After Delay' is not of the expected type SlideLeftSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'After Delay' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .afterDelay(destination: vc, segue: segue)
+      case "open":
+        guard let segue = segue as? SlackTextViewController.SLKCrossoverSegue else {
+          fatalError("Segue 'open' is not of the expected type SlackTextViewController.SLKCrossoverSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'open' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`open`(destination: vc, segue: segue)
+      case "private":
+        guard let segue = segue as? ExtraModule.SlideDownSegue else {
+          fatalError("Segue 'private' is not of the expected type ExtraModule.SlideDownSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SlideUpSegue else {
+          fatalError("Segue 'public' is not of the expected type SlideUpSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in LocationPicker.LocationPickerViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension SlackTextViewController.SLKTextViewController {
+  internal enum StoryboardSegue: String {
+    case afterDelay = "After Delay"
+    case `open`
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case afterDelay(destination: SlackTextViewController.SLKTextViewController, segue: SlideLeftSegue)
+    case `open`(destination: SlackTextViewController.SLKTextViewController, segue: SlackTextViewController.SLKCrossoverSegue)
+    case `private`(destination: SlackTextViewController.SLKTextViewController, segue: ExtraModule.SlideDownSegue)
+    case `public`(destination: SlackTextViewController.SLKTextViewController, segue: SlideUpSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "After Delay":
+        guard let segue = segue as? SlideLeftSegue else {
+          fatalError("Segue 'After Delay' is not of the expected type SlideLeftSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'After Delay' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .afterDelay(destination: vc, segue: segue)
+      case "open":
+        guard let segue = segue as? SlackTextViewController.SLKCrossoverSegue else {
+          fatalError("Segue 'open' is not of the expected type SlackTextViewController.SLKCrossoverSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'open' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`open`(destination: vc, segue: segue)
+      case "private":
+        guard let segue = segue as? ExtraModule.SlideDownSegue else {
+          fatalError("Segue 'private' is not of the expected type ExtraModule.SlideDownSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SlideUpSegue else {
+          fatalError("Segue 'public' is not of the expected type SlideUpSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SlackTextViewController.SLKTextViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension CreateAccViewController {
+  internal enum StoryboardSegue: String {
+    case showPassword = "ShowPassword"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case showPassword(destination: ExtraModule.ValidatePasswordViewController)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "ShowPassword":
+        guard let vc = segue.destination as? ExtraModule.ValidatePasswordViewController else {
+          fatalError("Destination of segue 'ShowPassword' is not of the expected type ExtraModule.ValidatePasswordViewController.")
+        }
+        self = .showPassword(destination: vc)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in CreateAccViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
 internal enum StoryboardSegue {
   internal enum AdditionalImport: String, SegueType {
     case afterDelay = "After Delay"

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/all-noDefinedModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/all-noDefinedModule.swift
@@ -17,6 +17,253 @@ import UIKit
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+internal extension PickerViewController {
+  internal enum StoryboardSegue: String {
+    case customBack = "CustomBack"
+    case embed = "Embed"
+    case nonCustom = "NonCustom"
+    case showNavCtrl = "Show-NavCtrl"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case customBack(destination: UIKit.UIViewController, segue: SwiftGen.SlideLeftSegue)
+    case embed(destination: UIKit.UIViewController)
+    case nonCustom(destination: UIKit.UIViewController)
+    case showNavCtrl(destination: UIKit.UINavigationController, segue: CustomSegueClass)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "CustomBack":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'CustomBack' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        let vc = segue.destination
+        self = .customBack(destination: vc, segue: segue)
+      case "Embed":
+        let vc = segue.destination
+        self = .embed(destination: vc)
+      case "NonCustom":
+        let vc = segue.destination
+        self = .nonCustom(destination: vc)
+      case "Show-NavCtrl":
+        guard let segue = segue as? CustomSegueClass else {
+          fatalError("Segue 'Show-NavCtrl' is not of the expected type CustomSegueClass.")
+        }
+        guard let vc = segue.destination as? UIKit.UINavigationController else {
+          fatalError("Destination of segue 'Show-NavCtrl' is not of the expected type UIKit.UINavigationController.")
+        }
+        self = .showNavCtrl(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in PickerViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension ExtraModule.ValidatePasswordViewController {
+  internal enum StoryboardSegue: String {
+    case showPassword = "ShowPassword"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case showPassword(destination: ExtraModule.ValidatePasswordViewController)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "ShowPassword":
+        guard let vc = segue.destination as? ExtraModule.ValidatePasswordViewController else {
+          fatalError("Destination of segue 'ShowPassword' is not of the expected type ExtraModule.ValidatePasswordViewController.")
+        }
+        self = .showPassword(destination: vc)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in ExtraModule.ValidatePasswordViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension LocationPicker.LocationPickerViewController {
+  internal enum StoryboardSegue: String {
+    case afterDelay = "After Delay"
+    case `open`
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case afterDelay(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideLeftSegue)
+    case `open`(destination: SlackTextViewController.SLKTextViewController, segue: SlackTextViewController.SLKCrossoverSegue)
+    case `private`(destination: SlackTextViewController.SLKTextViewController, segue: ExtraModule.SlideDownSegue)
+    case `public`(destination: SlackTextViewController.SLKTextViewController, segue: SlideUpSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "After Delay":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'After Delay' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'After Delay' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .afterDelay(destination: vc, segue: segue)
+      case "open":
+        guard let segue = segue as? SlackTextViewController.SLKCrossoverSegue else {
+          fatalError("Segue 'open' is not of the expected type SlackTextViewController.SLKCrossoverSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'open' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`open`(destination: vc, segue: segue)
+      case "private":
+        guard let segue = segue as? ExtraModule.SlideDownSegue else {
+          fatalError("Segue 'private' is not of the expected type ExtraModule.SlideDownSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SlideUpSegue else {
+          fatalError("Segue 'public' is not of the expected type SlideUpSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in LocationPicker.LocationPickerViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension SlackTextViewController.SLKTextViewController {
+  internal enum StoryboardSegue: String {
+    case afterDelay = "After Delay"
+    case `open`
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case afterDelay(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideLeftSegue)
+    case `open`(destination: SlackTextViewController.SLKTextViewController, segue: SlackTextViewController.SLKCrossoverSegue)
+    case `private`(destination: SlackTextViewController.SLKTextViewController, segue: ExtraModule.SlideDownSegue)
+    case `public`(destination: SlackTextViewController.SLKTextViewController, segue: SlideUpSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "After Delay":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'After Delay' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'After Delay' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .afterDelay(destination: vc, segue: segue)
+      case "open":
+        guard let segue = segue as? SlackTextViewController.SLKCrossoverSegue else {
+          fatalError("Segue 'open' is not of the expected type SlackTextViewController.SLKCrossoverSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'open' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`open`(destination: vc, segue: segue)
+      case "private":
+        guard let segue = segue as? ExtraModule.SlideDownSegue else {
+          fatalError("Segue 'private' is not of the expected type ExtraModule.SlideDownSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SlideUpSegue else {
+          fatalError("Segue 'public' is not of the expected type SlideUpSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SlackTextViewController.SLKTextViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension SwiftGen.CreateAccViewController {
+  internal enum StoryboardSegue: String {
+    case showPassword = "ShowPassword"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case showPassword(destination: ExtraModule.ValidatePasswordViewController)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "ShowPassword":
+        guard let vc = segue.destination as? ExtraModule.ValidatePasswordViewController else {
+          fatalError("Destination of segue 'ShowPassword' is not of the expected type ExtraModule.ValidatePasswordViewController.")
+        }
+        self = .showPassword(destination: vc)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SwiftGen.CreateAccViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
 internal enum StoryboardSegue {
   internal enum AdditionalImport: String, SegueType {
     case afterDelay = "After Delay"

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/all-publicAccess.swift
@@ -16,6 +16,253 @@ import UIKit
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+public extension SwiftGen.PickerViewController {
+  public enum StoryboardSegue: String {
+    case customBack = "CustomBack"
+    case embed = "Embed"
+    case nonCustom = "NonCustom"
+    case showNavCtrl = "Show-NavCtrl"
+  }
+
+  public func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  public enum TypedStoryboardSegue {
+    case customBack(destination: UIKit.UIViewController, segue: SwiftGen.SlideLeftSegue)
+    case embed(destination: UIKit.UIViewController)
+    case nonCustom(destination: UIKit.UIViewController)
+    case showNavCtrl(destination: UIKit.UINavigationController, segue: SwiftGen.CustomSegueClass)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "CustomBack":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'CustomBack' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        let vc = segue.destination
+        self = .customBack(destination: vc, segue: segue)
+      case "Embed":
+        let vc = segue.destination
+        self = .embed(destination: vc)
+      case "NonCustom":
+        let vc = segue.destination
+        self = .nonCustom(destination: vc)
+      case "Show-NavCtrl":
+        guard let segue = segue as? SwiftGen.CustomSegueClass else {
+          fatalError("Segue 'Show-NavCtrl' is not of the expected type SwiftGen.CustomSegueClass.")
+        }
+        guard let vc = segue.destination as? UIKit.UINavigationController else {
+          fatalError("Destination of segue 'Show-NavCtrl' is not of the expected type UIKit.UINavigationController.")
+        }
+        self = .showNavCtrl(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SwiftGen.PickerViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+public extension ExtraModule.ValidatePasswordViewController {
+  public enum StoryboardSegue: String {
+    case showPassword = "ShowPassword"
+  }
+
+  public func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  public enum TypedStoryboardSegue {
+    case showPassword(destination: ExtraModule.ValidatePasswordViewController)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "ShowPassword":
+        guard let vc = segue.destination as? ExtraModule.ValidatePasswordViewController else {
+          fatalError("Destination of segue 'ShowPassword' is not of the expected type ExtraModule.ValidatePasswordViewController.")
+        }
+        self = .showPassword(destination: vc)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in ExtraModule.ValidatePasswordViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+public extension LocationPicker.LocationPickerViewController {
+  public enum StoryboardSegue: String {
+    case afterDelay = "After Delay"
+    case `open`
+    case `private`
+    case `public`
+  }
+
+  public func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  public enum TypedStoryboardSegue {
+    case afterDelay(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideLeftSegue)
+    case `open`(destination: SlackTextViewController.SLKTextViewController, segue: SlackTextViewController.SLKCrossoverSegue)
+    case `private`(destination: SlackTextViewController.SLKTextViewController, segue: ExtraModule.SlideDownSegue)
+    case `public`(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideUpSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "After Delay":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'After Delay' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'After Delay' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .afterDelay(destination: vc, segue: segue)
+      case "open":
+        guard let segue = segue as? SlackTextViewController.SLKCrossoverSegue else {
+          fatalError("Segue 'open' is not of the expected type SlackTextViewController.SLKCrossoverSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'open' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`open`(destination: vc, segue: segue)
+      case "private":
+        guard let segue = segue as? ExtraModule.SlideDownSegue else {
+          fatalError("Segue 'private' is not of the expected type ExtraModule.SlideDownSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.SlideUpSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.SlideUpSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in LocationPicker.LocationPickerViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+public extension SlackTextViewController.SLKTextViewController {
+  public enum StoryboardSegue: String {
+    case afterDelay = "After Delay"
+    case `open`
+    case `private`
+    case `public`
+  }
+
+  public func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  public enum TypedStoryboardSegue {
+    case afterDelay(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideLeftSegue)
+    case `open`(destination: SlackTextViewController.SLKTextViewController, segue: SlackTextViewController.SLKCrossoverSegue)
+    case `private`(destination: SlackTextViewController.SLKTextViewController, segue: ExtraModule.SlideDownSegue)
+    case `public`(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideUpSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "After Delay":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'After Delay' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'After Delay' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .afterDelay(destination: vc, segue: segue)
+      case "open":
+        guard let segue = segue as? SlackTextViewController.SLKCrossoverSegue else {
+          fatalError("Segue 'open' is not of the expected type SlackTextViewController.SLKCrossoverSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'open' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`open`(destination: vc, segue: segue)
+      case "private":
+        guard let segue = segue as? ExtraModule.SlideDownSegue else {
+          fatalError("Segue 'private' is not of the expected type ExtraModule.SlideDownSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.SlideUpSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.SlideUpSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SlackTextViewController.SLKTextViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+public extension SwiftGen.CreateAccViewController {
+  public enum StoryboardSegue: String {
+    case showPassword = "ShowPassword"
+  }
+
+  public func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  public enum TypedStoryboardSegue {
+    case showPassword(destination: ExtraModule.ValidatePasswordViewController)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "ShowPassword":
+        guard let vc = segue.destination as? ExtraModule.ValidatePasswordViewController else {
+          fatalError("Destination of segue 'ShowPassword' is not of the expected type ExtraModule.ValidatePasswordViewController.")
+        }
+        self = .showPassword(destination: vc)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SwiftGen.CreateAccViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
 public enum StoryboardSegue {
   public enum AdditionalImport: String, SegueType {
     case afterDelay = "After Delay"

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/all-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/all-withExtraModule.swift
@@ -15,6 +15,253 @@ import UIKit
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+internal extension SwiftGen.PickerViewController {
+  internal enum StoryboardSegue: String {
+    case customBack = "CustomBack"
+    case embed = "Embed"
+    case nonCustom = "NonCustom"
+    case showNavCtrl = "Show-NavCtrl"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case customBack(destination: UIKit.UIViewController, segue: SwiftGen.SlideLeftSegue)
+    case embed(destination: UIKit.UIViewController)
+    case nonCustom(destination: UIKit.UIViewController)
+    case showNavCtrl(destination: UIKit.UINavigationController, segue: SwiftGen.CustomSegueClass)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "CustomBack":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'CustomBack' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        let vc = segue.destination
+        self = .customBack(destination: vc, segue: segue)
+      case "Embed":
+        let vc = segue.destination
+        self = .embed(destination: vc)
+      case "NonCustom":
+        let vc = segue.destination
+        self = .nonCustom(destination: vc)
+      case "Show-NavCtrl":
+        guard let segue = segue as? SwiftGen.CustomSegueClass else {
+          fatalError("Segue 'Show-NavCtrl' is not of the expected type SwiftGen.CustomSegueClass.")
+        }
+        guard let vc = segue.destination as? UIKit.UINavigationController else {
+          fatalError("Destination of segue 'Show-NavCtrl' is not of the expected type UIKit.UINavigationController.")
+        }
+        self = .showNavCtrl(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SwiftGen.PickerViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension ExtraModule.ValidatePasswordViewController {
+  internal enum StoryboardSegue: String {
+    case showPassword = "ShowPassword"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case showPassword(destination: ExtraModule.ValidatePasswordViewController)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "ShowPassword":
+        guard let vc = segue.destination as? ExtraModule.ValidatePasswordViewController else {
+          fatalError("Destination of segue 'ShowPassword' is not of the expected type ExtraModule.ValidatePasswordViewController.")
+        }
+        self = .showPassword(destination: vc)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in ExtraModule.ValidatePasswordViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension LocationPicker.LocationPickerViewController {
+  internal enum StoryboardSegue: String {
+    case afterDelay = "After Delay"
+    case `open`
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case afterDelay(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideLeftSegue)
+    case `open`(destination: SlackTextViewController.SLKTextViewController, segue: SlackTextViewController.SLKCrossoverSegue)
+    case `private`(destination: SlackTextViewController.SLKTextViewController, segue: ExtraModule.SlideDownSegue)
+    case `public`(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideUpSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "After Delay":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'After Delay' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'After Delay' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .afterDelay(destination: vc, segue: segue)
+      case "open":
+        guard let segue = segue as? SlackTextViewController.SLKCrossoverSegue else {
+          fatalError("Segue 'open' is not of the expected type SlackTextViewController.SLKCrossoverSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'open' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`open`(destination: vc, segue: segue)
+      case "private":
+        guard let segue = segue as? ExtraModule.SlideDownSegue else {
+          fatalError("Segue 'private' is not of the expected type ExtraModule.SlideDownSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.SlideUpSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.SlideUpSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in LocationPicker.LocationPickerViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension SlackTextViewController.SLKTextViewController {
+  internal enum StoryboardSegue: String {
+    case afterDelay = "After Delay"
+    case `open`
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case afterDelay(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideLeftSegue)
+    case `open`(destination: SlackTextViewController.SLKTextViewController, segue: SlackTextViewController.SLKCrossoverSegue)
+    case `private`(destination: SlackTextViewController.SLKTextViewController, segue: ExtraModule.SlideDownSegue)
+    case `public`(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideUpSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "After Delay":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'After Delay' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'After Delay' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .afterDelay(destination: vc, segue: segue)
+      case "open":
+        guard let segue = segue as? SlackTextViewController.SLKCrossoverSegue else {
+          fatalError("Segue 'open' is not of the expected type SlackTextViewController.SLKCrossoverSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'open' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`open`(destination: vc, segue: segue)
+      case "private":
+        guard let segue = segue as? ExtraModule.SlideDownSegue else {
+          fatalError("Segue 'private' is not of the expected type ExtraModule.SlideDownSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.SlideUpSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.SlideUpSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SlackTextViewController.SLKTextViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension SwiftGen.CreateAccViewController {
+  internal enum StoryboardSegue: String {
+    case showPassword = "ShowPassword"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case showPassword(destination: ExtraModule.ValidatePasswordViewController)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "ShowPassword":
+        guard let vc = segue.destination as? ExtraModule.ValidatePasswordViewController else {
+          fatalError("Destination of segue 'ShowPassword' is not of the expected type ExtraModule.ValidatePasswordViewController.")
+        }
+        self = .showPassword(destination: vc)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SwiftGen.CreateAccViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
 internal enum StoryboardSegue {
   internal enum AdditionalImport: String, SegueType {
     case afterDelay = "After Delay"

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/all.swift
@@ -16,6 +16,253 @@ import UIKit
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+internal extension SwiftGen.PickerViewController {
+  internal enum StoryboardSegue: String {
+    case customBack = "CustomBack"
+    case embed = "Embed"
+    case nonCustom = "NonCustom"
+    case showNavCtrl = "Show-NavCtrl"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case customBack(destination: UIKit.UIViewController, segue: SwiftGen.SlideLeftSegue)
+    case embed(destination: UIKit.UIViewController)
+    case nonCustom(destination: UIKit.UIViewController)
+    case showNavCtrl(destination: UIKit.UINavigationController, segue: SwiftGen.CustomSegueClass)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "CustomBack":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'CustomBack' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        let vc = segue.destination
+        self = .customBack(destination: vc, segue: segue)
+      case "Embed":
+        let vc = segue.destination
+        self = .embed(destination: vc)
+      case "NonCustom":
+        let vc = segue.destination
+        self = .nonCustom(destination: vc)
+      case "Show-NavCtrl":
+        guard let segue = segue as? SwiftGen.CustomSegueClass else {
+          fatalError("Segue 'Show-NavCtrl' is not of the expected type SwiftGen.CustomSegueClass.")
+        }
+        guard let vc = segue.destination as? UIKit.UINavigationController else {
+          fatalError("Destination of segue 'Show-NavCtrl' is not of the expected type UIKit.UINavigationController.")
+        }
+        self = .showNavCtrl(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SwiftGen.PickerViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension ExtraModule.ValidatePasswordViewController {
+  internal enum StoryboardSegue: String {
+    case showPassword = "ShowPassword"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case showPassword(destination: ExtraModule.ValidatePasswordViewController)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "ShowPassword":
+        guard let vc = segue.destination as? ExtraModule.ValidatePasswordViewController else {
+          fatalError("Destination of segue 'ShowPassword' is not of the expected type ExtraModule.ValidatePasswordViewController.")
+        }
+        self = .showPassword(destination: vc)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in ExtraModule.ValidatePasswordViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension LocationPicker.LocationPickerViewController {
+  internal enum StoryboardSegue: String {
+    case afterDelay = "After Delay"
+    case `open`
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case afterDelay(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideLeftSegue)
+    case `open`(destination: SlackTextViewController.SLKTextViewController, segue: SlackTextViewController.SLKCrossoverSegue)
+    case `private`(destination: SlackTextViewController.SLKTextViewController, segue: ExtraModule.SlideDownSegue)
+    case `public`(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideUpSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "After Delay":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'After Delay' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'After Delay' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .afterDelay(destination: vc, segue: segue)
+      case "open":
+        guard let segue = segue as? SlackTextViewController.SLKCrossoverSegue else {
+          fatalError("Segue 'open' is not of the expected type SlackTextViewController.SLKCrossoverSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'open' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`open`(destination: vc, segue: segue)
+      case "private":
+        guard let segue = segue as? ExtraModule.SlideDownSegue else {
+          fatalError("Segue 'private' is not of the expected type ExtraModule.SlideDownSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.SlideUpSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.SlideUpSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in LocationPicker.LocationPickerViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension SlackTextViewController.SLKTextViewController {
+  internal enum StoryboardSegue: String {
+    case afterDelay = "After Delay"
+    case `open`
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case afterDelay(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideLeftSegue)
+    case `open`(destination: SlackTextViewController.SLKTextViewController, segue: SlackTextViewController.SLKCrossoverSegue)
+    case `private`(destination: SlackTextViewController.SLKTextViewController, segue: ExtraModule.SlideDownSegue)
+    case `public`(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideUpSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "After Delay":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'After Delay' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'After Delay' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .afterDelay(destination: vc, segue: segue)
+      case "open":
+        guard let segue = segue as? SlackTextViewController.SLKCrossoverSegue else {
+          fatalError("Segue 'open' is not of the expected type SlackTextViewController.SLKCrossoverSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'open' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`open`(destination: vc, segue: segue)
+      case "private":
+        guard let segue = segue as? ExtraModule.SlideDownSegue else {
+          fatalError("Segue 'private' is not of the expected type ExtraModule.SlideDownSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.SlideUpSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.SlideUpSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SlackTextViewController.SLKTextViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension SwiftGen.CreateAccViewController {
+  internal enum StoryboardSegue: String {
+    case showPassword = "ShowPassword"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case showPassword(destination: ExtraModule.ValidatePasswordViewController)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "ShowPassword":
+        guard let vc = segue.destination as? ExtraModule.ValidatePasswordViewController else {
+          fatalError("Destination of segue 'ShowPassword' is not of the expected type ExtraModule.ValidatePasswordViewController.")
+        }
+        self = .showPassword(destination: vc)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SwiftGen.CreateAccViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
 internal enum StoryboardSegue {
   internal enum AdditionalImport: String, SegueType {
     case afterDelay = "After Delay"

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/all-customName.swift
@@ -16,6 +16,248 @@ import UIKit
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+internal extension SwiftGen.PickerViewController {
+  internal enum XCTStoryboardCustom: String {
+    case customBack = "CustomBack"
+    case embed = "Embed"
+    case nonCustom = "NonCustom"
+    case showNavCtrl = "Show-NavCtrl"
+  }
+
+  internal func perform(segue: XCTStoryboardCustom, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedXCTStoryboardCustom {
+    case customBack(destination: UIKit.UIViewController, segue: SwiftGen.SlideLeftSegue)
+    case embed(destination: UIKit.UIViewController)
+    case nonCustom(destination: UIKit.UIViewController)
+    case showNavCtrl(destination: UIKit.UINavigationController, segue: SwiftGen.CustomSegueClass)
+    case customUnnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "CustomBack":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'CustomBack' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        let vc = segue.destination
+        self = .customBack(destination: vc, segue: segue)
+      case "Embed":
+        let vc = segue.destination
+        self = .embed(destination: vc)
+      case "NonCustom":
+        let vc = segue.destination
+        self = .nonCustom(destination: vc)
+      case "Show-NavCtrl":
+        guard let segue = segue as? SwiftGen.CustomSegueClass else {
+          fatalError("Segue 'Show-NavCtrl' is not of the expected type SwiftGen.CustomSegueClass.")
+        }
+        guard let vc = segue.destination as? UIKit.UINavigationController else {
+          fatalError("Destination of segue 'Show-NavCtrl' is not of the expected type UIKit.UINavigationController.")
+        }
+        self = .showNavCtrl(destination: vc, segue: segue)
+      case "":
+        self = .customUnnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SwiftGen.PickerViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension ExtraModule.ValidatePasswordViewController {
+  internal enum XCTStoryboardCustom: String {
+    case showPassword = "ShowPassword"
+  }
+
+  internal func perform(segue: XCTStoryboardCustom, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedXCTStoryboardCustom {
+    case showPassword(destination: ExtraModule.ValidatePasswordViewController)
+    case customUnnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "ShowPassword":
+        guard let vc = segue.destination as? ExtraModule.ValidatePasswordViewController else {
+          fatalError("Destination of segue 'ShowPassword' is not of the expected type ExtraModule.ValidatePasswordViewController.")
+        }
+        self = .showPassword(destination: vc)
+      case "":
+        self = .customUnnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in ExtraModule.ValidatePasswordViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension LocationPicker.LocationPickerViewController {
+  internal enum XCTStoryboardCustom: String {
+    case afterDelay = "After Delay"
+    case `open`
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: XCTStoryboardCustom, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedXCTStoryboardCustom {
+    case afterDelay(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideLeftSegue)
+    case `open`(destination: SlackTextViewController.SLKTextViewController, segue: SlackTextViewController.SLKCrossoverSegue)
+    case `private`(destination: SlackTextViewController.SLKTextViewController, segue: ExtraModule.SlideDownSegue)
+    case `public`(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideUpSegue)
+    case customUnnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "After Delay":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'After Delay' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'After Delay' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .afterDelay(destination: vc, segue: segue)
+      case "open":
+        guard let segue = segue as? SlackTextViewController.SLKCrossoverSegue else {
+          fatalError("Segue 'open' is not of the expected type SlackTextViewController.SLKCrossoverSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'open' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`open`(destination: vc, segue: segue)
+      case "private":
+        guard let segue = segue as? ExtraModule.SlideDownSegue else {
+          fatalError("Segue 'private' is not of the expected type ExtraModule.SlideDownSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.SlideUpSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.SlideUpSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .customUnnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in LocationPicker.LocationPickerViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension SlackTextViewController.SLKTextViewController {
+  internal enum XCTStoryboardCustom: String {
+    case afterDelay = "After Delay"
+    case `open`
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: XCTStoryboardCustom, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedXCTStoryboardCustom {
+    case afterDelay(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideLeftSegue)
+    case `open`(destination: SlackTextViewController.SLKTextViewController, segue: SlackTextViewController.SLKCrossoverSegue)
+    case `private`(destination: SlackTextViewController.SLKTextViewController, segue: ExtraModule.SlideDownSegue)
+    case `public`(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideUpSegue)
+    case customUnnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "After Delay":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'After Delay' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'After Delay' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .afterDelay(destination: vc, segue: segue)
+      case "open":
+        guard let segue = segue as? SlackTextViewController.SLKCrossoverSegue else {
+          fatalError("Segue 'open' is not of the expected type SlackTextViewController.SLKCrossoverSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'open' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`open`(destination: vc, segue: segue)
+      case "private":
+        guard let segue = segue as? ExtraModule.SlideDownSegue else {
+          fatalError("Segue 'private' is not of the expected type ExtraModule.SlideDownSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.SlideUpSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.SlideUpSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .customUnnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SlackTextViewController.SLKTextViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension SwiftGen.CreateAccViewController {
+  internal enum XCTStoryboardCustom: String {
+    case showPassword = "ShowPassword"
+  }
+
+  internal func perform(segue: XCTStoryboardCustom, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedXCTStoryboardCustom {
+    case showPassword(destination: ExtraModule.ValidatePasswordViewController)
+    case customUnnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "ShowPassword":
+        guard let vc = segue.destination as? ExtraModule.ValidatePasswordViewController else {
+          fatalError("Destination of segue 'ShowPassword' is not of the expected type ExtraModule.ValidatePasswordViewController.")
+        }
+        self = .showPassword(destination: vc)
+      case "":
+        self = .customUnnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SwiftGen.CreateAccViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
 internal enum XCTStoryboardCustom {
   internal enum AdditionalImport: String, SegueType {
     case afterDelay = "After Delay"

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/all-ignoreTargetModule-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/all-ignoreTargetModule-withExtraModule.swift
@@ -15,6 +15,248 @@ import UIKit
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+internal extension PickerViewController {
+  internal enum StoryboardSegue: String {
+    case customBack = "CustomBack"
+    case embed = "Embed"
+    case nonCustom = "NonCustom"
+    case showNavCtrl = "Show-NavCtrl"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case customBack(destination: UIKit.UIViewController, segue: SlideLeftSegue)
+    case embed(destination: UIKit.UIViewController)
+    case nonCustom(destination: UIKit.UIViewController)
+    case showNavCtrl(destination: UIKit.UINavigationController, segue: CustomSegueClass)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "CustomBack":
+        guard let segue = segue as? SlideLeftSegue else {
+          fatalError("Segue 'CustomBack' is not of the expected type SlideLeftSegue.")
+        }
+        let vc = segue.destination
+        self = .customBack(destination: vc, segue: segue)
+      case "Embed":
+        let vc = segue.destination
+        self = .embed(destination: vc)
+      case "NonCustom":
+        let vc = segue.destination
+        self = .nonCustom(destination: vc)
+      case "Show-NavCtrl":
+        guard let segue = segue as? CustomSegueClass else {
+          fatalError("Segue 'Show-NavCtrl' is not of the expected type CustomSegueClass.")
+        }
+        guard let vc = segue.destination as? UIKit.UINavigationController else {
+          fatalError("Destination of segue 'Show-NavCtrl' is not of the expected type UIKit.UINavigationController.")
+        }
+        self = .showNavCtrl(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in PickerViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension ValidatePasswordViewController {
+  internal enum StoryboardSegue: String {
+    case showPassword = "ShowPassword"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case showPassword(destination: ValidatePasswordViewController)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "ShowPassword":
+        guard let vc = segue.destination as? ValidatePasswordViewController else {
+          fatalError("Destination of segue 'ShowPassword' is not of the expected type ValidatePasswordViewController.")
+        }
+        self = .showPassword(destination: vc)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in ValidatePasswordViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension LocationPicker.LocationPickerViewController {
+  internal enum StoryboardSegue: String {
+    case afterDelay = "After Delay"
+    case `open`
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case afterDelay(destination: SlackTextViewController.SLKTextViewController, segue: SlideLeftSegue)
+    case `open`(destination: SlackTextViewController.SLKTextViewController, segue: SlackTextViewController.SLKCrossoverSegue)
+    case `private`(destination: SlackTextViewController.SLKTextViewController, segue: SlideDownSegue)
+    case `public`(destination: SlackTextViewController.SLKTextViewController, segue: SlideUpSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "After Delay":
+        guard let segue = segue as? SlideLeftSegue else {
+          fatalError("Segue 'After Delay' is not of the expected type SlideLeftSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'After Delay' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .afterDelay(destination: vc, segue: segue)
+      case "open":
+        guard let segue = segue as? SlackTextViewController.SLKCrossoverSegue else {
+          fatalError("Segue 'open' is not of the expected type SlackTextViewController.SLKCrossoverSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'open' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`open`(destination: vc, segue: segue)
+      case "private":
+        guard let segue = segue as? SlideDownSegue else {
+          fatalError("Segue 'private' is not of the expected type SlideDownSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SlideUpSegue else {
+          fatalError("Segue 'public' is not of the expected type SlideUpSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in LocationPicker.LocationPickerViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension SlackTextViewController.SLKTextViewController {
+  internal enum StoryboardSegue: String {
+    case afterDelay = "After Delay"
+    case `open`
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case afterDelay(destination: SlackTextViewController.SLKTextViewController, segue: SlideLeftSegue)
+    case `open`(destination: SlackTextViewController.SLKTextViewController, segue: SlackTextViewController.SLKCrossoverSegue)
+    case `private`(destination: SlackTextViewController.SLKTextViewController, segue: SlideDownSegue)
+    case `public`(destination: SlackTextViewController.SLKTextViewController, segue: SlideUpSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "After Delay":
+        guard let segue = segue as? SlideLeftSegue else {
+          fatalError("Segue 'After Delay' is not of the expected type SlideLeftSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'After Delay' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .afterDelay(destination: vc, segue: segue)
+      case "open":
+        guard let segue = segue as? SlackTextViewController.SLKCrossoverSegue else {
+          fatalError("Segue 'open' is not of the expected type SlackTextViewController.SLKCrossoverSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'open' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`open`(destination: vc, segue: segue)
+      case "private":
+        guard let segue = segue as? SlideDownSegue else {
+          fatalError("Segue 'private' is not of the expected type SlideDownSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SlideUpSegue else {
+          fatalError("Segue 'public' is not of the expected type SlideUpSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SlackTextViewController.SLKTextViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension CreateAccViewController {
+  internal enum StoryboardSegue: String {
+    case showPassword = "ShowPassword"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case showPassword(destination: ValidatePasswordViewController)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "ShowPassword":
+        guard let vc = segue.destination as? ValidatePasswordViewController else {
+          fatalError("Destination of segue 'ShowPassword' is not of the expected type ValidatePasswordViewController.")
+        }
+        self = .showPassword(destination: vc)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in CreateAccViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
 internal enum StoryboardSegue {
   internal enum AdditionalImport: String, SegueType {
     case afterDelay = "After Delay"

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/all-ignoreTargetModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/all-ignoreTargetModule.swift
@@ -16,6 +16,248 @@ import UIKit
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+internal extension PickerViewController {
+  internal enum StoryboardSegue: String {
+    case customBack = "CustomBack"
+    case embed = "Embed"
+    case nonCustom = "NonCustom"
+    case showNavCtrl = "Show-NavCtrl"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case customBack(destination: UIKit.UIViewController, segue: SlideLeftSegue)
+    case embed(destination: UIKit.UIViewController)
+    case nonCustom(destination: UIKit.UIViewController)
+    case showNavCtrl(destination: UIKit.UINavigationController, segue: CustomSegueClass)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "CustomBack":
+        guard let segue = segue as? SlideLeftSegue else {
+          fatalError("Segue 'CustomBack' is not of the expected type SlideLeftSegue.")
+        }
+        let vc = segue.destination
+        self = .customBack(destination: vc, segue: segue)
+      case "Embed":
+        let vc = segue.destination
+        self = .embed(destination: vc)
+      case "NonCustom":
+        let vc = segue.destination
+        self = .nonCustom(destination: vc)
+      case "Show-NavCtrl":
+        guard let segue = segue as? CustomSegueClass else {
+          fatalError("Segue 'Show-NavCtrl' is not of the expected type CustomSegueClass.")
+        }
+        guard let vc = segue.destination as? UIKit.UINavigationController else {
+          fatalError("Destination of segue 'Show-NavCtrl' is not of the expected type UIKit.UINavigationController.")
+        }
+        self = .showNavCtrl(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in PickerViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension ExtraModule.ValidatePasswordViewController {
+  internal enum StoryboardSegue: String {
+    case showPassword = "ShowPassword"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case showPassword(destination: ExtraModule.ValidatePasswordViewController)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "ShowPassword":
+        guard let vc = segue.destination as? ExtraModule.ValidatePasswordViewController else {
+          fatalError("Destination of segue 'ShowPassword' is not of the expected type ExtraModule.ValidatePasswordViewController.")
+        }
+        self = .showPassword(destination: vc)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in ExtraModule.ValidatePasswordViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension LocationPicker.LocationPickerViewController {
+  internal enum StoryboardSegue: String {
+    case afterDelay = "After Delay"
+    case `open`
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case afterDelay(destination: SlackTextViewController.SLKTextViewController, segue: SlideLeftSegue)
+    case `open`(destination: SlackTextViewController.SLKTextViewController, segue: SlackTextViewController.SLKCrossoverSegue)
+    case `private`(destination: SlackTextViewController.SLKTextViewController, segue: ExtraModule.SlideDownSegue)
+    case `public`(destination: SlackTextViewController.SLKTextViewController, segue: SlideUpSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "After Delay":
+        guard let segue = segue as? SlideLeftSegue else {
+          fatalError("Segue 'After Delay' is not of the expected type SlideLeftSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'After Delay' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .afterDelay(destination: vc, segue: segue)
+      case "open":
+        guard let segue = segue as? SlackTextViewController.SLKCrossoverSegue else {
+          fatalError("Segue 'open' is not of the expected type SlackTextViewController.SLKCrossoverSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'open' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`open`(destination: vc, segue: segue)
+      case "private":
+        guard let segue = segue as? ExtraModule.SlideDownSegue else {
+          fatalError("Segue 'private' is not of the expected type ExtraModule.SlideDownSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SlideUpSegue else {
+          fatalError("Segue 'public' is not of the expected type SlideUpSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in LocationPicker.LocationPickerViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension SlackTextViewController.SLKTextViewController {
+  internal enum StoryboardSegue: String {
+    case afterDelay = "After Delay"
+    case `open`
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case afterDelay(destination: SlackTextViewController.SLKTextViewController, segue: SlideLeftSegue)
+    case `open`(destination: SlackTextViewController.SLKTextViewController, segue: SlackTextViewController.SLKCrossoverSegue)
+    case `private`(destination: SlackTextViewController.SLKTextViewController, segue: ExtraModule.SlideDownSegue)
+    case `public`(destination: SlackTextViewController.SLKTextViewController, segue: SlideUpSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "After Delay":
+        guard let segue = segue as? SlideLeftSegue else {
+          fatalError("Segue 'After Delay' is not of the expected type SlideLeftSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'After Delay' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .afterDelay(destination: vc, segue: segue)
+      case "open":
+        guard let segue = segue as? SlackTextViewController.SLKCrossoverSegue else {
+          fatalError("Segue 'open' is not of the expected type SlackTextViewController.SLKCrossoverSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'open' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`open`(destination: vc, segue: segue)
+      case "private":
+        guard let segue = segue as? ExtraModule.SlideDownSegue else {
+          fatalError("Segue 'private' is not of the expected type ExtraModule.SlideDownSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SlideUpSegue else {
+          fatalError("Segue 'public' is not of the expected type SlideUpSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SlackTextViewController.SLKTextViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension CreateAccViewController {
+  internal enum StoryboardSegue: String {
+    case showPassword = "ShowPassword"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case showPassword(destination: ExtraModule.ValidatePasswordViewController)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "ShowPassword":
+        guard let vc = segue.destination as? ExtraModule.ValidatePasswordViewController else {
+          fatalError("Destination of segue 'ShowPassword' is not of the expected type ExtraModule.ValidatePasswordViewController.")
+        }
+        self = .showPassword(destination: vc)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in CreateAccViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
 internal enum StoryboardSegue {
   internal enum AdditionalImport: String, SegueType {
     case afterDelay = "After Delay"

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/all-noDefinedModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/all-noDefinedModule.swift
@@ -17,6 +17,248 @@ import UIKit
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+internal extension PickerViewController {
+  internal enum StoryboardSegue: String {
+    case customBack = "CustomBack"
+    case embed = "Embed"
+    case nonCustom = "NonCustom"
+    case showNavCtrl = "Show-NavCtrl"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case customBack(destination: UIKit.UIViewController, segue: SwiftGen.SlideLeftSegue)
+    case embed(destination: UIKit.UIViewController)
+    case nonCustom(destination: UIKit.UIViewController)
+    case showNavCtrl(destination: UIKit.UINavigationController, segue: CustomSegueClass)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "CustomBack":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'CustomBack' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        let vc = segue.destination
+        self = .customBack(destination: vc, segue: segue)
+      case "Embed":
+        let vc = segue.destination
+        self = .embed(destination: vc)
+      case "NonCustom":
+        let vc = segue.destination
+        self = .nonCustom(destination: vc)
+      case "Show-NavCtrl":
+        guard let segue = segue as? CustomSegueClass else {
+          fatalError("Segue 'Show-NavCtrl' is not of the expected type CustomSegueClass.")
+        }
+        guard let vc = segue.destination as? UIKit.UINavigationController else {
+          fatalError("Destination of segue 'Show-NavCtrl' is not of the expected type UIKit.UINavigationController.")
+        }
+        self = .showNavCtrl(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in PickerViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension ExtraModule.ValidatePasswordViewController {
+  internal enum StoryboardSegue: String {
+    case showPassword = "ShowPassword"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case showPassword(destination: ExtraModule.ValidatePasswordViewController)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "ShowPassword":
+        guard let vc = segue.destination as? ExtraModule.ValidatePasswordViewController else {
+          fatalError("Destination of segue 'ShowPassword' is not of the expected type ExtraModule.ValidatePasswordViewController.")
+        }
+        self = .showPassword(destination: vc)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in ExtraModule.ValidatePasswordViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension LocationPicker.LocationPickerViewController {
+  internal enum StoryboardSegue: String {
+    case afterDelay = "After Delay"
+    case `open`
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case afterDelay(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideLeftSegue)
+    case `open`(destination: SlackTextViewController.SLKTextViewController, segue: SlackTextViewController.SLKCrossoverSegue)
+    case `private`(destination: SlackTextViewController.SLKTextViewController, segue: ExtraModule.SlideDownSegue)
+    case `public`(destination: SlackTextViewController.SLKTextViewController, segue: SlideUpSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "After Delay":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'After Delay' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'After Delay' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .afterDelay(destination: vc, segue: segue)
+      case "open":
+        guard let segue = segue as? SlackTextViewController.SLKCrossoverSegue else {
+          fatalError("Segue 'open' is not of the expected type SlackTextViewController.SLKCrossoverSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'open' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`open`(destination: vc, segue: segue)
+      case "private":
+        guard let segue = segue as? ExtraModule.SlideDownSegue else {
+          fatalError("Segue 'private' is not of the expected type ExtraModule.SlideDownSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SlideUpSegue else {
+          fatalError("Segue 'public' is not of the expected type SlideUpSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in LocationPicker.LocationPickerViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension SlackTextViewController.SLKTextViewController {
+  internal enum StoryboardSegue: String {
+    case afterDelay = "After Delay"
+    case `open`
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case afterDelay(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideLeftSegue)
+    case `open`(destination: SlackTextViewController.SLKTextViewController, segue: SlackTextViewController.SLKCrossoverSegue)
+    case `private`(destination: SlackTextViewController.SLKTextViewController, segue: ExtraModule.SlideDownSegue)
+    case `public`(destination: SlackTextViewController.SLKTextViewController, segue: SlideUpSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "After Delay":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'After Delay' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'After Delay' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .afterDelay(destination: vc, segue: segue)
+      case "open":
+        guard let segue = segue as? SlackTextViewController.SLKCrossoverSegue else {
+          fatalError("Segue 'open' is not of the expected type SlackTextViewController.SLKCrossoverSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'open' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`open`(destination: vc, segue: segue)
+      case "private":
+        guard let segue = segue as? ExtraModule.SlideDownSegue else {
+          fatalError("Segue 'private' is not of the expected type ExtraModule.SlideDownSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SlideUpSegue else {
+          fatalError("Segue 'public' is not of the expected type SlideUpSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SlackTextViewController.SLKTextViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension SwiftGen.CreateAccViewController {
+  internal enum StoryboardSegue: String {
+    case showPassword = "ShowPassword"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case showPassword(destination: ExtraModule.ValidatePasswordViewController)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "ShowPassword":
+        guard let vc = segue.destination as? ExtraModule.ValidatePasswordViewController else {
+          fatalError("Destination of segue 'ShowPassword' is not of the expected type ExtraModule.ValidatePasswordViewController.")
+        }
+        self = .showPassword(destination: vc)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SwiftGen.CreateAccViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
 internal enum StoryboardSegue {
   internal enum AdditionalImport: String, SegueType {
     case afterDelay = "After Delay"

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/all-publicAccess.swift
@@ -16,6 +16,248 @@ import UIKit
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+public extension SwiftGen.PickerViewController {
+  public enum StoryboardSegue: String {
+    case customBack = "CustomBack"
+    case embed = "Embed"
+    case nonCustom = "NonCustom"
+    case showNavCtrl = "Show-NavCtrl"
+  }
+
+  public func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  public enum TypedStoryboardSegue {
+    case customBack(destination: UIKit.UIViewController, segue: SwiftGen.SlideLeftSegue)
+    case embed(destination: UIKit.UIViewController)
+    case nonCustom(destination: UIKit.UIViewController)
+    case showNavCtrl(destination: UIKit.UINavigationController, segue: SwiftGen.CustomSegueClass)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "CustomBack":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'CustomBack' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        let vc = segue.destination
+        self = .customBack(destination: vc, segue: segue)
+      case "Embed":
+        let vc = segue.destination
+        self = .embed(destination: vc)
+      case "NonCustom":
+        let vc = segue.destination
+        self = .nonCustom(destination: vc)
+      case "Show-NavCtrl":
+        guard let segue = segue as? SwiftGen.CustomSegueClass else {
+          fatalError("Segue 'Show-NavCtrl' is not of the expected type SwiftGen.CustomSegueClass.")
+        }
+        guard let vc = segue.destination as? UIKit.UINavigationController else {
+          fatalError("Destination of segue 'Show-NavCtrl' is not of the expected type UIKit.UINavigationController.")
+        }
+        self = .showNavCtrl(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SwiftGen.PickerViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+public extension ExtraModule.ValidatePasswordViewController {
+  public enum StoryboardSegue: String {
+    case showPassword = "ShowPassword"
+  }
+
+  public func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  public enum TypedStoryboardSegue {
+    case showPassword(destination: ExtraModule.ValidatePasswordViewController)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "ShowPassword":
+        guard let vc = segue.destination as? ExtraModule.ValidatePasswordViewController else {
+          fatalError("Destination of segue 'ShowPassword' is not of the expected type ExtraModule.ValidatePasswordViewController.")
+        }
+        self = .showPassword(destination: vc)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in ExtraModule.ValidatePasswordViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+public extension LocationPicker.LocationPickerViewController {
+  public enum StoryboardSegue: String {
+    case afterDelay = "After Delay"
+    case `open`
+    case `private`
+    case `public`
+  }
+
+  public func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  public enum TypedStoryboardSegue {
+    case afterDelay(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideLeftSegue)
+    case `open`(destination: SlackTextViewController.SLKTextViewController, segue: SlackTextViewController.SLKCrossoverSegue)
+    case `private`(destination: SlackTextViewController.SLKTextViewController, segue: ExtraModule.SlideDownSegue)
+    case `public`(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideUpSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "After Delay":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'After Delay' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'After Delay' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .afterDelay(destination: vc, segue: segue)
+      case "open":
+        guard let segue = segue as? SlackTextViewController.SLKCrossoverSegue else {
+          fatalError("Segue 'open' is not of the expected type SlackTextViewController.SLKCrossoverSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'open' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`open`(destination: vc, segue: segue)
+      case "private":
+        guard let segue = segue as? ExtraModule.SlideDownSegue else {
+          fatalError("Segue 'private' is not of the expected type ExtraModule.SlideDownSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.SlideUpSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.SlideUpSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in LocationPicker.LocationPickerViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+public extension SlackTextViewController.SLKTextViewController {
+  public enum StoryboardSegue: String {
+    case afterDelay = "After Delay"
+    case `open`
+    case `private`
+    case `public`
+  }
+
+  public func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  public enum TypedStoryboardSegue {
+    case afterDelay(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideLeftSegue)
+    case `open`(destination: SlackTextViewController.SLKTextViewController, segue: SlackTextViewController.SLKCrossoverSegue)
+    case `private`(destination: SlackTextViewController.SLKTextViewController, segue: ExtraModule.SlideDownSegue)
+    case `public`(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideUpSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "After Delay":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'After Delay' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'After Delay' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .afterDelay(destination: vc, segue: segue)
+      case "open":
+        guard let segue = segue as? SlackTextViewController.SLKCrossoverSegue else {
+          fatalError("Segue 'open' is not of the expected type SlackTextViewController.SLKCrossoverSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'open' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`open`(destination: vc, segue: segue)
+      case "private":
+        guard let segue = segue as? ExtraModule.SlideDownSegue else {
+          fatalError("Segue 'private' is not of the expected type ExtraModule.SlideDownSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.SlideUpSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.SlideUpSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SlackTextViewController.SLKTextViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+public extension SwiftGen.CreateAccViewController {
+  public enum StoryboardSegue: String {
+    case showPassword = "ShowPassword"
+  }
+
+  public func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  public enum TypedStoryboardSegue {
+    case showPassword(destination: ExtraModule.ValidatePasswordViewController)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "ShowPassword":
+        guard let vc = segue.destination as? ExtraModule.ValidatePasswordViewController else {
+          fatalError("Destination of segue 'ShowPassword' is not of the expected type ExtraModule.ValidatePasswordViewController.")
+        }
+        self = .showPassword(destination: vc)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SwiftGen.CreateAccViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
 public enum StoryboardSegue {
   public enum AdditionalImport: String, SegueType {
     case afterDelay = "After Delay"

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/all-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/all-withExtraModule.swift
@@ -15,6 +15,248 @@ import UIKit
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+internal extension SwiftGen.PickerViewController {
+  internal enum StoryboardSegue: String {
+    case customBack = "CustomBack"
+    case embed = "Embed"
+    case nonCustom = "NonCustom"
+    case showNavCtrl = "Show-NavCtrl"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case customBack(destination: UIKit.UIViewController, segue: SwiftGen.SlideLeftSegue)
+    case embed(destination: UIKit.UIViewController)
+    case nonCustom(destination: UIKit.UIViewController)
+    case showNavCtrl(destination: UIKit.UINavigationController, segue: SwiftGen.CustomSegueClass)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "CustomBack":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'CustomBack' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        let vc = segue.destination
+        self = .customBack(destination: vc, segue: segue)
+      case "Embed":
+        let vc = segue.destination
+        self = .embed(destination: vc)
+      case "NonCustom":
+        let vc = segue.destination
+        self = .nonCustom(destination: vc)
+      case "Show-NavCtrl":
+        guard let segue = segue as? SwiftGen.CustomSegueClass else {
+          fatalError("Segue 'Show-NavCtrl' is not of the expected type SwiftGen.CustomSegueClass.")
+        }
+        guard let vc = segue.destination as? UIKit.UINavigationController else {
+          fatalError("Destination of segue 'Show-NavCtrl' is not of the expected type UIKit.UINavigationController.")
+        }
+        self = .showNavCtrl(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SwiftGen.PickerViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension ExtraModule.ValidatePasswordViewController {
+  internal enum StoryboardSegue: String {
+    case showPassword = "ShowPassword"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case showPassword(destination: ExtraModule.ValidatePasswordViewController)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "ShowPassword":
+        guard let vc = segue.destination as? ExtraModule.ValidatePasswordViewController else {
+          fatalError("Destination of segue 'ShowPassword' is not of the expected type ExtraModule.ValidatePasswordViewController.")
+        }
+        self = .showPassword(destination: vc)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in ExtraModule.ValidatePasswordViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension LocationPicker.LocationPickerViewController {
+  internal enum StoryboardSegue: String {
+    case afterDelay = "After Delay"
+    case `open`
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case afterDelay(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideLeftSegue)
+    case `open`(destination: SlackTextViewController.SLKTextViewController, segue: SlackTextViewController.SLKCrossoverSegue)
+    case `private`(destination: SlackTextViewController.SLKTextViewController, segue: ExtraModule.SlideDownSegue)
+    case `public`(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideUpSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "After Delay":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'After Delay' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'After Delay' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .afterDelay(destination: vc, segue: segue)
+      case "open":
+        guard let segue = segue as? SlackTextViewController.SLKCrossoverSegue else {
+          fatalError("Segue 'open' is not of the expected type SlackTextViewController.SLKCrossoverSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'open' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`open`(destination: vc, segue: segue)
+      case "private":
+        guard let segue = segue as? ExtraModule.SlideDownSegue else {
+          fatalError("Segue 'private' is not of the expected type ExtraModule.SlideDownSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.SlideUpSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.SlideUpSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in LocationPicker.LocationPickerViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension SlackTextViewController.SLKTextViewController {
+  internal enum StoryboardSegue: String {
+    case afterDelay = "After Delay"
+    case `open`
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case afterDelay(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideLeftSegue)
+    case `open`(destination: SlackTextViewController.SLKTextViewController, segue: SlackTextViewController.SLKCrossoverSegue)
+    case `private`(destination: SlackTextViewController.SLKTextViewController, segue: ExtraModule.SlideDownSegue)
+    case `public`(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideUpSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "After Delay":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'After Delay' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'After Delay' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .afterDelay(destination: vc, segue: segue)
+      case "open":
+        guard let segue = segue as? SlackTextViewController.SLKCrossoverSegue else {
+          fatalError("Segue 'open' is not of the expected type SlackTextViewController.SLKCrossoverSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'open' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`open`(destination: vc, segue: segue)
+      case "private":
+        guard let segue = segue as? ExtraModule.SlideDownSegue else {
+          fatalError("Segue 'private' is not of the expected type ExtraModule.SlideDownSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.SlideUpSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.SlideUpSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SlackTextViewController.SLKTextViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension SwiftGen.CreateAccViewController {
+  internal enum StoryboardSegue: String {
+    case showPassword = "ShowPassword"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case showPassword(destination: ExtraModule.ValidatePasswordViewController)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "ShowPassword":
+        guard let vc = segue.destination as? ExtraModule.ValidatePasswordViewController else {
+          fatalError("Destination of segue 'ShowPassword' is not of the expected type ExtraModule.ValidatePasswordViewController.")
+        }
+        self = .showPassword(destination: vc)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SwiftGen.CreateAccViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
 internal enum StoryboardSegue {
   internal enum AdditionalImport: String, SegueType {
     case afterDelay = "After Delay"

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/all.swift
@@ -16,6 +16,248 @@ import UIKit
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+internal extension SwiftGen.PickerViewController {
+  internal enum StoryboardSegue: String {
+    case customBack = "CustomBack"
+    case embed = "Embed"
+    case nonCustom = "NonCustom"
+    case showNavCtrl = "Show-NavCtrl"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case customBack(destination: UIKit.UIViewController, segue: SwiftGen.SlideLeftSegue)
+    case embed(destination: UIKit.UIViewController)
+    case nonCustom(destination: UIKit.UIViewController)
+    case showNavCtrl(destination: UIKit.UINavigationController, segue: SwiftGen.CustomSegueClass)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "CustomBack":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'CustomBack' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        let vc = segue.destination
+        self = .customBack(destination: vc, segue: segue)
+      case "Embed":
+        let vc = segue.destination
+        self = .embed(destination: vc)
+      case "NonCustom":
+        let vc = segue.destination
+        self = .nonCustom(destination: vc)
+      case "Show-NavCtrl":
+        guard let segue = segue as? SwiftGen.CustomSegueClass else {
+          fatalError("Segue 'Show-NavCtrl' is not of the expected type SwiftGen.CustomSegueClass.")
+        }
+        guard let vc = segue.destination as? UIKit.UINavigationController else {
+          fatalError("Destination of segue 'Show-NavCtrl' is not of the expected type UIKit.UINavigationController.")
+        }
+        self = .showNavCtrl(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SwiftGen.PickerViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension ExtraModule.ValidatePasswordViewController {
+  internal enum StoryboardSegue: String {
+    case showPassword = "ShowPassword"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case showPassword(destination: ExtraModule.ValidatePasswordViewController)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "ShowPassword":
+        guard let vc = segue.destination as? ExtraModule.ValidatePasswordViewController else {
+          fatalError("Destination of segue 'ShowPassword' is not of the expected type ExtraModule.ValidatePasswordViewController.")
+        }
+        self = .showPassword(destination: vc)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in ExtraModule.ValidatePasswordViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension LocationPicker.LocationPickerViewController {
+  internal enum StoryboardSegue: String {
+    case afterDelay = "After Delay"
+    case `open`
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case afterDelay(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideLeftSegue)
+    case `open`(destination: SlackTextViewController.SLKTextViewController, segue: SlackTextViewController.SLKCrossoverSegue)
+    case `private`(destination: SlackTextViewController.SLKTextViewController, segue: ExtraModule.SlideDownSegue)
+    case `public`(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideUpSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "After Delay":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'After Delay' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'After Delay' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .afterDelay(destination: vc, segue: segue)
+      case "open":
+        guard let segue = segue as? SlackTextViewController.SLKCrossoverSegue else {
+          fatalError("Segue 'open' is not of the expected type SlackTextViewController.SLKCrossoverSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'open' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`open`(destination: vc, segue: segue)
+      case "private":
+        guard let segue = segue as? ExtraModule.SlideDownSegue else {
+          fatalError("Segue 'private' is not of the expected type ExtraModule.SlideDownSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.SlideUpSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.SlideUpSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in LocationPicker.LocationPickerViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension SlackTextViewController.SLKTextViewController {
+  internal enum StoryboardSegue: String {
+    case afterDelay = "After Delay"
+    case `open`
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case afterDelay(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideLeftSegue)
+    case `open`(destination: SlackTextViewController.SLKTextViewController, segue: SlackTextViewController.SLKCrossoverSegue)
+    case `private`(destination: SlackTextViewController.SLKTextViewController, segue: ExtraModule.SlideDownSegue)
+    case `public`(destination: SlackTextViewController.SLKTextViewController, segue: SwiftGen.SlideUpSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "After Delay":
+        guard let segue = segue as? SwiftGen.SlideLeftSegue else {
+          fatalError("Segue 'After Delay' is not of the expected type SwiftGen.SlideLeftSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'After Delay' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .afterDelay(destination: vc, segue: segue)
+      case "open":
+        guard let segue = segue as? SlackTextViewController.SLKCrossoverSegue else {
+          fatalError("Segue 'open' is not of the expected type SlackTextViewController.SLKCrossoverSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'open' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`open`(destination: vc, segue: segue)
+      case "private":
+        guard let segue = segue as? ExtraModule.SlideDownSegue else {
+          fatalError("Segue 'private' is not of the expected type ExtraModule.SlideDownSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.SlideUpSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.SlideUpSegue.")
+        }
+        guard let vc = segue.destination as? SlackTextViewController.SLKTextViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type SlackTextViewController.SLKTextViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SlackTextViewController.SLKTextViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension SwiftGen.CreateAccViewController {
+  internal enum StoryboardSegue: String {
+    case showPassword = "ShowPassword"
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case showPassword(destination: ExtraModule.ValidatePasswordViewController)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "ShowPassword":
+        guard let vc = segue.destination as? ExtraModule.ValidatePasswordViewController else {
+          fatalError("Destination of segue 'ShowPassword' is not of the expected type ExtraModule.ValidatePasswordViewController.")
+        }
+        self = .showPassword(destination: vc)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SwiftGen.CreateAccViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
 internal enum StoryboardSegue {
   internal enum AdditionalImport: String, SegueType {
     case afterDelay = "After Delay"

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-customName.swift
@@ -13,6 +13,206 @@ import PrefsWindowController
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+internal extension SwiftGen.DetailsViewController {
+  internal enum XCTStoryboardCustom: String {
+    case embed = "Embed"
+    case fade = "Fade"
+    case login = "Login"
+    case modal = "Modal"
+    case popover = "Popover"
+    case sheet = "Sheet"
+    case show = "Show"
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: XCTStoryboardCustom, sender: Any? = nil) {
+    let identifier = NSStoryboardSegue.Identifier(segue.rawValue)
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedXCTStoryboardCustom {
+    case embed(destination: AppKit.NSViewController)
+    case fade(destination: AppKit.NSViewController, segue: PrefsWindowController.SlowFadeSegue)
+    case login(destination: AppKit.NSViewController, segue: ExtraModule.LoginSegue)
+    case modal(destination: AppKit.NSViewController)
+    case popover(destination: AppKit.NSViewController)
+    case sheet(destination: AppKit.NSViewController)
+    case show(destination: AppKit.NSViewController)
+    case `private`(destination: AppKit.NSViewController, segue: SwiftGen.RotateSegue)
+    case `public`(destination: AppKit.NSViewController, segue: SwiftGen.ZoomSegue)
+    case customUnnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier?.rawValue ?? "" {
+      case "Embed":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Embed' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .embed(destination: vc)
+      case "Fade":
+        guard let segue = segue as? PrefsWindowController.SlowFadeSegue else {
+          fatalError("Segue 'Fade' is not of the expected type PrefsWindowController.SlowFadeSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Fade' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .fade(destination: vc, segue: segue)
+      case "Login":
+        guard let segue = segue as? ExtraModule.LoginSegue else {
+          fatalError("Segue 'Login' is not of the expected type ExtraModule.LoginSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Login' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .login(destination: vc, segue: segue)
+      case "Modal":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Modal' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .modal(destination: vc)
+      case "Popover":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Popover' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .popover(destination: vc)
+      case "Sheet":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Sheet' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .sheet(destination: vc)
+      case "Show":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Show' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .show(destination: vc)
+      case "private":
+        guard let segue = segue as? SwiftGen.RotateSegue else {
+          fatalError("Segue 'private' is not of the expected type SwiftGen.RotateSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.ZoomSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.ZoomSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .customUnnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier?.rawValue ?? "")' in SwiftGen.DetailsViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension SwiftGen.CustomTabViewController {
+  internal enum XCTStoryboardCustom: String {
+    case embed = "Embed"
+    case fade = "Fade"
+    case login = "Login"
+    case modal = "Modal"
+    case popover = "Popover"
+    case sheet = "Sheet"
+    case show = "Show"
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: XCTStoryboardCustom, sender: Any? = nil) {
+    let identifier = NSStoryboardSegue.Identifier(segue.rawValue)
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedXCTStoryboardCustom {
+    case embed(destination: AppKit.NSViewController)
+    case fade(destination: AppKit.NSViewController, segue: PrefsWindowController.SlowFadeSegue)
+    case login(destination: AppKit.NSViewController, segue: ExtraModule.LoginSegue)
+    case modal(destination: AppKit.NSViewController)
+    case popover(destination: AppKit.NSViewController)
+    case sheet(destination: AppKit.NSViewController)
+    case show(destination: AppKit.NSViewController)
+    case `private`(destination: AppKit.NSViewController, segue: SwiftGen.RotateSegue)
+    case `public`(destination: AppKit.NSViewController, segue: SwiftGen.ZoomSegue)
+    case customUnnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier?.rawValue ?? "" {
+      case "Embed":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Embed' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .embed(destination: vc)
+      case "Fade":
+        guard let segue = segue as? PrefsWindowController.SlowFadeSegue else {
+          fatalError("Segue 'Fade' is not of the expected type PrefsWindowController.SlowFadeSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Fade' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .fade(destination: vc, segue: segue)
+      case "Login":
+        guard let segue = segue as? ExtraModule.LoginSegue else {
+          fatalError("Segue 'Login' is not of the expected type ExtraModule.LoginSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Login' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .login(destination: vc, segue: segue)
+      case "Modal":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Modal' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .modal(destination: vc)
+      case "Popover":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Popover' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .popover(destination: vc)
+      case "Sheet":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Sheet' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .sheet(destination: vc)
+      case "Show":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Show' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .show(destination: vc)
+      case "private":
+        guard let segue = segue as? SwiftGen.RotateSegue else {
+          fatalError("Segue 'private' is not of the expected type SwiftGen.RotateSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.ZoomSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.ZoomSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .customUnnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier?.rawValue ?? "")' in SwiftGen.CustomTabViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
 internal enum XCTStoryboardCustom {
   internal enum Message: String, SegueType {
     case embed = "Embed"

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-ignoreTargetModule-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-ignoreTargetModule-withExtraModule.swift
@@ -12,6 +12,206 @@ import PrefsWindowController
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+internal extension DetailsViewController {
+  internal enum StoryboardSegue: String {
+    case embed = "Embed"
+    case fade = "Fade"
+    case login = "Login"
+    case modal = "Modal"
+    case popover = "Popover"
+    case sheet = "Sheet"
+    case show = "Show"
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = NSStoryboardSegue.Identifier(segue.rawValue)
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case embed(destination: AppKit.NSViewController)
+    case fade(destination: AppKit.NSViewController, segue: PrefsWindowController.SlowFadeSegue)
+    case login(destination: AppKit.NSViewController, segue: LoginSegue)
+    case modal(destination: AppKit.NSViewController)
+    case popover(destination: AppKit.NSViewController)
+    case sheet(destination: AppKit.NSViewController)
+    case show(destination: AppKit.NSViewController)
+    case `private`(destination: AppKit.NSViewController, segue: RotateSegue)
+    case `public`(destination: AppKit.NSViewController, segue: ZoomSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier?.rawValue ?? "" {
+      case "Embed":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Embed' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .embed(destination: vc)
+      case "Fade":
+        guard let segue = segue as? PrefsWindowController.SlowFadeSegue else {
+          fatalError("Segue 'Fade' is not of the expected type PrefsWindowController.SlowFadeSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Fade' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .fade(destination: vc, segue: segue)
+      case "Login":
+        guard let segue = segue as? LoginSegue else {
+          fatalError("Segue 'Login' is not of the expected type LoginSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Login' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .login(destination: vc, segue: segue)
+      case "Modal":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Modal' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .modal(destination: vc)
+      case "Popover":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Popover' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .popover(destination: vc)
+      case "Sheet":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Sheet' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .sheet(destination: vc)
+      case "Show":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Show' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .show(destination: vc)
+      case "private":
+        guard let segue = segue as? RotateSegue else {
+          fatalError("Segue 'private' is not of the expected type RotateSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? ZoomSegue else {
+          fatalError("Segue 'public' is not of the expected type ZoomSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier?.rawValue ?? "")' in DetailsViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension CustomTabViewController {
+  internal enum StoryboardSegue: String {
+    case embed = "Embed"
+    case fade = "Fade"
+    case login = "Login"
+    case modal = "Modal"
+    case popover = "Popover"
+    case sheet = "Sheet"
+    case show = "Show"
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = NSStoryboardSegue.Identifier(segue.rawValue)
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case embed(destination: AppKit.NSViewController)
+    case fade(destination: AppKit.NSViewController, segue: PrefsWindowController.SlowFadeSegue)
+    case login(destination: AppKit.NSViewController, segue: LoginSegue)
+    case modal(destination: AppKit.NSViewController)
+    case popover(destination: AppKit.NSViewController)
+    case sheet(destination: AppKit.NSViewController)
+    case show(destination: AppKit.NSViewController)
+    case `private`(destination: AppKit.NSViewController, segue: RotateSegue)
+    case `public`(destination: AppKit.NSViewController, segue: ZoomSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier?.rawValue ?? "" {
+      case "Embed":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Embed' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .embed(destination: vc)
+      case "Fade":
+        guard let segue = segue as? PrefsWindowController.SlowFadeSegue else {
+          fatalError("Segue 'Fade' is not of the expected type PrefsWindowController.SlowFadeSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Fade' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .fade(destination: vc, segue: segue)
+      case "Login":
+        guard let segue = segue as? LoginSegue else {
+          fatalError("Segue 'Login' is not of the expected type LoginSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Login' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .login(destination: vc, segue: segue)
+      case "Modal":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Modal' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .modal(destination: vc)
+      case "Popover":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Popover' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .popover(destination: vc)
+      case "Sheet":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Sheet' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .sheet(destination: vc)
+      case "Show":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Show' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .show(destination: vc)
+      case "private":
+        guard let segue = segue as? RotateSegue else {
+          fatalError("Segue 'private' is not of the expected type RotateSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? ZoomSegue else {
+          fatalError("Segue 'public' is not of the expected type ZoomSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier?.rawValue ?? "")' in CustomTabViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
 internal enum StoryboardSegue {
   internal enum Message: String, SegueType {
     case embed = "Embed"

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-ignoreTargetModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-ignoreTargetModule.swift
@@ -13,6 +13,206 @@ import PrefsWindowController
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+internal extension DetailsViewController {
+  internal enum StoryboardSegue: String {
+    case embed = "Embed"
+    case fade = "Fade"
+    case login = "Login"
+    case modal = "Modal"
+    case popover = "Popover"
+    case sheet = "Sheet"
+    case show = "Show"
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = NSStoryboardSegue.Identifier(segue.rawValue)
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case embed(destination: AppKit.NSViewController)
+    case fade(destination: AppKit.NSViewController, segue: PrefsWindowController.SlowFadeSegue)
+    case login(destination: AppKit.NSViewController, segue: ExtraModule.LoginSegue)
+    case modal(destination: AppKit.NSViewController)
+    case popover(destination: AppKit.NSViewController)
+    case sheet(destination: AppKit.NSViewController)
+    case show(destination: AppKit.NSViewController)
+    case `private`(destination: AppKit.NSViewController, segue: RotateSegue)
+    case `public`(destination: AppKit.NSViewController, segue: ZoomSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier?.rawValue ?? "" {
+      case "Embed":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Embed' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .embed(destination: vc)
+      case "Fade":
+        guard let segue = segue as? PrefsWindowController.SlowFadeSegue else {
+          fatalError("Segue 'Fade' is not of the expected type PrefsWindowController.SlowFadeSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Fade' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .fade(destination: vc, segue: segue)
+      case "Login":
+        guard let segue = segue as? ExtraModule.LoginSegue else {
+          fatalError("Segue 'Login' is not of the expected type ExtraModule.LoginSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Login' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .login(destination: vc, segue: segue)
+      case "Modal":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Modal' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .modal(destination: vc)
+      case "Popover":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Popover' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .popover(destination: vc)
+      case "Sheet":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Sheet' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .sheet(destination: vc)
+      case "Show":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Show' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .show(destination: vc)
+      case "private":
+        guard let segue = segue as? RotateSegue else {
+          fatalError("Segue 'private' is not of the expected type RotateSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? ZoomSegue else {
+          fatalError("Segue 'public' is not of the expected type ZoomSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier?.rawValue ?? "")' in DetailsViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension CustomTabViewController {
+  internal enum StoryboardSegue: String {
+    case embed = "Embed"
+    case fade = "Fade"
+    case login = "Login"
+    case modal = "Modal"
+    case popover = "Popover"
+    case sheet = "Sheet"
+    case show = "Show"
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = NSStoryboardSegue.Identifier(segue.rawValue)
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case embed(destination: AppKit.NSViewController)
+    case fade(destination: AppKit.NSViewController, segue: PrefsWindowController.SlowFadeSegue)
+    case login(destination: AppKit.NSViewController, segue: ExtraModule.LoginSegue)
+    case modal(destination: AppKit.NSViewController)
+    case popover(destination: AppKit.NSViewController)
+    case sheet(destination: AppKit.NSViewController)
+    case show(destination: AppKit.NSViewController)
+    case `private`(destination: AppKit.NSViewController, segue: RotateSegue)
+    case `public`(destination: AppKit.NSViewController, segue: ZoomSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier?.rawValue ?? "" {
+      case "Embed":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Embed' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .embed(destination: vc)
+      case "Fade":
+        guard let segue = segue as? PrefsWindowController.SlowFadeSegue else {
+          fatalError("Segue 'Fade' is not of the expected type PrefsWindowController.SlowFadeSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Fade' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .fade(destination: vc, segue: segue)
+      case "Login":
+        guard let segue = segue as? ExtraModule.LoginSegue else {
+          fatalError("Segue 'Login' is not of the expected type ExtraModule.LoginSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Login' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .login(destination: vc, segue: segue)
+      case "Modal":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Modal' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .modal(destination: vc)
+      case "Popover":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Popover' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .popover(destination: vc)
+      case "Sheet":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Sheet' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .sheet(destination: vc)
+      case "Show":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Show' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .show(destination: vc)
+      case "private":
+        guard let segue = segue as? RotateSegue else {
+          fatalError("Segue 'private' is not of the expected type RotateSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? ZoomSegue else {
+          fatalError("Segue 'public' is not of the expected type ZoomSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier?.rawValue ?? "")' in CustomTabViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
 internal enum StoryboardSegue {
   internal enum Message: String, SegueType {
     case embed = "Embed"

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-noDefinedModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-noDefinedModule.swift
@@ -14,6 +14,206 @@ import SwiftGen
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+internal extension DetailsViewController {
+  internal enum StoryboardSegue: String {
+    case embed = "Embed"
+    case fade = "Fade"
+    case login = "Login"
+    case modal = "Modal"
+    case popover = "Popover"
+    case sheet = "Sheet"
+    case show = "Show"
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = NSStoryboardSegue.Identifier(segue.rawValue)
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case embed(destination: AppKit.NSViewController)
+    case fade(destination: AppKit.NSViewController, segue: PrefsWindowController.SlowFadeSegue)
+    case login(destination: AppKit.NSViewController, segue: ExtraModule.LoginSegue)
+    case modal(destination: AppKit.NSViewController)
+    case popover(destination: AppKit.NSViewController)
+    case sheet(destination: AppKit.NSViewController)
+    case show(destination: AppKit.NSViewController)
+    case `private`(destination: AppKit.NSViewController, segue: RotateSegue)
+    case `public`(destination: AppKit.NSViewController, segue: SwiftGen.ZoomSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier?.rawValue ?? "" {
+      case "Embed":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Embed' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .embed(destination: vc)
+      case "Fade":
+        guard let segue = segue as? PrefsWindowController.SlowFadeSegue else {
+          fatalError("Segue 'Fade' is not of the expected type PrefsWindowController.SlowFadeSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Fade' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .fade(destination: vc, segue: segue)
+      case "Login":
+        guard let segue = segue as? ExtraModule.LoginSegue else {
+          fatalError("Segue 'Login' is not of the expected type ExtraModule.LoginSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Login' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .login(destination: vc, segue: segue)
+      case "Modal":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Modal' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .modal(destination: vc)
+      case "Popover":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Popover' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .popover(destination: vc)
+      case "Sheet":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Sheet' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .sheet(destination: vc)
+      case "Show":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Show' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .show(destination: vc)
+      case "private":
+        guard let segue = segue as? RotateSegue else {
+          fatalError("Segue 'private' is not of the expected type RotateSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.ZoomSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.ZoomSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier?.rawValue ?? "")' in DetailsViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension SwiftGen.CustomTabViewController {
+  internal enum StoryboardSegue: String {
+    case embed = "Embed"
+    case fade = "Fade"
+    case login = "Login"
+    case modal = "Modal"
+    case popover = "Popover"
+    case sheet = "Sheet"
+    case show = "Show"
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = NSStoryboardSegue.Identifier(segue.rawValue)
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case embed(destination: AppKit.NSViewController)
+    case fade(destination: AppKit.NSViewController, segue: PrefsWindowController.SlowFadeSegue)
+    case login(destination: AppKit.NSViewController, segue: ExtraModule.LoginSegue)
+    case modal(destination: AppKit.NSViewController)
+    case popover(destination: AppKit.NSViewController)
+    case sheet(destination: AppKit.NSViewController)
+    case show(destination: AppKit.NSViewController)
+    case `private`(destination: AppKit.NSViewController, segue: RotateSegue)
+    case `public`(destination: AppKit.NSViewController, segue: SwiftGen.ZoomSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier?.rawValue ?? "" {
+      case "Embed":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Embed' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .embed(destination: vc)
+      case "Fade":
+        guard let segue = segue as? PrefsWindowController.SlowFadeSegue else {
+          fatalError("Segue 'Fade' is not of the expected type PrefsWindowController.SlowFadeSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Fade' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .fade(destination: vc, segue: segue)
+      case "Login":
+        guard let segue = segue as? ExtraModule.LoginSegue else {
+          fatalError("Segue 'Login' is not of the expected type ExtraModule.LoginSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Login' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .login(destination: vc, segue: segue)
+      case "Modal":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Modal' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .modal(destination: vc)
+      case "Popover":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Popover' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .popover(destination: vc)
+      case "Sheet":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Sheet' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .sheet(destination: vc)
+      case "Show":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Show' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .show(destination: vc)
+      case "private":
+        guard let segue = segue as? RotateSegue else {
+          fatalError("Segue 'private' is not of the expected type RotateSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.ZoomSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.ZoomSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier?.rawValue ?? "")' in SwiftGen.CustomTabViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
 internal enum StoryboardSegue {
   internal enum Message: String, SegueType {
     case embed = "Embed"

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-publicAccess.swift
@@ -13,6 +13,206 @@ import PrefsWindowController
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+public extension SwiftGen.DetailsViewController {
+  public enum StoryboardSegue: String {
+    case embed = "Embed"
+    case fade = "Fade"
+    case login = "Login"
+    case modal = "Modal"
+    case popover = "Popover"
+    case sheet = "Sheet"
+    case show = "Show"
+    case `private`
+    case `public`
+  }
+
+  public func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = NSStoryboardSegue.Identifier(segue.rawValue)
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  public enum TypedStoryboardSegue {
+    case embed(destination: AppKit.NSViewController)
+    case fade(destination: AppKit.NSViewController, segue: PrefsWindowController.SlowFadeSegue)
+    case login(destination: AppKit.NSViewController, segue: ExtraModule.LoginSegue)
+    case modal(destination: AppKit.NSViewController)
+    case popover(destination: AppKit.NSViewController)
+    case sheet(destination: AppKit.NSViewController)
+    case show(destination: AppKit.NSViewController)
+    case `private`(destination: AppKit.NSViewController, segue: SwiftGen.RotateSegue)
+    case `public`(destination: AppKit.NSViewController, segue: SwiftGen.ZoomSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier?.rawValue ?? "" {
+      case "Embed":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Embed' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .embed(destination: vc)
+      case "Fade":
+        guard let segue = segue as? PrefsWindowController.SlowFadeSegue else {
+          fatalError("Segue 'Fade' is not of the expected type PrefsWindowController.SlowFadeSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Fade' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .fade(destination: vc, segue: segue)
+      case "Login":
+        guard let segue = segue as? ExtraModule.LoginSegue else {
+          fatalError("Segue 'Login' is not of the expected type ExtraModule.LoginSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Login' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .login(destination: vc, segue: segue)
+      case "Modal":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Modal' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .modal(destination: vc)
+      case "Popover":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Popover' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .popover(destination: vc)
+      case "Sheet":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Sheet' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .sheet(destination: vc)
+      case "Show":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Show' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .show(destination: vc)
+      case "private":
+        guard let segue = segue as? SwiftGen.RotateSegue else {
+          fatalError("Segue 'private' is not of the expected type SwiftGen.RotateSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.ZoomSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.ZoomSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier?.rawValue ?? "")' in SwiftGen.DetailsViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+public extension SwiftGen.CustomTabViewController {
+  public enum StoryboardSegue: String {
+    case embed = "Embed"
+    case fade = "Fade"
+    case login = "Login"
+    case modal = "Modal"
+    case popover = "Popover"
+    case sheet = "Sheet"
+    case show = "Show"
+    case `private`
+    case `public`
+  }
+
+  public func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = NSStoryboardSegue.Identifier(segue.rawValue)
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  public enum TypedStoryboardSegue {
+    case embed(destination: AppKit.NSViewController)
+    case fade(destination: AppKit.NSViewController, segue: PrefsWindowController.SlowFadeSegue)
+    case login(destination: AppKit.NSViewController, segue: ExtraModule.LoginSegue)
+    case modal(destination: AppKit.NSViewController)
+    case popover(destination: AppKit.NSViewController)
+    case sheet(destination: AppKit.NSViewController)
+    case show(destination: AppKit.NSViewController)
+    case `private`(destination: AppKit.NSViewController, segue: SwiftGen.RotateSegue)
+    case `public`(destination: AppKit.NSViewController, segue: SwiftGen.ZoomSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier?.rawValue ?? "" {
+      case "Embed":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Embed' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .embed(destination: vc)
+      case "Fade":
+        guard let segue = segue as? PrefsWindowController.SlowFadeSegue else {
+          fatalError("Segue 'Fade' is not of the expected type PrefsWindowController.SlowFadeSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Fade' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .fade(destination: vc, segue: segue)
+      case "Login":
+        guard let segue = segue as? ExtraModule.LoginSegue else {
+          fatalError("Segue 'Login' is not of the expected type ExtraModule.LoginSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Login' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .login(destination: vc, segue: segue)
+      case "Modal":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Modal' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .modal(destination: vc)
+      case "Popover":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Popover' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .popover(destination: vc)
+      case "Sheet":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Sheet' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .sheet(destination: vc)
+      case "Show":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Show' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .show(destination: vc)
+      case "private":
+        guard let segue = segue as? SwiftGen.RotateSegue else {
+          fatalError("Segue 'private' is not of the expected type SwiftGen.RotateSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.ZoomSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.ZoomSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier?.rawValue ?? "")' in SwiftGen.CustomTabViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
 public enum StoryboardSegue {
   public enum Message: String, SegueType {
     case embed = "Embed"

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-withExtraModule.swift
@@ -12,6 +12,206 @@ import PrefsWindowController
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+internal extension SwiftGen.DetailsViewController {
+  internal enum StoryboardSegue: String {
+    case embed = "Embed"
+    case fade = "Fade"
+    case login = "Login"
+    case modal = "Modal"
+    case popover = "Popover"
+    case sheet = "Sheet"
+    case show = "Show"
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = NSStoryboardSegue.Identifier(segue.rawValue)
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case embed(destination: AppKit.NSViewController)
+    case fade(destination: AppKit.NSViewController, segue: PrefsWindowController.SlowFadeSegue)
+    case login(destination: AppKit.NSViewController, segue: ExtraModule.LoginSegue)
+    case modal(destination: AppKit.NSViewController)
+    case popover(destination: AppKit.NSViewController)
+    case sheet(destination: AppKit.NSViewController)
+    case show(destination: AppKit.NSViewController)
+    case `private`(destination: AppKit.NSViewController, segue: SwiftGen.RotateSegue)
+    case `public`(destination: AppKit.NSViewController, segue: SwiftGen.ZoomSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier?.rawValue ?? "" {
+      case "Embed":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Embed' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .embed(destination: vc)
+      case "Fade":
+        guard let segue = segue as? PrefsWindowController.SlowFadeSegue else {
+          fatalError("Segue 'Fade' is not of the expected type PrefsWindowController.SlowFadeSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Fade' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .fade(destination: vc, segue: segue)
+      case "Login":
+        guard let segue = segue as? ExtraModule.LoginSegue else {
+          fatalError("Segue 'Login' is not of the expected type ExtraModule.LoginSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Login' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .login(destination: vc, segue: segue)
+      case "Modal":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Modal' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .modal(destination: vc)
+      case "Popover":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Popover' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .popover(destination: vc)
+      case "Sheet":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Sheet' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .sheet(destination: vc)
+      case "Show":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Show' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .show(destination: vc)
+      case "private":
+        guard let segue = segue as? SwiftGen.RotateSegue else {
+          fatalError("Segue 'private' is not of the expected type SwiftGen.RotateSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.ZoomSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.ZoomSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier?.rawValue ?? "")' in SwiftGen.DetailsViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension SwiftGen.CustomTabViewController {
+  internal enum StoryboardSegue: String {
+    case embed = "Embed"
+    case fade = "Fade"
+    case login = "Login"
+    case modal = "Modal"
+    case popover = "Popover"
+    case sheet = "Sheet"
+    case show = "Show"
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = NSStoryboardSegue.Identifier(segue.rawValue)
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case embed(destination: AppKit.NSViewController)
+    case fade(destination: AppKit.NSViewController, segue: PrefsWindowController.SlowFadeSegue)
+    case login(destination: AppKit.NSViewController, segue: ExtraModule.LoginSegue)
+    case modal(destination: AppKit.NSViewController)
+    case popover(destination: AppKit.NSViewController)
+    case sheet(destination: AppKit.NSViewController)
+    case show(destination: AppKit.NSViewController)
+    case `private`(destination: AppKit.NSViewController, segue: SwiftGen.RotateSegue)
+    case `public`(destination: AppKit.NSViewController, segue: SwiftGen.ZoomSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier?.rawValue ?? "" {
+      case "Embed":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Embed' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .embed(destination: vc)
+      case "Fade":
+        guard let segue = segue as? PrefsWindowController.SlowFadeSegue else {
+          fatalError("Segue 'Fade' is not of the expected type PrefsWindowController.SlowFadeSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Fade' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .fade(destination: vc, segue: segue)
+      case "Login":
+        guard let segue = segue as? ExtraModule.LoginSegue else {
+          fatalError("Segue 'Login' is not of the expected type ExtraModule.LoginSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Login' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .login(destination: vc, segue: segue)
+      case "Modal":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Modal' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .modal(destination: vc)
+      case "Popover":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Popover' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .popover(destination: vc)
+      case "Sheet":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Sheet' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .sheet(destination: vc)
+      case "Show":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Show' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .show(destination: vc)
+      case "private":
+        guard let segue = segue as? SwiftGen.RotateSegue else {
+          fatalError("Segue 'private' is not of the expected type SwiftGen.RotateSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.ZoomSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.ZoomSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier?.rawValue ?? "")' in SwiftGen.CustomTabViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
 internal enum StoryboardSegue {
   internal enum Message: String, SegueType {
     case embed = "Embed"

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all.swift
@@ -13,6 +13,206 @@ import PrefsWindowController
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+internal extension SwiftGen.DetailsViewController {
+  internal enum StoryboardSegue: String {
+    case embed = "Embed"
+    case fade = "Fade"
+    case login = "Login"
+    case modal = "Modal"
+    case popover = "Popover"
+    case sheet = "Sheet"
+    case show = "Show"
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = NSStoryboardSegue.Identifier(segue.rawValue)
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case embed(destination: AppKit.NSViewController)
+    case fade(destination: AppKit.NSViewController, segue: PrefsWindowController.SlowFadeSegue)
+    case login(destination: AppKit.NSViewController, segue: ExtraModule.LoginSegue)
+    case modal(destination: AppKit.NSViewController)
+    case popover(destination: AppKit.NSViewController)
+    case sheet(destination: AppKit.NSViewController)
+    case show(destination: AppKit.NSViewController)
+    case `private`(destination: AppKit.NSViewController, segue: SwiftGen.RotateSegue)
+    case `public`(destination: AppKit.NSViewController, segue: SwiftGen.ZoomSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier?.rawValue ?? "" {
+      case "Embed":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Embed' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .embed(destination: vc)
+      case "Fade":
+        guard let segue = segue as? PrefsWindowController.SlowFadeSegue else {
+          fatalError("Segue 'Fade' is not of the expected type PrefsWindowController.SlowFadeSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Fade' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .fade(destination: vc, segue: segue)
+      case "Login":
+        guard let segue = segue as? ExtraModule.LoginSegue else {
+          fatalError("Segue 'Login' is not of the expected type ExtraModule.LoginSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Login' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .login(destination: vc, segue: segue)
+      case "Modal":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Modal' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .modal(destination: vc)
+      case "Popover":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Popover' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .popover(destination: vc)
+      case "Sheet":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Sheet' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .sheet(destination: vc)
+      case "Show":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Show' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .show(destination: vc)
+      case "private":
+        guard let segue = segue as? SwiftGen.RotateSegue else {
+          fatalError("Segue 'private' is not of the expected type SwiftGen.RotateSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.ZoomSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.ZoomSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier?.rawValue ?? "")' in SwiftGen.DetailsViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension SwiftGen.CustomTabViewController {
+  internal enum StoryboardSegue: String {
+    case embed = "Embed"
+    case fade = "Fade"
+    case login = "Login"
+    case modal = "Modal"
+    case popover = "Popover"
+    case sheet = "Sheet"
+    case show = "Show"
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    let identifier = NSStoryboardSegue.Identifier(segue.rawValue)
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case embed(destination: AppKit.NSViewController)
+    case fade(destination: AppKit.NSViewController, segue: PrefsWindowController.SlowFadeSegue)
+    case login(destination: AppKit.NSViewController, segue: ExtraModule.LoginSegue)
+    case modal(destination: AppKit.NSViewController)
+    case popover(destination: AppKit.NSViewController)
+    case sheet(destination: AppKit.NSViewController)
+    case show(destination: AppKit.NSViewController)
+    case `private`(destination: AppKit.NSViewController, segue: SwiftGen.RotateSegue)
+    case `public`(destination: AppKit.NSViewController, segue: SwiftGen.ZoomSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier?.rawValue ?? "" {
+      case "Embed":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Embed' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .embed(destination: vc)
+      case "Fade":
+        guard let segue = segue as? PrefsWindowController.SlowFadeSegue else {
+          fatalError("Segue 'Fade' is not of the expected type PrefsWindowController.SlowFadeSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Fade' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .fade(destination: vc, segue: segue)
+      case "Login":
+        guard let segue = segue as? ExtraModule.LoginSegue else {
+          fatalError("Segue 'Login' is not of the expected type ExtraModule.LoginSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Login' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .login(destination: vc, segue: segue)
+      case "Modal":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Modal' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .modal(destination: vc)
+      case "Popover":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Popover' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .popover(destination: vc)
+      case "Sheet":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Sheet' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .sheet(destination: vc)
+      case "Show":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Show' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .show(destination: vc)
+      case "private":
+        guard let segue = segue as? SwiftGen.RotateSegue else {
+          fatalError("Segue 'private' is not of the expected type SwiftGen.RotateSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.ZoomSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.ZoomSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier?.rawValue ?? "")' in SwiftGen.CustomTabViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
 internal enum StoryboardSegue {
   internal enum Message: String, SegueType {
     case embed = "Embed"

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-customName.swift
@@ -13,6 +13,204 @@ import PrefsWindowController
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+internal extension SwiftGen.DetailsViewController {
+  internal enum XCTStoryboardCustom: String {
+    case embed = "Embed"
+    case fade = "Fade"
+    case login = "Login"
+    case modal = "Modal"
+    case popover = "Popover"
+    case sheet = "Sheet"
+    case show = "Show"
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: XCTStoryboardCustom, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedXCTStoryboardCustom {
+    case embed(destination: AppKit.NSViewController)
+    case fade(destination: AppKit.NSViewController, segue: PrefsWindowController.SlowFadeSegue)
+    case login(destination: AppKit.NSViewController, segue: ExtraModule.LoginSegue)
+    case modal(destination: AppKit.NSViewController)
+    case popover(destination: AppKit.NSViewController)
+    case sheet(destination: AppKit.NSViewController)
+    case show(destination: AppKit.NSViewController)
+    case `private`(destination: AppKit.NSViewController, segue: SwiftGen.RotateSegue)
+    case `public`(destination: AppKit.NSViewController, segue: SwiftGen.ZoomSegue)
+    case customUnnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "Embed":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Embed' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .embed(destination: vc)
+      case "Fade":
+        guard let segue = segue as? PrefsWindowController.SlowFadeSegue else {
+          fatalError("Segue 'Fade' is not of the expected type PrefsWindowController.SlowFadeSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Fade' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .fade(destination: vc, segue: segue)
+      case "Login":
+        guard let segue = segue as? ExtraModule.LoginSegue else {
+          fatalError("Segue 'Login' is not of the expected type ExtraModule.LoginSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Login' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .login(destination: vc, segue: segue)
+      case "Modal":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Modal' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .modal(destination: vc)
+      case "Popover":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Popover' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .popover(destination: vc)
+      case "Sheet":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Sheet' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .sheet(destination: vc)
+      case "Show":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Show' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .show(destination: vc)
+      case "private":
+        guard let segue = segue as? SwiftGen.RotateSegue else {
+          fatalError("Segue 'private' is not of the expected type SwiftGen.RotateSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.ZoomSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.ZoomSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .customUnnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SwiftGen.DetailsViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension SwiftGen.CustomTabViewController {
+  internal enum XCTStoryboardCustom: String {
+    case embed = "Embed"
+    case fade = "Fade"
+    case login = "Login"
+    case modal = "Modal"
+    case popover = "Popover"
+    case sheet = "Sheet"
+    case show = "Show"
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: XCTStoryboardCustom, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedXCTStoryboardCustom {
+    case embed(destination: AppKit.NSViewController)
+    case fade(destination: AppKit.NSViewController, segue: PrefsWindowController.SlowFadeSegue)
+    case login(destination: AppKit.NSViewController, segue: ExtraModule.LoginSegue)
+    case modal(destination: AppKit.NSViewController)
+    case popover(destination: AppKit.NSViewController)
+    case sheet(destination: AppKit.NSViewController)
+    case show(destination: AppKit.NSViewController)
+    case `private`(destination: AppKit.NSViewController, segue: SwiftGen.RotateSegue)
+    case `public`(destination: AppKit.NSViewController, segue: SwiftGen.ZoomSegue)
+    case customUnnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "Embed":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Embed' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .embed(destination: vc)
+      case "Fade":
+        guard let segue = segue as? PrefsWindowController.SlowFadeSegue else {
+          fatalError("Segue 'Fade' is not of the expected type PrefsWindowController.SlowFadeSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Fade' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .fade(destination: vc, segue: segue)
+      case "Login":
+        guard let segue = segue as? ExtraModule.LoginSegue else {
+          fatalError("Segue 'Login' is not of the expected type ExtraModule.LoginSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Login' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .login(destination: vc, segue: segue)
+      case "Modal":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Modal' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .modal(destination: vc)
+      case "Popover":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Popover' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .popover(destination: vc)
+      case "Sheet":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Sheet' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .sheet(destination: vc)
+      case "Show":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Show' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .show(destination: vc)
+      case "private":
+        guard let segue = segue as? SwiftGen.RotateSegue else {
+          fatalError("Segue 'private' is not of the expected type SwiftGen.RotateSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.ZoomSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.ZoomSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .customUnnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SwiftGen.CustomTabViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
 internal enum XCTStoryboardCustom {
   internal enum Message: String, SegueType {
     case embed = "Embed"

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-ignoreTargetModule-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-ignoreTargetModule-withExtraModule.swift
@@ -12,6 +12,204 @@ import PrefsWindowController
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+internal extension DetailsViewController {
+  internal enum StoryboardSegue: String {
+    case embed = "Embed"
+    case fade = "Fade"
+    case login = "Login"
+    case modal = "Modal"
+    case popover = "Popover"
+    case sheet = "Sheet"
+    case show = "Show"
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case embed(destination: AppKit.NSViewController)
+    case fade(destination: AppKit.NSViewController, segue: PrefsWindowController.SlowFadeSegue)
+    case login(destination: AppKit.NSViewController, segue: LoginSegue)
+    case modal(destination: AppKit.NSViewController)
+    case popover(destination: AppKit.NSViewController)
+    case sheet(destination: AppKit.NSViewController)
+    case show(destination: AppKit.NSViewController)
+    case `private`(destination: AppKit.NSViewController, segue: RotateSegue)
+    case `public`(destination: AppKit.NSViewController, segue: ZoomSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "Embed":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Embed' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .embed(destination: vc)
+      case "Fade":
+        guard let segue = segue as? PrefsWindowController.SlowFadeSegue else {
+          fatalError("Segue 'Fade' is not of the expected type PrefsWindowController.SlowFadeSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Fade' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .fade(destination: vc, segue: segue)
+      case "Login":
+        guard let segue = segue as? LoginSegue else {
+          fatalError("Segue 'Login' is not of the expected type LoginSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Login' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .login(destination: vc, segue: segue)
+      case "Modal":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Modal' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .modal(destination: vc)
+      case "Popover":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Popover' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .popover(destination: vc)
+      case "Sheet":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Sheet' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .sheet(destination: vc)
+      case "Show":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Show' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .show(destination: vc)
+      case "private":
+        guard let segue = segue as? RotateSegue else {
+          fatalError("Segue 'private' is not of the expected type RotateSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? ZoomSegue else {
+          fatalError("Segue 'public' is not of the expected type ZoomSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in DetailsViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension CustomTabViewController {
+  internal enum StoryboardSegue: String {
+    case embed = "Embed"
+    case fade = "Fade"
+    case login = "Login"
+    case modal = "Modal"
+    case popover = "Popover"
+    case sheet = "Sheet"
+    case show = "Show"
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case embed(destination: AppKit.NSViewController)
+    case fade(destination: AppKit.NSViewController, segue: PrefsWindowController.SlowFadeSegue)
+    case login(destination: AppKit.NSViewController, segue: LoginSegue)
+    case modal(destination: AppKit.NSViewController)
+    case popover(destination: AppKit.NSViewController)
+    case sheet(destination: AppKit.NSViewController)
+    case show(destination: AppKit.NSViewController)
+    case `private`(destination: AppKit.NSViewController, segue: RotateSegue)
+    case `public`(destination: AppKit.NSViewController, segue: ZoomSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "Embed":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Embed' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .embed(destination: vc)
+      case "Fade":
+        guard let segue = segue as? PrefsWindowController.SlowFadeSegue else {
+          fatalError("Segue 'Fade' is not of the expected type PrefsWindowController.SlowFadeSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Fade' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .fade(destination: vc, segue: segue)
+      case "Login":
+        guard let segue = segue as? LoginSegue else {
+          fatalError("Segue 'Login' is not of the expected type LoginSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Login' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .login(destination: vc, segue: segue)
+      case "Modal":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Modal' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .modal(destination: vc)
+      case "Popover":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Popover' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .popover(destination: vc)
+      case "Sheet":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Sheet' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .sheet(destination: vc)
+      case "Show":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Show' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .show(destination: vc)
+      case "private":
+        guard let segue = segue as? RotateSegue else {
+          fatalError("Segue 'private' is not of the expected type RotateSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? ZoomSegue else {
+          fatalError("Segue 'public' is not of the expected type ZoomSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in CustomTabViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
 internal enum StoryboardSegue {
   internal enum Message: String, SegueType {
     case embed = "Embed"

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-ignoreTargetModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-ignoreTargetModule.swift
@@ -13,6 +13,204 @@ import PrefsWindowController
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+internal extension DetailsViewController {
+  internal enum StoryboardSegue: String {
+    case embed = "Embed"
+    case fade = "Fade"
+    case login = "Login"
+    case modal = "Modal"
+    case popover = "Popover"
+    case sheet = "Sheet"
+    case show = "Show"
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case embed(destination: AppKit.NSViewController)
+    case fade(destination: AppKit.NSViewController, segue: PrefsWindowController.SlowFadeSegue)
+    case login(destination: AppKit.NSViewController, segue: ExtraModule.LoginSegue)
+    case modal(destination: AppKit.NSViewController)
+    case popover(destination: AppKit.NSViewController)
+    case sheet(destination: AppKit.NSViewController)
+    case show(destination: AppKit.NSViewController)
+    case `private`(destination: AppKit.NSViewController, segue: RotateSegue)
+    case `public`(destination: AppKit.NSViewController, segue: ZoomSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "Embed":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Embed' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .embed(destination: vc)
+      case "Fade":
+        guard let segue = segue as? PrefsWindowController.SlowFadeSegue else {
+          fatalError("Segue 'Fade' is not of the expected type PrefsWindowController.SlowFadeSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Fade' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .fade(destination: vc, segue: segue)
+      case "Login":
+        guard let segue = segue as? ExtraModule.LoginSegue else {
+          fatalError("Segue 'Login' is not of the expected type ExtraModule.LoginSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Login' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .login(destination: vc, segue: segue)
+      case "Modal":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Modal' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .modal(destination: vc)
+      case "Popover":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Popover' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .popover(destination: vc)
+      case "Sheet":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Sheet' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .sheet(destination: vc)
+      case "Show":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Show' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .show(destination: vc)
+      case "private":
+        guard let segue = segue as? RotateSegue else {
+          fatalError("Segue 'private' is not of the expected type RotateSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? ZoomSegue else {
+          fatalError("Segue 'public' is not of the expected type ZoomSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in DetailsViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension CustomTabViewController {
+  internal enum StoryboardSegue: String {
+    case embed = "Embed"
+    case fade = "Fade"
+    case login = "Login"
+    case modal = "Modal"
+    case popover = "Popover"
+    case sheet = "Sheet"
+    case show = "Show"
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case embed(destination: AppKit.NSViewController)
+    case fade(destination: AppKit.NSViewController, segue: PrefsWindowController.SlowFadeSegue)
+    case login(destination: AppKit.NSViewController, segue: ExtraModule.LoginSegue)
+    case modal(destination: AppKit.NSViewController)
+    case popover(destination: AppKit.NSViewController)
+    case sheet(destination: AppKit.NSViewController)
+    case show(destination: AppKit.NSViewController)
+    case `private`(destination: AppKit.NSViewController, segue: RotateSegue)
+    case `public`(destination: AppKit.NSViewController, segue: ZoomSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "Embed":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Embed' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .embed(destination: vc)
+      case "Fade":
+        guard let segue = segue as? PrefsWindowController.SlowFadeSegue else {
+          fatalError("Segue 'Fade' is not of the expected type PrefsWindowController.SlowFadeSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Fade' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .fade(destination: vc, segue: segue)
+      case "Login":
+        guard let segue = segue as? ExtraModule.LoginSegue else {
+          fatalError("Segue 'Login' is not of the expected type ExtraModule.LoginSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Login' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .login(destination: vc, segue: segue)
+      case "Modal":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Modal' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .modal(destination: vc)
+      case "Popover":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Popover' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .popover(destination: vc)
+      case "Sheet":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Sheet' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .sheet(destination: vc)
+      case "Show":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Show' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .show(destination: vc)
+      case "private":
+        guard let segue = segue as? RotateSegue else {
+          fatalError("Segue 'private' is not of the expected type RotateSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? ZoomSegue else {
+          fatalError("Segue 'public' is not of the expected type ZoomSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in CustomTabViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
 internal enum StoryboardSegue {
   internal enum Message: String, SegueType {
     case embed = "Embed"

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-noDefinedModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-noDefinedModule.swift
@@ -14,6 +14,204 @@ import SwiftGen
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+internal extension DetailsViewController {
+  internal enum StoryboardSegue: String {
+    case embed = "Embed"
+    case fade = "Fade"
+    case login = "Login"
+    case modal = "Modal"
+    case popover = "Popover"
+    case sheet = "Sheet"
+    case show = "Show"
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case embed(destination: AppKit.NSViewController)
+    case fade(destination: AppKit.NSViewController, segue: PrefsWindowController.SlowFadeSegue)
+    case login(destination: AppKit.NSViewController, segue: ExtraModule.LoginSegue)
+    case modal(destination: AppKit.NSViewController)
+    case popover(destination: AppKit.NSViewController)
+    case sheet(destination: AppKit.NSViewController)
+    case show(destination: AppKit.NSViewController)
+    case `private`(destination: AppKit.NSViewController, segue: RotateSegue)
+    case `public`(destination: AppKit.NSViewController, segue: SwiftGen.ZoomSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "Embed":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Embed' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .embed(destination: vc)
+      case "Fade":
+        guard let segue = segue as? PrefsWindowController.SlowFadeSegue else {
+          fatalError("Segue 'Fade' is not of the expected type PrefsWindowController.SlowFadeSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Fade' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .fade(destination: vc, segue: segue)
+      case "Login":
+        guard let segue = segue as? ExtraModule.LoginSegue else {
+          fatalError("Segue 'Login' is not of the expected type ExtraModule.LoginSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Login' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .login(destination: vc, segue: segue)
+      case "Modal":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Modal' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .modal(destination: vc)
+      case "Popover":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Popover' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .popover(destination: vc)
+      case "Sheet":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Sheet' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .sheet(destination: vc)
+      case "Show":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Show' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .show(destination: vc)
+      case "private":
+        guard let segue = segue as? RotateSegue else {
+          fatalError("Segue 'private' is not of the expected type RotateSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.ZoomSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.ZoomSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in DetailsViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension SwiftGen.CustomTabViewController {
+  internal enum StoryboardSegue: String {
+    case embed = "Embed"
+    case fade = "Fade"
+    case login = "Login"
+    case modal = "Modal"
+    case popover = "Popover"
+    case sheet = "Sheet"
+    case show = "Show"
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case embed(destination: AppKit.NSViewController)
+    case fade(destination: AppKit.NSViewController, segue: PrefsWindowController.SlowFadeSegue)
+    case login(destination: AppKit.NSViewController, segue: ExtraModule.LoginSegue)
+    case modal(destination: AppKit.NSViewController)
+    case popover(destination: AppKit.NSViewController)
+    case sheet(destination: AppKit.NSViewController)
+    case show(destination: AppKit.NSViewController)
+    case `private`(destination: AppKit.NSViewController, segue: RotateSegue)
+    case `public`(destination: AppKit.NSViewController, segue: SwiftGen.ZoomSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "Embed":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Embed' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .embed(destination: vc)
+      case "Fade":
+        guard let segue = segue as? PrefsWindowController.SlowFadeSegue else {
+          fatalError("Segue 'Fade' is not of the expected type PrefsWindowController.SlowFadeSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Fade' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .fade(destination: vc, segue: segue)
+      case "Login":
+        guard let segue = segue as? ExtraModule.LoginSegue else {
+          fatalError("Segue 'Login' is not of the expected type ExtraModule.LoginSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Login' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .login(destination: vc, segue: segue)
+      case "Modal":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Modal' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .modal(destination: vc)
+      case "Popover":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Popover' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .popover(destination: vc)
+      case "Sheet":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Sheet' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .sheet(destination: vc)
+      case "Show":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Show' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .show(destination: vc)
+      case "private":
+        guard let segue = segue as? RotateSegue else {
+          fatalError("Segue 'private' is not of the expected type RotateSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.ZoomSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.ZoomSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SwiftGen.CustomTabViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
 internal enum StoryboardSegue {
   internal enum Message: String, SegueType {
     case embed = "Embed"

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-publicAccess.swift
@@ -13,6 +13,204 @@ import PrefsWindowController
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+public extension SwiftGen.DetailsViewController {
+  public enum StoryboardSegue: String {
+    case embed = "Embed"
+    case fade = "Fade"
+    case login = "Login"
+    case modal = "Modal"
+    case popover = "Popover"
+    case sheet = "Sheet"
+    case show = "Show"
+    case `private`
+    case `public`
+  }
+
+  public func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  public enum TypedStoryboardSegue {
+    case embed(destination: AppKit.NSViewController)
+    case fade(destination: AppKit.NSViewController, segue: PrefsWindowController.SlowFadeSegue)
+    case login(destination: AppKit.NSViewController, segue: ExtraModule.LoginSegue)
+    case modal(destination: AppKit.NSViewController)
+    case popover(destination: AppKit.NSViewController)
+    case sheet(destination: AppKit.NSViewController)
+    case show(destination: AppKit.NSViewController)
+    case `private`(destination: AppKit.NSViewController, segue: SwiftGen.RotateSegue)
+    case `public`(destination: AppKit.NSViewController, segue: SwiftGen.ZoomSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "Embed":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Embed' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .embed(destination: vc)
+      case "Fade":
+        guard let segue = segue as? PrefsWindowController.SlowFadeSegue else {
+          fatalError("Segue 'Fade' is not of the expected type PrefsWindowController.SlowFadeSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Fade' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .fade(destination: vc, segue: segue)
+      case "Login":
+        guard let segue = segue as? ExtraModule.LoginSegue else {
+          fatalError("Segue 'Login' is not of the expected type ExtraModule.LoginSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Login' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .login(destination: vc, segue: segue)
+      case "Modal":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Modal' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .modal(destination: vc)
+      case "Popover":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Popover' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .popover(destination: vc)
+      case "Sheet":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Sheet' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .sheet(destination: vc)
+      case "Show":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Show' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .show(destination: vc)
+      case "private":
+        guard let segue = segue as? SwiftGen.RotateSegue else {
+          fatalError("Segue 'private' is not of the expected type SwiftGen.RotateSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.ZoomSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.ZoomSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SwiftGen.DetailsViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+public extension SwiftGen.CustomTabViewController {
+  public enum StoryboardSegue: String {
+    case embed = "Embed"
+    case fade = "Fade"
+    case login = "Login"
+    case modal = "Modal"
+    case popover = "Popover"
+    case sheet = "Sheet"
+    case show = "Show"
+    case `private`
+    case `public`
+  }
+
+  public func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  public enum TypedStoryboardSegue {
+    case embed(destination: AppKit.NSViewController)
+    case fade(destination: AppKit.NSViewController, segue: PrefsWindowController.SlowFadeSegue)
+    case login(destination: AppKit.NSViewController, segue: ExtraModule.LoginSegue)
+    case modal(destination: AppKit.NSViewController)
+    case popover(destination: AppKit.NSViewController)
+    case sheet(destination: AppKit.NSViewController)
+    case show(destination: AppKit.NSViewController)
+    case `private`(destination: AppKit.NSViewController, segue: SwiftGen.RotateSegue)
+    case `public`(destination: AppKit.NSViewController, segue: SwiftGen.ZoomSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "Embed":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Embed' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .embed(destination: vc)
+      case "Fade":
+        guard let segue = segue as? PrefsWindowController.SlowFadeSegue else {
+          fatalError("Segue 'Fade' is not of the expected type PrefsWindowController.SlowFadeSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Fade' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .fade(destination: vc, segue: segue)
+      case "Login":
+        guard let segue = segue as? ExtraModule.LoginSegue else {
+          fatalError("Segue 'Login' is not of the expected type ExtraModule.LoginSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Login' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .login(destination: vc, segue: segue)
+      case "Modal":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Modal' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .modal(destination: vc)
+      case "Popover":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Popover' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .popover(destination: vc)
+      case "Sheet":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Sheet' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .sheet(destination: vc)
+      case "Show":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Show' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .show(destination: vc)
+      case "private":
+        guard let segue = segue as? SwiftGen.RotateSegue else {
+          fatalError("Segue 'private' is not of the expected type SwiftGen.RotateSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.ZoomSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.ZoomSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SwiftGen.CustomTabViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
 public enum StoryboardSegue {
   public enum Message: String, SegueType {
     case embed = "Embed"

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-withExtraModule.swift
@@ -12,6 +12,204 @@ import PrefsWindowController
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+internal extension SwiftGen.DetailsViewController {
+  internal enum StoryboardSegue: String {
+    case embed = "Embed"
+    case fade = "Fade"
+    case login = "Login"
+    case modal = "Modal"
+    case popover = "Popover"
+    case sheet = "Sheet"
+    case show = "Show"
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case embed(destination: AppKit.NSViewController)
+    case fade(destination: AppKit.NSViewController, segue: PrefsWindowController.SlowFadeSegue)
+    case login(destination: AppKit.NSViewController, segue: ExtraModule.LoginSegue)
+    case modal(destination: AppKit.NSViewController)
+    case popover(destination: AppKit.NSViewController)
+    case sheet(destination: AppKit.NSViewController)
+    case show(destination: AppKit.NSViewController)
+    case `private`(destination: AppKit.NSViewController, segue: SwiftGen.RotateSegue)
+    case `public`(destination: AppKit.NSViewController, segue: SwiftGen.ZoomSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "Embed":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Embed' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .embed(destination: vc)
+      case "Fade":
+        guard let segue = segue as? PrefsWindowController.SlowFadeSegue else {
+          fatalError("Segue 'Fade' is not of the expected type PrefsWindowController.SlowFadeSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Fade' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .fade(destination: vc, segue: segue)
+      case "Login":
+        guard let segue = segue as? ExtraModule.LoginSegue else {
+          fatalError("Segue 'Login' is not of the expected type ExtraModule.LoginSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Login' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .login(destination: vc, segue: segue)
+      case "Modal":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Modal' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .modal(destination: vc)
+      case "Popover":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Popover' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .popover(destination: vc)
+      case "Sheet":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Sheet' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .sheet(destination: vc)
+      case "Show":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Show' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .show(destination: vc)
+      case "private":
+        guard let segue = segue as? SwiftGen.RotateSegue else {
+          fatalError("Segue 'private' is not of the expected type SwiftGen.RotateSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.ZoomSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.ZoomSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SwiftGen.DetailsViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension SwiftGen.CustomTabViewController {
+  internal enum StoryboardSegue: String {
+    case embed = "Embed"
+    case fade = "Fade"
+    case login = "Login"
+    case modal = "Modal"
+    case popover = "Popover"
+    case sheet = "Sheet"
+    case show = "Show"
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case embed(destination: AppKit.NSViewController)
+    case fade(destination: AppKit.NSViewController, segue: PrefsWindowController.SlowFadeSegue)
+    case login(destination: AppKit.NSViewController, segue: ExtraModule.LoginSegue)
+    case modal(destination: AppKit.NSViewController)
+    case popover(destination: AppKit.NSViewController)
+    case sheet(destination: AppKit.NSViewController)
+    case show(destination: AppKit.NSViewController)
+    case `private`(destination: AppKit.NSViewController, segue: SwiftGen.RotateSegue)
+    case `public`(destination: AppKit.NSViewController, segue: SwiftGen.ZoomSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "Embed":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Embed' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .embed(destination: vc)
+      case "Fade":
+        guard let segue = segue as? PrefsWindowController.SlowFadeSegue else {
+          fatalError("Segue 'Fade' is not of the expected type PrefsWindowController.SlowFadeSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Fade' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .fade(destination: vc, segue: segue)
+      case "Login":
+        guard let segue = segue as? ExtraModule.LoginSegue else {
+          fatalError("Segue 'Login' is not of the expected type ExtraModule.LoginSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Login' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .login(destination: vc, segue: segue)
+      case "Modal":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Modal' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .modal(destination: vc)
+      case "Popover":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Popover' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .popover(destination: vc)
+      case "Sheet":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Sheet' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .sheet(destination: vc)
+      case "Show":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Show' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .show(destination: vc)
+      case "private":
+        guard let segue = segue as? SwiftGen.RotateSegue else {
+          fatalError("Segue 'private' is not of the expected type SwiftGen.RotateSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.ZoomSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.ZoomSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SwiftGen.CustomTabViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
 internal enum StoryboardSegue {
   internal enum Message: String, SegueType {
     case embed = "Embed"

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all.swift
@@ -13,6 +13,204 @@ import PrefsWindowController
 // MARK: - Storyboard Segues
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+internal extension SwiftGen.DetailsViewController {
+  internal enum StoryboardSegue: String {
+    case embed = "Embed"
+    case fade = "Fade"
+    case login = "Login"
+    case modal = "Modal"
+    case popover = "Popover"
+    case sheet = "Sheet"
+    case show = "Show"
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case embed(destination: AppKit.NSViewController)
+    case fade(destination: AppKit.NSViewController, segue: PrefsWindowController.SlowFadeSegue)
+    case login(destination: AppKit.NSViewController, segue: ExtraModule.LoginSegue)
+    case modal(destination: AppKit.NSViewController)
+    case popover(destination: AppKit.NSViewController)
+    case sheet(destination: AppKit.NSViewController)
+    case show(destination: AppKit.NSViewController)
+    case `private`(destination: AppKit.NSViewController, segue: SwiftGen.RotateSegue)
+    case `public`(destination: AppKit.NSViewController, segue: SwiftGen.ZoomSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "Embed":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Embed' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .embed(destination: vc)
+      case "Fade":
+        guard let segue = segue as? PrefsWindowController.SlowFadeSegue else {
+          fatalError("Segue 'Fade' is not of the expected type PrefsWindowController.SlowFadeSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Fade' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .fade(destination: vc, segue: segue)
+      case "Login":
+        guard let segue = segue as? ExtraModule.LoginSegue else {
+          fatalError("Segue 'Login' is not of the expected type ExtraModule.LoginSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Login' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .login(destination: vc, segue: segue)
+      case "Modal":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Modal' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .modal(destination: vc)
+      case "Popover":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Popover' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .popover(destination: vc)
+      case "Sheet":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Sheet' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .sheet(destination: vc)
+      case "Show":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Show' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .show(destination: vc)
+      case "private":
+        guard let segue = segue as? SwiftGen.RotateSegue else {
+          fatalError("Segue 'private' is not of the expected type SwiftGen.RotateSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.ZoomSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.ZoomSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SwiftGen.DetailsViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
+internal extension SwiftGen.CustomTabViewController {
+  internal enum StoryboardSegue: String {
+    case embed = "Embed"
+    case fade = "Fade"
+    case login = "Login"
+    case modal = "Modal"
+    case popover = "Popover"
+    case sheet = "Sheet"
+    case show = "Show"
+    case `private`
+    case `public`
+  }
+
+  internal func perform(segue: StoryboardSegue, sender: Any? = nil) {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+
+  internal enum TypedStoryboardSegue {
+    case embed(destination: AppKit.NSViewController)
+    case fade(destination: AppKit.NSViewController, segue: PrefsWindowController.SlowFadeSegue)
+    case login(destination: AppKit.NSViewController, segue: ExtraModule.LoginSegue)
+    case modal(destination: AppKit.NSViewController)
+    case popover(destination: AppKit.NSViewController)
+    case sheet(destination: AppKit.NSViewController)
+    case show(destination: AppKit.NSViewController)
+    case `private`(destination: AppKit.NSViewController, segue: SwiftGen.RotateSegue)
+    case `public`(destination: AppKit.NSViewController, segue: SwiftGen.ZoomSegue)
+    case unnamedSegue
+
+    // swiftlint:disable cyclomatic_complexity
+    init(segue: StoryboardSegue) {
+      switch segue.identifier ?? "" {
+      case "Embed":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Embed' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .embed(destination: vc)
+      case "Fade":
+        guard let segue = segue as? PrefsWindowController.SlowFadeSegue else {
+          fatalError("Segue 'Fade' is not of the expected type PrefsWindowController.SlowFadeSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Fade' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .fade(destination: vc, segue: segue)
+      case "Login":
+        guard let segue = segue as? ExtraModule.LoginSegue else {
+          fatalError("Segue 'Login' is not of the expected type ExtraModule.LoginSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Login' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .login(destination: vc, segue: segue)
+      case "Modal":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Modal' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .modal(destination: vc)
+      case "Popover":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Popover' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .popover(destination: vc)
+      case "Sheet":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Sheet' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .sheet(destination: vc)
+      case "Show":
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'Show' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .show(destination: vc)
+      case "private":
+        guard let segue = segue as? SwiftGen.RotateSegue else {
+          fatalError("Segue 'private' is not of the expected type SwiftGen.RotateSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'private' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`private`(destination: vc, segue: segue)
+      case "public":
+        guard let segue = segue as? SwiftGen.ZoomSegue else {
+          fatalError("Segue 'public' is not of the expected type SwiftGen.ZoomSegue.")
+        }
+        guard let vc = segue.destinationController as? AppKit.NSViewController else {
+          fatalError("Destination of segue 'public' is not of the expected type AppKit.NSViewController.")
+        }
+        self = .`public`(destination: vc, segue: segue)
+      case "":
+        self = .unnamedSegue
+      default:
+        fatalError("Unrecognized segue '\(segue.identifier ?? "")' in SwiftGen.CustomTabViewController")
+      }
+    }
+    // swiftlint:enable cyclomatic_complexity
+  }
+}
+
 internal enum StoryboardSegue {
   internal enum Message: String, SegueType {
     case embed = "Embed"

--- a/Sources/TestUtils/Fixtures/Resources/IB-iOS/AdditionalImport.storyboard
+++ b/Sources/TestUtils/Fixtures/Resources/IB-iOS/AdditionalImport.storyboard
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="sCq-1b-U1T">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="sCq-1b-U1T">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -55,7 +55,7 @@
         <!--Text View Controller-->
         <scene sceneID="7Iv-Wo-KlP">
             <objects>
-                <viewController storyboardIdentifier="public" id="se3-pM-ewQ" customClass="SLKTextViewController" customModule="SlackTextViewController" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="internal" id="se3-pM-ewQ" customClass="SLKTextViewController" customModule="SlackTextViewController" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="bZe-rr-B5m"/>
                         <viewControllerLayoutGuide type="bottom" id="xUW-hc-u7u"/>
@@ -73,7 +73,7 @@
         <!--Text View Controller-->
         <scene sceneID="zL2-OT-vrF">
             <objects>
-                <viewController storyboardIdentifier="public" id="t0K-MT-iCN" customClass="SLKTextViewController" customModule="SlackTextViewController" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="private" id="t0K-MT-iCN" customClass="SLKTextViewController" customModule="SlackTextViewController" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="tQi-3j-stJ"/>
                         <viewControllerLayoutGuide type="bottom" id="sxz-Gx-cZD"/>

--- a/Sources/TestUtils/Fixtures/StencilContexts/IB-iOS/all.yaml
+++ b/Sources/TestUtils/Fixtures/StencilContexts/IB-iOS/all.yaml
@@ -1,3 +1,243 @@
+customSceneTypes:
+- module: "<placeholder>"
+  moduleIsPlaceholder: true
+  segues:
+  - customClass: ""
+    customModule: ""
+    destination:
+      customClass: "PickerViewController"
+      customModule: "NotCurrentModule"
+      identifier: "URLChooser"
+      module: "NotCurrentModule"
+      moduleIsPlaceholder: true
+      type: "PickerViewController"
+    identifier: ""
+    kind: "show"
+    module: "UIKit"
+    moduleIsPlaceholder: false
+    type: "UIStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "TableViewController"
+      identifier: "MessagesList"
+      module: "UIKit"
+      moduleIsPlaceholder: false
+      type: "UITableViewController"
+    identifier: ""
+    kind: "relationship"
+    module: "UIKit"
+    moduleIsPlaceholder: false
+    type: "UIStoryboardSegue"
+  - customClass: "SlideLeftSegue"
+    customModule: "SwiftGen"
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "UIKit"
+      moduleIsPlaceholder: false
+      type: "UIViewController"
+    identifier: "CustomBack"
+    kind: "custom"
+    module: "SwiftGen"
+    moduleIsPlaceholder: false
+    type: "SlideLeftSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "UIKit"
+      moduleIsPlaceholder: false
+      type: "UIViewController"
+    identifier: "Embed"
+    kind: "embed"
+    module: "UIKit"
+    moduleIsPlaceholder: false
+    type: "UIStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: "Composer"
+      module: "UIKit"
+      moduleIsPlaceholder: false
+      type: "UIViewController"
+    identifier: "NonCustom"
+    kind: "showDetail"
+    module: "UIKit"
+    moduleIsPlaceholder: false
+    type: "UIStoryboardSegue"
+  - customClass: "CustomSegueClass"
+    customModule: "NotCurrentModule"
+    destination:
+      baseType: "NavigationController"
+      identifier: "NavCtrl"
+      module: "UIKit"
+      moduleIsPlaceholder: false
+      type: "UINavigationController"
+    identifier: "Show-NavCtrl"
+    kind: "presentation"
+    module: "NotCurrentModule"
+    moduleIsPlaceholder: true
+    type: "CustomSegueClass"
+  type: "PickerViewController"
+- module: "ExtraModule"
+  moduleIsPlaceholder: false
+  segues:
+  - customClass: ""
+    customModule: ""
+    destination:
+      customClass: "ValidatePasswordViewController"
+      customModule: "ExtraModule"
+      identifier: "Validate_Password"
+      module: "ExtraModule"
+      moduleIsPlaceholder: false
+      type: "ValidatePasswordViewController"
+    identifier: "ShowPassword"
+    kind: "show"
+    module: "UIKit"
+    moduleIsPlaceholder: false
+    type: "UIStoryboardSegue"
+  type: "ValidatePasswordViewController"
+- module: "LocationPicker"
+  moduleIsPlaceholder: false
+  segues:
+  - customClass: "SlideLeftSegue"
+    customModule: "SwiftGen"
+    destination:
+      customClass: "SLKTextViewController"
+      customModule: "SlackTextViewController"
+      identifier: "internal"
+      module: "SlackTextViewController"
+      moduleIsPlaceholder: false
+      type: "SLKTextViewController"
+    identifier: "After Delay"
+    kind: "custom"
+    module: "SwiftGen"
+    moduleIsPlaceholder: false
+    type: "SlideLeftSegue"
+  - customClass: "SLKCrossoverSegue"
+    customModule: "SlackTextViewController"
+    destination:
+      customClass: "SLKTextViewController"
+      customModule: "SlackTextViewController"
+      identifier: "private"
+      module: "SlackTextViewController"
+      moduleIsPlaceholder: false
+      type: "SLKTextViewController"
+    identifier: "open"
+    kind: "custom"
+    module: "SlackTextViewController"
+    moduleIsPlaceholder: false
+    type: "SLKCrossoverSegue"
+  - customClass: "SlideDownSegue"
+    customModule: "ExtraModule"
+    destination:
+      customClass: "SLKTextViewController"
+      customModule: "SlackTextViewController"
+      identifier: "public"
+      module: "SlackTextViewController"
+      moduleIsPlaceholder: false
+      type: "SLKTextViewController"
+    identifier: "private"
+    kind: "custom"
+    module: "ExtraModule"
+    moduleIsPlaceholder: false
+    type: "SlideDownSegue"
+  - customClass: "SlideUpSegue"
+    customModule: "NotCurrentModule"
+    destination:
+      customClass: "SLKTextViewController"
+      customModule: "SlackTextViewController"
+      identifier: "internal"
+      module: "SlackTextViewController"
+      moduleIsPlaceholder: false
+      type: "SLKTextViewController"
+    identifier: "public"
+    kind: "custom"
+    module: "NotCurrentModule"
+    moduleIsPlaceholder: true
+    type: "SlideUpSegue"
+  type: "LocationPickerViewController"
+- module: "SlackTextViewController"
+  moduleIsPlaceholder: false
+  segues:
+  - customClass: "SlideLeftSegue"
+    customModule: "SwiftGen"
+    destination:
+      customClass: "SLKTextViewController"
+      customModule: "SlackTextViewController"
+      identifier: "internal"
+      module: "SlackTextViewController"
+      moduleIsPlaceholder: false
+      type: "SLKTextViewController"
+    identifier: "After Delay"
+    kind: "custom"
+    module: "SwiftGen"
+    moduleIsPlaceholder: false
+    type: "SlideLeftSegue"
+  - customClass: "SLKCrossoverSegue"
+    customModule: "SlackTextViewController"
+    destination:
+      customClass: "SLKTextViewController"
+      customModule: "SlackTextViewController"
+      identifier: "private"
+      module: "SlackTextViewController"
+      moduleIsPlaceholder: false
+      type: "SLKTextViewController"
+    identifier: "open"
+    kind: "custom"
+    module: "SlackTextViewController"
+    moduleIsPlaceholder: false
+    type: "SLKCrossoverSegue"
+  - customClass: "SlideDownSegue"
+    customModule: "ExtraModule"
+    destination:
+      customClass: "SLKTextViewController"
+      customModule: "SlackTextViewController"
+      identifier: "public"
+      module: "SlackTextViewController"
+      moduleIsPlaceholder: false
+      type: "SLKTextViewController"
+    identifier: "private"
+    kind: "custom"
+    module: "ExtraModule"
+    moduleIsPlaceholder: false
+    type: "SlideDownSegue"
+  - customClass: "SlideUpSegue"
+    customModule: "NotCurrentModule"
+    destination:
+      customClass: "SLKTextViewController"
+      customModule: "SlackTextViewController"
+      identifier: "internal"
+      module: "SlackTextViewController"
+      moduleIsPlaceholder: false
+      type: "SLKTextViewController"
+    identifier: "public"
+    kind: "custom"
+    module: "NotCurrentModule"
+    moduleIsPlaceholder: true
+    type: "SlideUpSegue"
+  type: "SLKTextViewController"
+- module: "SwiftGen"
+  moduleIsPlaceholder: false
+  segues:
+  - customClass: ""
+    customModule: ""
+    destination:
+      customClass: "ValidatePasswordViewController"
+      customModule: "ExtraModule"
+      identifier: "Validate_Password"
+      module: "ExtraModule"
+      moduleIsPlaceholder: false
+      type: "ValidatePasswordViewController"
+    identifier: "ShowPassword"
+    kind: "show"
+    module: "UIKit"
+    moduleIsPlaceholder: false
+    type: "UIStoryboardSegue"
+  type: "CreateAccViewController"
 modules:
 - "AVKit"
 - "ExtraModule"
@@ -20,6 +260,18 @@ storyboards:
   scenes:
   - customClass: "SLKTextViewController"
     customModule: "SlackTextViewController"
+    identifier: "internal"
+    module: "SlackTextViewController"
+    moduleIsPlaceholder: false
+    type: "SLKTextViewController"
+  - customClass: "SLKTextViewController"
+    customModule: "SlackTextViewController"
+    identifier: "private"
+    module: "SlackTextViewController"
+    moduleIsPlaceholder: false
+    type: "SLKTextViewController"
+  - customClass: "SLKTextViewController"
+    customModule: "SlackTextViewController"
     identifier: "public"
     module: "SlackTextViewController"
     moduleIsPlaceholder: false
@@ -27,25 +279,57 @@ storyboards:
   segues:
   - customClass: "SlideLeftSegue"
     customModule: "SwiftGen"
+    destination:
+      customClass: "SLKTextViewController"
+      customModule: "SlackTextViewController"
+      identifier: "internal"
+      module: "SlackTextViewController"
+      moduleIsPlaceholder: false
+      type: "SLKTextViewController"
     identifier: "After Delay"
+    kind: "custom"
     module: "SwiftGen"
     moduleIsPlaceholder: false
     type: "SlideLeftSegue"
   - customClass: "SLKCrossoverSegue"
     customModule: "SlackTextViewController"
+    destination:
+      customClass: "SLKTextViewController"
+      customModule: "SlackTextViewController"
+      identifier: "private"
+      module: "SlackTextViewController"
+      moduleIsPlaceholder: false
+      type: "SLKTextViewController"
     identifier: "open"
+    kind: "custom"
     module: "SlackTextViewController"
     moduleIsPlaceholder: false
     type: "SLKCrossoverSegue"
   - customClass: "SlideDownSegue"
     customModule: "ExtraModule"
+    destination:
+      customClass: "SLKTextViewController"
+      customModule: "SlackTextViewController"
+      identifier: "public"
+      module: "SlackTextViewController"
+      moduleIsPlaceholder: false
+      type: "SLKTextViewController"
     identifier: "private"
+    kind: "custom"
     module: "ExtraModule"
     moduleIsPlaceholder: false
     type: "SlideDownSegue"
   - customClass: "SlideUpSegue"
     customModule: "NotCurrentModule"
+    destination:
+      customClass: "SLKTextViewController"
+      customModule: "SlackTextViewController"
+      identifier: "internal"
+      module: "SlackTextViewController"
+      moduleIsPlaceholder: false
+      type: "SLKTextViewController"
     identifier: "public"
+    kind: "custom"
     module: "NotCurrentModule"
     moduleIsPlaceholder: true
     type: "SlideUpSegue"
@@ -151,25 +435,53 @@ storyboards:
   segues:
   - customClass: "SlideLeftSegue"
     customModule: "SwiftGen"
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "UIKit"
+      moduleIsPlaceholder: false
+      type: "UIViewController"
     identifier: "CustomBack"
+    kind: "custom"
     module: "SwiftGen"
     moduleIsPlaceholder: false
     type: "SlideLeftSegue"
   - customClass: ""
     customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "UIKit"
+      moduleIsPlaceholder: false
+      type: "UIViewController"
     identifier: "Embed"
+    kind: "embed"
     module: "UIKit"
     moduleIsPlaceholder: false
     type: "UIStoryboardSegue"
   - customClass: ""
     customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: "Composer"
+      module: "UIKit"
+      moduleIsPlaceholder: false
+      type: "UIViewController"
     identifier: "NonCustom"
+    kind: "showDetail"
     module: "UIKit"
     moduleIsPlaceholder: false
     type: "UIStoryboardSegue"
   - customClass: "CustomSegueClass"
     customModule: "NotCurrentModule"
+    destination:
+      baseType: "NavigationController"
+      identifier: "NavCtrl"
+      module: "UIKit"
+      moduleIsPlaceholder: false
+      type: "UINavigationController"
     identifier: "Show-NavCtrl"
+    kind: "presentation"
     module: "NotCurrentModule"
     moduleIsPlaceholder: true
     type: "CustomSegueClass"
@@ -217,7 +529,15 @@ storyboards:
   segues:
   - customClass: ""
     customModule: ""
+    destination:
+      customClass: "ValidatePasswordViewController"
+      customModule: "ExtraModule"
+      identifier: "Validate_Password"
+      module: "ExtraModule"
+      moduleIsPlaceholder: false
+      type: "ValidatePasswordViewController"
     identifier: "ShowPassword"
+    kind: "show"
     module: "UIKit"
     moduleIsPlaceholder: false
     type: "UIStoryboardSegue"

--- a/Sources/TestUtils/Fixtures/StencilContexts/IB-iOS/anonymous.yaml
+++ b/Sources/TestUtils/Fixtures/StencilContexts/IB-iOS/anonymous.yaml
@@ -1,3 +1,4 @@
+customSceneTypes: []
 modules:
 - "UIKit"
 platform: "iOS"

--- a/Sources/TestUtils/Fixtures/StencilContexts/IB-iOS/empty.yaml
+++ b/Sources/TestUtils/Fixtures/StencilContexts/IB-iOS/empty.yaml
@@ -1,3 +1,4 @@
+customSceneTypes: []
 modules: []
 platform: ""
 storyboards: []

--- a/Sources/TestUtils/Fixtures/StencilContexts/IB-iOS/messages.yaml
+++ b/Sources/TestUtils/Fixtures/StencilContexts/IB-iOS/messages.yaml
@@ -1,3 +1,87 @@
+customSceneTypes:
+- module: "<placeholder>"
+  moduleIsPlaceholder: true
+  segues:
+  - customClass: ""
+    customModule: ""
+    destination:
+      customClass: "PickerViewController"
+      customModule: "NotCurrentModule"
+      identifier: "URLChooser"
+      module: "NotCurrentModule"
+      moduleIsPlaceholder: true
+      type: "PickerViewController"
+    identifier: ""
+    kind: "show"
+    module: "UIKit"
+    moduleIsPlaceholder: false
+    type: "UIStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "TableViewController"
+      identifier: "MessagesList"
+      module: "UIKit"
+      moduleIsPlaceholder: false
+      type: "UITableViewController"
+    identifier: ""
+    kind: "relationship"
+    module: "UIKit"
+    moduleIsPlaceholder: false
+    type: "UIStoryboardSegue"
+  - customClass: "SlideLeftSegue"
+    customModule: "SwiftGen"
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "UIKit"
+      moduleIsPlaceholder: false
+      type: "UIViewController"
+    identifier: "CustomBack"
+    kind: "custom"
+    module: "SwiftGen"
+    moduleIsPlaceholder: false
+    type: "SlideLeftSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "UIKit"
+      moduleIsPlaceholder: false
+      type: "UIViewController"
+    identifier: "Embed"
+    kind: "embed"
+    module: "UIKit"
+    moduleIsPlaceholder: false
+    type: "UIStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: "Composer"
+      module: "UIKit"
+      moduleIsPlaceholder: false
+      type: "UIViewController"
+    identifier: "NonCustom"
+    kind: "showDetail"
+    module: "UIKit"
+    moduleIsPlaceholder: false
+    type: "UIStoryboardSegue"
+  - customClass: "CustomSegueClass"
+    customModule: "NotCurrentModule"
+    destination:
+      baseType: "NavigationController"
+      identifier: "NavCtrl"
+      module: "UIKit"
+      moduleIsPlaceholder: false
+      type: "UINavigationController"
+    identifier: "Show-NavCtrl"
+    kind: "presentation"
+    module: "NotCurrentModule"
+    moduleIsPlaceholder: true
+    type: "CustomSegueClass"
+  type: "PickerViewController"
 modules:
 - "SwiftGen"
 - "UIKit"
@@ -36,25 +120,53 @@ storyboards:
   segues:
   - customClass: "SlideLeftSegue"
     customModule: "SwiftGen"
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "UIKit"
+      moduleIsPlaceholder: false
+      type: "UIViewController"
     identifier: "CustomBack"
+    kind: "custom"
     module: "SwiftGen"
     moduleIsPlaceholder: false
     type: "SlideLeftSegue"
   - customClass: ""
     customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "UIKit"
+      moduleIsPlaceholder: false
+      type: "UIViewController"
     identifier: "Embed"
+    kind: "embed"
     module: "UIKit"
     moduleIsPlaceholder: false
     type: "UIStoryboardSegue"
   - customClass: ""
     customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: "Composer"
+      module: "UIKit"
+      moduleIsPlaceholder: false
+      type: "UIViewController"
     identifier: "NonCustom"
+    kind: "showDetail"
     module: "UIKit"
     moduleIsPlaceholder: false
     type: "UIStoryboardSegue"
   - customClass: "CustomSegueClass"
     customModule: "NotCurrentModule"
+    destination:
+      baseType: "NavigationController"
+      identifier: "NavCtrl"
+      module: "UIKit"
+      moduleIsPlaceholder: false
+      type: "UINavigationController"
     identifier: "Show-NavCtrl"
+    kind: "presentation"
     module: "NotCurrentModule"
     moduleIsPlaceholder: true
     type: "CustomSegueClass"

--- a/Sources/TestUtils/Fixtures/StencilContexts/IB-macOS/all.yaml
+++ b/Sources/TestUtils/Fixtures/StencilContexts/IB-macOS/all.yaml
@@ -1,3 +1,362 @@
+customSceneTypes:
+- module: "<placeholder>"
+  moduleIsPlaceholder: true
+  segues:
+  - customClass: ""
+    customModule: ""
+    destination:
+      customClass: "DetailsViewController"
+      customModule: "NotCurrentModule"
+      identifier: "MessageDetails"
+      module: "NotCurrentModule"
+      moduleIsPlaceholder: true
+      type: "DetailsViewController"
+    identifier: ""
+    kind: "relationship"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      customClass: "CustomTabViewController"
+      customModule: "SwiftGen"
+      identifier: "MessagesTab"
+      module: "SwiftGen"
+      moduleIsPlaceholder: false
+      type: "CustomTabViewController"
+    identifier: ""
+    kind: "relationship"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: "MessageList"
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: ""
+    kind: "relationship"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "SplitViewController"
+      identifier: "SplitMessages"
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSSplitViewController"
+    identifier: ""
+    kind: "relationship"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: "MessageListFooter"
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "Embed"
+    kind: "embed"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: "SlowFadeSegue"
+    customModule: "PrefsWindowController"
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "Fade"
+    kind: "custom"
+    module: "PrefsWindowController"
+    moduleIsPlaceholder: false
+    type: "SlowFadeSegue"
+  - customClass: "LoginSegue"
+    customModule: "ExtraModule"
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "Login"
+    kind: "custom"
+    module: "ExtraModule"
+    moduleIsPlaceholder: false
+    type: "LoginSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "Modal"
+    kind: "modal"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "Popover"
+    kind: "popover"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "Sheet"
+    kind: "sheet"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "Show"
+    kind: "show"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: "RotateSegue"
+    customModule: "NotCurrentModule"
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "private"
+    kind: "custom"
+    module: "NotCurrentModule"
+    moduleIsPlaceholder: true
+    type: "RotateSegue"
+  - customClass: "ZoomSegue"
+    customModule: "SwiftGen"
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "public"
+    kind: "custom"
+    module: "SwiftGen"
+    moduleIsPlaceholder: false
+    type: "ZoomSegue"
+  type: "DetailsViewController"
+- module: "ExtraModule"
+  moduleIsPlaceholder: false
+  segues: []
+  type: "LoginViewController"
+- module: "PrefsWindowController"
+  moduleIsPlaceholder: false
+  segues: []
+  type: "DBPrefsWindowController"
+- module: "SwiftGen"
+  moduleIsPlaceholder: false
+  segues:
+  - customClass: ""
+    customModule: ""
+    destination:
+      customClass: "DetailsViewController"
+      customModule: "NotCurrentModule"
+      identifier: "MessageDetails"
+      module: "NotCurrentModule"
+      moduleIsPlaceholder: true
+      type: "DetailsViewController"
+    identifier: ""
+    kind: "relationship"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      customClass: "CustomTabViewController"
+      customModule: "SwiftGen"
+      identifier: "MessagesTab"
+      module: "SwiftGen"
+      moduleIsPlaceholder: false
+      type: "CustomTabViewController"
+    identifier: ""
+    kind: "relationship"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: "MessageList"
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: ""
+    kind: "relationship"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "SplitViewController"
+      identifier: "SplitMessages"
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSSplitViewController"
+    identifier: ""
+    kind: "relationship"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: "MessageListFooter"
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "Embed"
+    kind: "embed"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: "SlowFadeSegue"
+    customModule: "PrefsWindowController"
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "Fade"
+    kind: "custom"
+    module: "PrefsWindowController"
+    moduleIsPlaceholder: false
+    type: "SlowFadeSegue"
+  - customClass: "LoginSegue"
+    customModule: "ExtraModule"
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "Login"
+    kind: "custom"
+    module: "ExtraModule"
+    moduleIsPlaceholder: false
+    type: "LoginSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "Modal"
+    kind: "modal"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "Popover"
+    kind: "popover"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "Sheet"
+    kind: "sheet"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "Show"
+    kind: "show"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: "RotateSegue"
+    customModule: "NotCurrentModule"
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "private"
+    kind: "custom"
+    module: "NotCurrentModule"
+    moduleIsPlaceholder: true
+    type: "RotateSegue"
+  - customClass: "ZoomSegue"
+    customModule: "SwiftGen"
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "public"
+    kind: "custom"
+    module: "SwiftGen"
+    moduleIsPlaceholder: false
+    type: "ZoomSegue"
+  type: "CustomTabViewController"
 modules:
 - "AppKit"
 - "ExtraModule"
@@ -96,55 +455,118 @@ storyboards:
   segues:
   - customClass: ""
     customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: "MessageListFooter"
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
     identifier: "Embed"
+    kind: "embed"
     module: "AppKit"
     moduleIsPlaceholder: false
     type: "NSStoryboardSegue"
   - customClass: "SlowFadeSegue"
     customModule: "PrefsWindowController"
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
     identifier: "Fade"
+    kind: "custom"
     module: "PrefsWindowController"
     moduleIsPlaceholder: false
     type: "SlowFadeSegue"
   - customClass: "LoginSegue"
     customModule: "ExtraModule"
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
     identifier: "Login"
+    kind: "custom"
     module: "ExtraModule"
     moduleIsPlaceholder: false
     type: "LoginSegue"
   - customClass: ""
     customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
     identifier: "Modal"
+    kind: "modal"
     module: "AppKit"
     moduleIsPlaceholder: false
     type: "NSStoryboardSegue"
   - customClass: ""
     customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
     identifier: "Popover"
+    kind: "popover"
     module: "AppKit"
     moduleIsPlaceholder: false
     type: "NSStoryboardSegue"
   - customClass: ""
     customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
     identifier: "Sheet"
+    kind: "sheet"
     module: "AppKit"
     moduleIsPlaceholder: false
     type: "NSStoryboardSegue"
   - customClass: ""
     customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
     identifier: "Show"
+    kind: "show"
     module: "AppKit"
     moduleIsPlaceholder: false
     type: "NSStoryboardSegue"
   - customClass: "RotateSegue"
     customModule: "NotCurrentModule"
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
     identifier: "private"
+    kind: "custom"
     module: "NotCurrentModule"
     moduleIsPlaceholder: true
     type: "RotateSegue"
   - customClass: "ZoomSegue"
     customModule: "SwiftGen"
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
     identifier: "public"
+    kind: "custom"
     module: "SwiftGen"
     moduleIsPlaceholder: false
     type: "ZoomSegue"

--- a/Sources/TestUtils/Fixtures/StencilContexts/IB-macOS/anonymous.yaml
+++ b/Sources/TestUtils/Fixtures/StencilContexts/IB-macOS/anonymous.yaml
@@ -1,3 +1,4 @@
+customSceneTypes: []
 modules:
 - "AppKit"
 platform: "macOS"

--- a/Sources/TestUtils/Fixtures/StencilContexts/IB-macOS/empty.yaml
+++ b/Sources/TestUtils/Fixtures/StencilContexts/IB-macOS/empty.yaml
@@ -1,3 +1,4 @@
+customSceneTypes: []
 modules: []
 platform: ""
 storyboards: []

--- a/Sources/TestUtils/Fixtures/StencilContexts/IB-macOS/messages.yaml
+++ b/Sources/TestUtils/Fixtures/StencilContexts/IB-macOS/messages.yaml
@@ -1,3 +1,354 @@
+customSceneTypes:
+- module: "<placeholder>"
+  moduleIsPlaceholder: true
+  segues:
+  - customClass: ""
+    customModule: ""
+    destination:
+      customClass: "DetailsViewController"
+      customModule: "NotCurrentModule"
+      identifier: "MessageDetails"
+      module: "NotCurrentModule"
+      moduleIsPlaceholder: true
+      type: "DetailsViewController"
+    identifier: ""
+    kind: "relationship"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      customClass: "CustomTabViewController"
+      customModule: "SwiftGen"
+      identifier: "MessagesTab"
+      module: "SwiftGen"
+      moduleIsPlaceholder: false
+      type: "CustomTabViewController"
+    identifier: ""
+    kind: "relationship"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: "MessageList"
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: ""
+    kind: "relationship"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "SplitViewController"
+      identifier: "SplitMessages"
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSSplitViewController"
+    identifier: ""
+    kind: "relationship"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: "MessageListFooter"
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "Embed"
+    kind: "embed"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: "SlowFadeSegue"
+    customModule: "PrefsWindowController"
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "Fade"
+    kind: "custom"
+    module: "PrefsWindowController"
+    moduleIsPlaceholder: false
+    type: "SlowFadeSegue"
+  - customClass: "LoginSegue"
+    customModule: "ExtraModule"
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "Login"
+    kind: "custom"
+    module: "ExtraModule"
+    moduleIsPlaceholder: false
+    type: "LoginSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "Modal"
+    kind: "modal"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "Popover"
+    kind: "popover"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "Sheet"
+    kind: "sheet"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "Show"
+    kind: "show"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: "RotateSegue"
+    customModule: "NotCurrentModule"
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "private"
+    kind: "custom"
+    module: "NotCurrentModule"
+    moduleIsPlaceholder: true
+    type: "RotateSegue"
+  - customClass: "ZoomSegue"
+    customModule: "SwiftGen"
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "public"
+    kind: "custom"
+    module: "SwiftGen"
+    moduleIsPlaceholder: false
+    type: "ZoomSegue"
+  type: "DetailsViewController"
+- module: "SwiftGen"
+  moduleIsPlaceholder: false
+  segues:
+  - customClass: ""
+    customModule: ""
+    destination:
+      customClass: "DetailsViewController"
+      customModule: "NotCurrentModule"
+      identifier: "MessageDetails"
+      module: "NotCurrentModule"
+      moduleIsPlaceholder: true
+      type: "DetailsViewController"
+    identifier: ""
+    kind: "relationship"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      customClass: "CustomTabViewController"
+      customModule: "SwiftGen"
+      identifier: "MessagesTab"
+      module: "SwiftGen"
+      moduleIsPlaceholder: false
+      type: "CustomTabViewController"
+    identifier: ""
+    kind: "relationship"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: "MessageList"
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: ""
+    kind: "relationship"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "SplitViewController"
+      identifier: "SplitMessages"
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSSplitViewController"
+    identifier: ""
+    kind: "relationship"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: "MessageListFooter"
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "Embed"
+    kind: "embed"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: "SlowFadeSegue"
+    customModule: "PrefsWindowController"
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "Fade"
+    kind: "custom"
+    module: "PrefsWindowController"
+    moduleIsPlaceholder: false
+    type: "SlowFadeSegue"
+  - customClass: "LoginSegue"
+    customModule: "ExtraModule"
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "Login"
+    kind: "custom"
+    module: "ExtraModule"
+    moduleIsPlaceholder: false
+    type: "LoginSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "Modal"
+    kind: "modal"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "Popover"
+    kind: "popover"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "Sheet"
+    kind: "sheet"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "Show"
+    kind: "show"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: "RotateSegue"
+    customModule: "NotCurrentModule"
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "private"
+    kind: "custom"
+    module: "NotCurrentModule"
+    moduleIsPlaceholder: true
+    type: "RotateSegue"
+  - customClass: "ZoomSegue"
+    customModule: "SwiftGen"
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
+    identifier: "public"
+    kind: "custom"
+    module: "SwiftGen"
+    moduleIsPlaceholder: false
+    type: "ZoomSegue"
+  type: "CustomTabViewController"
 modules:
 - "AppKit"
 - "ExtraModule"
@@ -43,55 +394,118 @@ storyboards:
   segues:
   - customClass: ""
     customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: "MessageListFooter"
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
     identifier: "Embed"
+    kind: "embed"
     module: "AppKit"
     moduleIsPlaceholder: false
     type: "NSStoryboardSegue"
   - customClass: "SlowFadeSegue"
     customModule: "PrefsWindowController"
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
     identifier: "Fade"
+    kind: "custom"
     module: "PrefsWindowController"
     moduleIsPlaceholder: false
     type: "SlowFadeSegue"
   - customClass: "LoginSegue"
     customModule: "ExtraModule"
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
     identifier: "Login"
+    kind: "custom"
     module: "ExtraModule"
     moduleIsPlaceholder: false
     type: "LoginSegue"
   - customClass: ""
     customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
     identifier: "Modal"
+    kind: "modal"
     module: "AppKit"
     moduleIsPlaceholder: false
     type: "NSStoryboardSegue"
   - customClass: ""
     customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
     identifier: "Popover"
+    kind: "popover"
     module: "AppKit"
     moduleIsPlaceholder: false
     type: "NSStoryboardSegue"
   - customClass: ""
     customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
     identifier: "Sheet"
+    kind: "sheet"
     module: "AppKit"
     moduleIsPlaceholder: false
     type: "NSStoryboardSegue"
   - customClass: ""
     customModule: ""
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
     identifier: "Show"
+    kind: "show"
     module: "AppKit"
     moduleIsPlaceholder: false
     type: "NSStoryboardSegue"
   - customClass: "RotateSegue"
     customModule: "NotCurrentModule"
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
     identifier: "private"
+    kind: "custom"
     module: "NotCurrentModule"
     moduleIsPlaceholder: true
     type: "RotateSegue"
   - customClass: "ZoomSegue"
     customModule: "SwiftGen"
+    destination:
+      baseType: "ViewController"
+      identifier: ""
+      module: "AppKit"
+      moduleIsPlaceholder: false
+      type: "NSViewController"
     identifier: "public"
+    kind: "custom"
     module: "SwiftGen"
     moduleIsPlaceholder: false
     type: "ZoomSegue"

--- a/Tests/TemplatesTests/InterfaceBuilderTests.swift
+++ b/Tests/TemplatesTests/InterfaceBuilderTests.swift
@@ -33,7 +33,10 @@ class InterfaceBuilderTests: XCTestCase {
 
       // test: enumName parameter
       (
-        context: try StencilContext.enrich(context: context, parameters: ["enumName=XCTStoryboardCustom"]),
+        context: try StencilContext.enrich(
+          context: context,
+          parameters: ["enumName=XCTStoryboardCustom", "unnamedSegueCaseName=customUnnamedSegue"]
+        ),
         suffix: "-customName"
       ),
 


### PR DESCRIPTION
Transfer PRs https://github.com/SwiftGen/SwiftGenKit/pull/54 and https://github.com/SwiftGen/templates/pull/79.
Fixes #362.

## SwiftgenKit Changes

This PR improves the storyboards parser in 2 ways:
- Know which segues start from which scenes
- Know the type information for a segue destination
The PR also refactors the Storyboards parser a bit (split up in files).

## Templates Changes

Uses the improvements added in SwiftGenKit to generate extensions for non-base classes (UIKit/AppKit), so that a user can:
- Perform a segue safely with an enum of segues that start from that scene (you can no longer incorrectly start a segue from a VC that doesn't support it).
- Prepare for a segue in a type safe way:
  - Have an exhaustive list of possible cases, including one for unnamed segues.
  - Get the segue's destination in the correct type (no need to cast it).
  - Get the segue itself as the correct subclass if you're using custom segues.

----------

For performing a segue, the user goes from:
```swift
perform(segue: StoryboardSegue.MyStoryboard.nextStep)
```
To:
```swift
perform(segue: .nextStep)
```

For preparing for a segue, the user goes from:
```swift
override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
  // autocomplete for cases won't work because of optionals
  switch segueEnum {
  case .nextStep?:
    guard let destination = segue.destination as? NextStepViewController else { return }
    // destination is casted version
  case .login?:
    guard let destination = segue.destination as? LoginViewController else { return }
    // destination is casted version
  default:
    // Handle segues that are for other scenes, or unnamed segues
  }
}
```
To:
```swift
override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
  switch TypedStoryboardSegue(segue: segue) {
  case .nextStep(let destination):
    // destination is casted version
  case .login(let destination):
    // destination is casted version
  case .unnamedSegue:
    // This case is added if you have unnamed segues (with identifier "")
  }
}
```