### PR TITLE
Enable extra SwiftLint rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,3 @@
-disabled_rules:
- - type_name
-
 opt_in_rules:
  - array_init
  - attributes

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -21,7 +21,6 @@ opt_in_rules:
  - operator_usage_whitespace
  - overridden_super_call
  - override_in_extension
- - pattern_matching_keywords
  - private_action
  - private_outlet
  - prohibited_super_call

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,7 +2,36 @@ disabled_rules:
  - type_name
 
 opt_in_rules:
+ - array_init
+ - attributes
+ - closure_end_indentation
+ - closure_spacing
+ - contains_over_first_not_nil
+ - discouraged_optional_boolean
+ - empty_count
+ - fatal_error_message
+ - first_where
  - force_unwrapping
+ - implicit_return
+ - implicitly_unwrapped_optional
+ - joined_default_parameter
+ - literal_expression_end_indentation
+ - multiline_arguments
+ - multiline_parameters
+ - operator_usage_whitespace
+ - overridden_super_call
+ - override_in_extension
+ - pattern_matching_keywords
+ - private_action
+ - private_outlet
+ - prohibited_super_call
+ - redundant_nil_coalescing
+ - sorted_first_last
+ - sorted_imports
+ - trailing_closure
+ - unneeded_parentheses_in_closure_argument
+ - vertical_parameter_alignment_on_call
+ - yoda_condition
 
 # Rules customization
 line_length:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ _None_
 * Switched to using SwiftLint via CocoaPods instead of our own install scripts.  
   [David Jennes](https://github.com/djbe) 
   [#401](https://github.com/SwiftGen/SwiftGen/pull/401)
+* Enabled some extra SwiftLint rules for better code consistency.  
+  [David Jennes](https://github.com/djbe) 
+  [#402](https://github.com/SwiftGen/SwiftGen/pull/402)
 
 ## 5.3.0
 

--- a/Sources/SwiftGen/Commander/ConfigCommands.swift
+++ b/Sources/SwiftGen/Commander/ConfigCommands.swift
@@ -24,9 +24,9 @@ extension Config.Entry {
   }
 
   func run(parserCommand: ParserCLI) throws {
-    let parser = try parserCommand.parserType.init(options: [:], warningHandler: { (msg, _, _) in
+    let parser = try parserCommand.parserType.init(options: [:]) { msg, _, _ in
       logMessage(.warning, msg)
-    })
+    }
     try parser.parse(paths: self.paths)
     let templateRealPath = try self.template.resolvePath(forSubcommand: parserCommand.name)
     let template = try StencilSwiftTemplate(templateString: templateRealPath.read(),
@@ -45,7 +45,9 @@ extension Config.Entry {
 // MARK: Lint
 
 let configLintCommand = command(
-  Option<Path>("config", default: "swiftgen.yml", flag: "c",
+  Option<Path>("config",
+               default: "swiftgen.yml",
+               flag: "c",
                description: "Path to the configuration file to use",
                validator: checkPath(type: "config file") { $0.isFile })
 ) { file in
@@ -59,10 +61,14 @@ let configLintCommand = command(
 // MARK: Run
 
 let configRunCommand = command(
-  Option<Path>("config", default: "swiftgen.yml", flag: "c",
+  Option<Path>("config",
+               default: "swiftgen.yml",
+               flag: "c",
                description: "Path to the configuration file to use",
                validator: checkPath(type: "config file") { $0.isFile }),
-  Flag("verbose", default: false, flag: "v",
+  Flag("verbose",
+       default: false,
+       flag: "v",
        description: "Print each command being executed")
 ) { file, verbose in
   try ErrorPrettifier.execute {

--- a/Sources/SwiftGen/Commander/OutputDestination.swift
+++ b/Sources/SwiftGen/Commander/OutputDestination.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2017 AliSoftware. All rights reserved.
 //
 
-import PathKit
 import Commander
+import PathKit
 
 enum OutputDestination: ArgumentConvertible {
   case console

--- a/Sources/SwiftGen/Commander/ParserCLICommands.swift
+++ b/Sources/SwiftGen/Commander/ParserCLICommands.swift
@@ -13,8 +13,10 @@ private let templateNameOption = Option<String>(
   "template",
   default: "",
   flag: "t",
-  description: "The name of the template to use for code generation. " +
-  "See `swiftgen templates list` for a list of available names"
+  description: """
+    The name of the template to use for code generation. \
+    See `swiftgen templates list` for a list of available names
+    """
 )
 
 private let templatePathOption = Option<String>(

--- a/Sources/SwiftGen/Commander/ParserCLICommands.swift
+++ b/Sources/SwiftGen/Commander/ParserCLICommands.swift
@@ -10,18 +10,23 @@ import StencilSwiftKit
 import SwiftGenKit
 
 private let templateNameOption = Option<String>(
-  "template", default: "", flag: "t",
+  "template",
+  default: "",
+  flag: "t",
   description: "The name of the template to use for code generation. " +
   "See `swiftgen templates list` for a list of available names"
 )
 
 private let templatePathOption = Option<String>(
-  "templatePath", default: "", flag: "p",
+  "templatePath",
+  default: "",
+  flag: "p",
   description: "The path of the template to use for code generation."
 )
 
 private let paramsOption = VariadicOption<String>(
-  "param", default: [],
+  "param",
+  default: [],
   description: "List of template parameters"
 )
 

--- a/Sources/SwiftGen/Commander/TemplatesCommands.swift
+++ b/Sources/SwiftGen/Commander/TemplatesCommands.swift
@@ -17,7 +17,9 @@ private func isSubcommandName(name: String) throws -> String {
 }
 
 let templatesListCommand = command(
-  Option<String>("only", default: "", flag: "l",
+  Option<String>("only",
+                 default: "",
+                 flag: "l",
                  description: "If specified, only list templates valid for that specific subcommand",
                  validator: isSubcommandName),
   outputOption
@@ -60,9 +62,11 @@ let templatesListCommand = command(
 // These will then be converted into an actual template path, and passed to the result closure.
 private func templatePathCommandGenerator(execute: @escaping (Path, OutputDestination) throws -> Void) -> CommandType {
   return command(
-    Argument<String>("subcommand",
+    Argument<String>(
+      "subcommand",
       description: "the name of the subcommand for the template, like `colors`"),
-    Argument<String>("template",
+    Argument<String>(
+      "template",
       description: "the name of the template to find, like `swift3` or `dot-syntax`"),
     outputOption
   ) { subcommand, name, output in

--- a/Sources/SwiftGen/Config/Config.swift
+++ b/Sources/SwiftGen/Config/Config.swift
@@ -32,8 +32,8 @@ extension Config {
     guard let config = anyConfig as? [String: Any] else {
       throw Config.Error.wrongType(key: nil, expected: "Dictionary", got: type(of: anyConfig))
     }
-    self.inputDir = (config[Keys.inputDir] as? String).map({ Path($0) })
-    self.outputDir = (config[Keys.outputDir] as? String).map({ Path($0) })
+    self.inputDir = (config[Keys.inputDir] as? String).map { Path($0) }
+    self.outputDir = (config[Keys.outputDir] as? String).map { Path($0) }
     var cmds: [String: [Config.Entry]] = [:]
     for parserCmd in allParserCommands {
       if let cmdEntry = config[parserCmd.name] {
@@ -85,21 +85,21 @@ extension Config {
 
     var description: String {
       switch self {
-      case .missingEntry(let key):
+      case let .missingEntry(key):
         return "Missing entry for key \(key)."
-      case .wrongType(let key, let expected, let got):
+      case let .wrongType(key, expected, got):
         return "Wrong type for key \(key ?? "root"): expected \(expected), got \(got)."
-      case .pathNotFound(let path):
+      case let .pathNotFound(path):
         return "File \(path) not found."
       }
     }
 
     func withKeyPrefixed(by prefix: String) -> Config.Error {
       switch self {
-      case .missingEntry(let key):
+      case let .missingEntry(key):
         return Config.Error.missingEntry(key: "\(prefix).\(key)")
-      case .wrongType(key: let key, expected: let expected, got: let got):
-        let fullKey = [prefix, key].flatMap({$0}).joined(separator: ".")
+      case let .wrongType(key, expected, got):
+        let fullKey = [prefix, key].flatMap({ $0 }).joined(separator: ".")
         return Config.Error.wrongType(key: fullKey, expected: expected, got: got)
       default:
         return self

--- a/Sources/SwiftGen/Config/Config.swift
+++ b/Sources/SwiftGen/Config/Config.swift
@@ -85,20 +85,20 @@ extension Config {
 
     var description: String {
       switch self {
-      case let .missingEntry(key):
+      case .missingEntry(let key):
         return "Missing entry for key \(key)."
-      case let .wrongType(key, expected, got):
+      case .wrongType(let key, let expected, let got):
         return "Wrong type for key \(key ?? "root"): expected \(expected), got \(got)."
-      case let .pathNotFound(path):
+      case .pathNotFound(let path):
         return "File \(path) not found."
       }
     }
 
     func withKeyPrefixed(by prefix: String) -> Config.Error {
       switch self {
-      case let .missingEntry(key):
+      case .missingEntry(let key):
         return Config.Error.missingEntry(key: "\(prefix).\(key)")
-      case let .wrongType(key, expected, got):
+      case .wrongType(let key, let expected, let got):
         let fullKey = [prefix, key].flatMap({ $0 }).joined(separator: ".")
         return Config.Error.wrongType(key: fullKey, expected: expected, got: got)
       default:

--- a/Sources/SwiftGen/Config/ConfigEntry.swift
+++ b/Sources/SwiftGen/Config/ConfigEntry.swift
@@ -93,9 +93,9 @@ extension Config.Entry {
       case .path(let path): return "-p \(path.string)"
       }
     }()
-    let params =  Parameters.flatten(dictionary: self.parameters)
-    let paramsList = params.isEmpty ? "" : (" " + params.map({ "--param \($0)" }).joined(separator: " "))
-    let inputPaths = self.paths.map({ $0.string }).joined(separator: " ")
+    let params = Parameters.flatten(dictionary: self.parameters)
+    let paramsList = params.isEmpty ? "" : (" " + params.map { "--param \($0)" }.joined(separator: " "))
+    let inputPaths = self.paths.map { $0.string }.joined(separator: " ")
     return "swiftgen \(cmd) \(tplFlag)\(paramsList) -o \(self.output) \(inputPaths)"
   }
 }

--- a/Sources/SwiftGen/Path+AppSupport.swift
+++ b/Sources/SwiftGen/Path+AppSupport.swift
@@ -12,7 +12,8 @@ extension Path {
   static let applicationSupport: Path = {
     let paths = NSSearchPathForDirectoriesInDomains(
       .applicationSupportDirectory,
-      .userDomainMask, true
+      .userDomainMask,
+      true
     )
     guard let path = paths.first else {
       fatalError("Unable to locate the Application Support directory on your machine!")

--- a/Sources/SwiftGen/TemplateRef.swift
+++ b/Sources/SwiftGen/TemplateRef.swift
@@ -69,13 +69,18 @@ extension TemplateRef.Error: CustomStringConvertible {
   var description: String {
     switch self {
     case .namedTemplateNotFound(let name):
-      return "Template named \(name) not found. Use `swiftgen templates` to list available named templates " +
-      "or use --templatePath to specify a template by its full path."
+      return """
+        Template named \(name) not found. Use `swiftgen templates` to list available named templates \
+        or use --templatePath to specify a template by its full path.
+        """
     case .templatePathNotFound(let path):
       return "Template not found at path \(path.description)."
     case .noTemplateProvided:
-      return "You must specify a template name (-t) or path (-p).\n\n" +
-      "To list all the available named templates, use 'swiftgen templates list'."
+      return """
+        You must specify a template name (-t) or path (-p).
+
+        To list all the available named templates, use 'swiftgen templates list'.
+        """
     case let .multipleTemplateOptions(path, name):
       return "You need to choose EITHER a named template OR a template path. Found name '\(name)' and path '\(path)'"
     }

--- a/Sources/SwiftGen/TemplateRef.swift
+++ b/Sources/SwiftGen/TemplateRef.swift
@@ -81,7 +81,7 @@ extension TemplateRef.Error: CustomStringConvertible {
 
         To list all the available named templates, use 'swiftgen templates list'.
         """
-    case let .multipleTemplateOptions(path, name):
+    case .multipleTemplateOptions(let path, let name):
       return "You need to choose EITHER a named template OR a template path. Found name '\(name)' and path '\(path)'"
     }
   }

--- a/Sources/SwiftGen/main.swift
+++ b/Sources/SwiftGen/main.swift
@@ -13,14 +13,16 @@ import SwiftGenKit
 // MARK: Common
 
 let outputOption = Option(
-  "output", default: OutputDestination.console, flag: "o",
+  "output",
+  default: OutputDestination.console,
+  flag: "o",
   description: "The path to the file to generate (Omit to generate to stdout)"
 )
 
 // MARK: - Main
 
 let main = Group {
-  $0.noCommand = { (path, group, parser) in
+  $0.noCommand = { path, group, parser in
     if parser.hasOption("help") {
       logMessage(.info, "Note: If you invoke swiftgen with no subcommand, it will default to `swiftgen config run`\n")
       throw GroupError.noCommand(path, group)

--- a/Sources/SwiftGen/main.swift
+++ b/Sources/SwiftGen/main.swift
@@ -55,7 +55,9 @@ let stencilSwiftKitVersion = Bundle(for: StencilSwiftKit.StencilSwiftTemplate.se
 let swiftGenKitVersion = Bundle(for: SwiftGenKit.AssetsCatalogParser.self)
   .infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0"
 
-main.run("SwiftGen v\(version) (" +
-  "Stencil v\(stencilVersion), " +
-  "StencilSwiftKit v\(stencilSwiftKitVersion), " +
-  "SwiftGenKit v\(swiftGenKitVersion))")
+main.run("""
+  SwiftGen v\(version) (\
+  Stencil v\(stencilVersion), \
+  StencilSwiftKit v\(stencilSwiftKitVersion), \
+  SwiftGenKit v\(swiftGenKitVersion))
+  """)

--- a/Sources/SwiftGenKit/Parsers/ColorsParser.swift
+++ b/Sources/SwiftGenKit/Parsers/ColorsParser.swift
@@ -14,12 +14,12 @@ public enum ColorsParserError: Error, CustomStringConvertible {
 
   public var description: String {
     switch self {
-    case let .invalidHexColor(path, string, key):
+    case .invalidHexColor(let path, let string, let key):
       let keyInfo = key.flatMap { " for key \"\($0)\"" } ?? ""
       return "error: Invalid hex color \"\(string)\" found\(keyInfo) (\(path))."
-    case let .invalidFile(path, reason):
+    case .invalidFile(let path, let reason):
       return "error: Unable to parse file at \(path). \(reason)"
-    case let .unsupportedFileType(path, supported):
+    case .unsupportedFileType(let path, let supported):
       return """
         error: Unsupported file type for \(path). \
         The supported file types are: \(supported.joined(separator: ", "))

--- a/Sources/SwiftGenKit/Parsers/ColorsParser.swift
+++ b/Sources/SwiftGenKit/Parsers/ColorsParser.swift
@@ -14,12 +14,12 @@ public enum ColorsParserError: Error, CustomStringConvertible {
 
   public var description: String {
     switch self {
-    case .invalidHexColor(let path, let string, let key):
+    case let .invalidHexColor(path, string, key):
       let keyInfo = key.flatMap { " for key \"\($0)\"" } ?? ""
       return "error: Invalid hex color \"\(string)\" found\(keyInfo) (\(path))."
-    case .invalidFile(let path, let reason):
+    case let .invalidFile(path, reason):
       return "error: Unable to parse file at \(path). \(reason)"
-    case .unsupportedFileType(let path, let supported):
+    case let .unsupportedFileType(path, supported):
       return "error: Unsupported file type for \(path). " +
         "The supported file types are: \(supported.joined(separator: ", "))"
     }
@@ -66,8 +66,12 @@ public final class ColorsParser: Parser {
   func register(parser: ColorsFileTypeParser.Type) {
     for ext in parser.extensions {
       if let old = parsers[ext] {
-        warningHandler?("error: Parser \(parser) tried to register the file type '\(ext)' already" +
-          "registered by \(old).", #file, #line)
+        warningHandler?("""
+          error: Parser \(parser) tried to register the file type '\(ext)' already \
+          registered by \(old).
+          """,
+          #file,
+          #line)
       }
       parsers[ext] = parser
     }
@@ -112,9 +116,9 @@ extension NSColor {
   var hexValue: UInt32 {
     guard let rgb = rgbColor else { return 0 }
 
-    let hexRed   = UInt32(round(rgb.redComponent   * 0xFF)) << 24
+    let hexRed = UInt32(round(rgb.redComponent * 0xFF)) << 24
     let hexGreen = UInt32(round(rgb.greenComponent * 0xFF)) << 16
-    let hexBlue  = UInt32(round(rgb.blueComponent  * 0xFF)) << 8
+    let hexBlue = UInt32(round(rgb.blueComponent * 0xFF)) << 8
     let hexAlpha = UInt32(round(rgb.alphaComponent * 0xFF))
 
     return hexRed | hexGreen | hexBlue | hexAlpha

--- a/Sources/SwiftGenKit/Parsers/ColorsParser.swift
+++ b/Sources/SwiftGenKit/Parsers/ColorsParser.swift
@@ -20,8 +20,10 @@ public enum ColorsParserError: Error, CustomStringConvertible {
     case let .invalidFile(path, reason):
       return "error: Unable to parse file at \(path). \(reason)"
     case let .unsupportedFileType(path, supported):
-      return "error: Unsupported file type for \(path). " +
-        "The supported file types are: \(supported.joined(separator: ", "))"
+      return """
+        error: Unsupported file type for \(path). \
+        The supported file types are: \(supported.joined(separator: ", "))
+        """
     }
   }
 }

--- a/Sources/SwiftGenKit/Parsers/FontsParser.swift
+++ b/Sources/SwiftGenKit/Parsers/FontsParser.swift
@@ -5,8 +5,8 @@
 // MIT License
 //
 
-import Foundation
 import AppKit.NSFont
+import Foundation
 import PathKit
 
 // MARK: Font
@@ -55,13 +55,13 @@ extension CTFont {
     let descs = CTFontManagerCreateFontDescriptorsFromURL(file.url as CFURL) as NSArray?
     guard let descRefs = (descs as? [CTFontDescriptor]) else { return [] }
 
-    return descRefs.flatMap { (desc) -> Font? in
+    return descRefs.flatMap { desc -> Font? in
       let font = CTFontCreateWithFontDescriptorAndOptions(desc, 0.0, nil, [.preventAutoActivation])
       let postScriptName = CTFontCopyPostScriptName(font) as String
       guard let familyName = CTFontCopyAttribute(font, kCTFontFamilyNameAttribute) as? String,
         let style = CTFontCopyAttribute(font, kCTFontStyleNameAttribute) as? String else { return nil }
 
-      let relPath = parent.flatMap({ file.relative(to: $0) }) ?? file
+      let relPath = parent.flatMap { file.relative(to: $0) } ?? file
       return Font(
         filePath: relPath.string,
         familyName: familyName,

--- a/Sources/SwiftGenKit/Parsers/StoryboardParser.swift
+++ b/Sources/SwiftGenKit/Parsers/StoryboardParser.swift
@@ -16,8 +16,10 @@ private enum XML {
       return "/document/scenes/scene/objects/*[@sceneMemberID=\"viewController\" and @id=\"\(identifier)\"]"
     }
     static func sceneXPath(initial: String) -> String {
-      return "/document/scenes/scene/objects/*[@sceneMemberID=\"viewController\" and " +
-        "string-length(@storyboardIdentifier) > 0]"
+      return """
+        /document/scenes/scene/objects/*[@sceneMemberID=\"viewController\" and \
+        string-length(@storyboardIdentifier) > 0]
+        """
     }
     static let placeholderTag = "viewControllerPlaceholder"
     static let customClassAttribute = "customClass"

--- a/Sources/SwiftGenKit/Parsers/StringsParser.swift
+++ b/Sources/SwiftGenKit/Parsers/StringsParser.swift
@@ -15,13 +15,13 @@ public enum StringsParserError: Error, CustomStringConvertible {
 
   public var description: String {
     switch self {
-    case let .duplicateTable(name):
+    case .duplicateTable(let name):
       return "Table \"\(name)\" already loaded, cannot add it again"
-    case let .failureOnLoading(path):
+    case .failureOnLoading(let path):
       return "Failed to load a file at \"\(path)\""
     case .invalidFormat:
       return "Invalid strings file"
-    case let .invalidPlaceholder(previous, new):
+    case .invalidPlaceholder(let previous, let new):
       return "Invalid placeholder type \(new) (previous: \(previous))"
     }
   }

--- a/Sources/SwiftGenKit/Parsers/StringsParser.swift
+++ b/Sources/SwiftGenKit/Parsers/StringsParser.swift
@@ -15,13 +15,13 @@ public enum StringsParserError: Error, CustomStringConvertible {
 
   public var description: String {
     switch self {
-    case .duplicateTable(let name):
+    case let .duplicateTable(name):
       return "Table \"\(name)\" already loaded, cannot add it again"
-    case .failureOnLoading(let path):
+    case let .failureOnLoading(path):
       return "Failed to load a file at \"\(path)\""
     case .invalidFormat:
       return "Invalid strings file"
-    case .invalidPlaceholder(let previous, let new):
+    case let .invalidPlaceholder(previous, new):
       return "Invalid placeholder type \(new) (previous: \(previous))"
     }
   }
@@ -146,7 +146,7 @@ public final class StringsParser: Parser {
 
     // Extract the list of chars (conversion specifiers) and their optional positional specifier
     let chars = formatTypesRegEx.matches(in: formatString, options: [], range: range)
-      .map({ match -> (String, Int?) in
+      .map { match -> (String, Int?) in
         let range: NSRange
         if match.range(at: 3).location != NSNotFound {
           // [dioux] are in range #3 because in #2 there may be length modifiers (like in "lld")
@@ -163,11 +163,11 @@ public final class StringsParser: Parser {
           return (char, nil)
         } else {
           // Remove the "$" at the end of the positional specifier, and convert to Int
-          let posRange1 = NSRange(location: posRange.location, length: posRange.length-1)
+          let posRange1 = NSRange(location: posRange.location, length: posRange.length - 1)
           let pos = (formatString as NSString).substring(with: posRange1)
           return (char, Int(pos))
         }
-    })
+      }
 
     // enumerate the conversion specifiers and their optionally forced position
     // and build the array of PlaceholderTypes accordingly
@@ -183,14 +183,14 @@ public final class StringsParser: Parser {
           nextNonPositional += 1
         }
         if insertionPos > 0 {
-          while list.count <= insertionPos-1 {
+          while list.count <= insertionPos - 1 {
             list.append(.unknown)
           }
-          let previous = list[insertionPos-1]
+          let previous = list[insertionPos - 1]
           guard previous == .unknown || previous == p else {
             throw StringsParserError.invalidPlaceholder(previous: previous, new: p)
           }
-          list[insertionPos-1] = p
+          list[insertionPos - 1] = p
         }
       }
     }

--- a/Sources/SwiftGenKit/Stencil/AssetsCatalogContext.swift
+++ b/Sources/SwiftGenKit/Stencil/AssetsCatalogContext.swift
@@ -42,19 +42,19 @@ extension AssetsCatalogParser {
   private func structure(entries: [Catalog.Entry]) -> [[String: Any]] {
     return entries.map { entry in
       switch entry {
-      case let .group(name: name, items: items):
+      case .group(let name, let items):
         return [
           "type": "group",
           "name": name,
           "items": structure(entries: items)
         ]
-      case let .color(name: name, value: value):
+      case .color(let name, let value):
         return [
           "type": "color",
           "name": name,
           "value": value
         ]
-      case let .image(name: name, value: value):
+      case .image(let name, let value):
         return [
           "type": "image",
           "name": name,

--- a/Sources/SwiftGenKit/Stencil/AssetsCatalogContext.swift
+++ b/Sources/SwiftGenKit/Stencil/AssetsCatalogContext.swift
@@ -28,11 +28,11 @@ extension AssetsCatalogParser {
     let catalogs = self.catalogs
       .sorted { lhs, rhs in lhs.name < rhs.name }
       .map { catalog -> [String: Any] in
-        return [
+        [
           "name": catalog.name,
           "assets": structure(entries: catalog.entries)
         ]
-    }
+      }
 
     return [
       "catalogs": catalogs

--- a/Sources/SwiftGenKit/Stencil/ColorsContext.swift
+++ b/Sources/SwiftGenKit/Stencil/ColorsContext.swift
@@ -19,7 +19,7 @@ import Foundation
 extension ColorsParser {
   public func stencilContext() -> [String: Any] {
     let palettes: [[String: Any]] = self.palettes
-      .sorted(by: { $0.name < $1.name })
+      .sorted { $0.name < $1.name }
       .map { palette in
         let colors = palette.colors
           .sorted { $0.key < $1.key }
@@ -29,7 +29,7 @@ extension ColorsParser {
           "name": palette.name,
           "colors": colors
         ]
-    }
+      }
 
     return [
       "palettes": palettes
@@ -40,7 +40,7 @@ extension ColorsParser {
     let name = name.trimmingCharacters(in: .whitespaces)
     let hex = "00000000" + String(value, radix: 16)
     let hexChars = Array(hex.suffix(8))
-    let comps = (0..<4).map { idx in String(hexChars[idx*2...idx*2+1]) }
+    let comps = (0..<4).map { idx in String(hexChars[(idx * 2)...(idx * 2 + 1)]) }
 
     return [
       "name": name,

--- a/Sources/SwiftGenKit/Stencil/StoryboardsContext.swift
+++ b/Sources/SwiftGenKit/Stencil/StoryboardsContext.swift
@@ -34,7 +34,7 @@ private func uppercaseFirst(_ string: String) -> String {
 extension StoryboardParser {
   public func stencilContext() -> [String: Any] {
     let storyboards = self.storyboards
-      .sorted { (lhs, rhs) in lhs.name < rhs.name }
+      .sorted { lhs, rhs in lhs.name < rhs.name }
       .map(map(storyboard:))
     return [
       "modules": modules.sorted(),

--- a/Sources/SwiftGenKit/Stencil/StringsContext.swift
+++ b/Sources/SwiftGenKit/Stencil/StringsContext.swift
@@ -39,7 +39,7 @@ extension StringsParser {
         "translation": entry.translation.newlineEscaped
       ]
 
-      if entry.types.count > 0 {
+      if !entry.types.isEmpty {
         result["types"] = entry.types.map { $0.rawValue }
       }
 
@@ -47,7 +47,7 @@ extension StringsParser {
     }
 
     let tables = self.tables.map { name, entries in
-      return [
+      [
         "name": name,
         "levels": structure(
           entries: entries,
@@ -63,7 +63,7 @@ extension StringsParser {
 
   private func normalize(_ string: String) -> String {
     let components = string.components(separatedBy: CharacterSet(charactersIn: "-_"))
-    return components.map { $0.capitalized }.joined(separator: "")
+    return components.map { $0.capitalized }.joined()
   }
 
   typealias Mapper = (_ entry: Entry, _ keyPath: [String]) -> [String: Any]
@@ -75,7 +75,7 @@ extension StringsParser {
     var structuredStrings: [String: Any] = [:]
 
     let strings = entries
-      .filter { $0.keyStructure.count == keyPath.count+1 }
+      .filter { $0.keyStructure.count == keyPath.count + 1 }
       .sorted { $0.key.lowercased() < $1.key.lowercased() }
       .map { mapper($0, keyPath) }
 
@@ -89,15 +89,15 @@ extension StringsParser {
 
     var children: [[String: Any]] = []
     let nextLevelKeyPaths: [[String]] = entries
-      .filter({ $0.keyStructure.count > keyPath.count+1 })
-      .map({ Array($0.keyStructure.prefix(keyPath.count+1)) })
+      .filter { $0.keyStructure.count > keyPath.count + 1 }
+      .map { Array($0.keyStructure.prefix(keyPath.count + 1)) }
 
     // make key paths unique
     let uniqueNextLevelKeyPaths = Array(Set(
       nextLevelKeyPaths.map { keyPath in
-        keyPath.map({
+        keyPath.map {
           $0.capitalized.replacingOccurrences(of: "-", with: "_")
-        }).joined(separator: ".")
+        }.joined(separator: ".")
       }))
       .sorted()
       .map { $0.components(separatedBy: ".") }

--- a/Tests/SwiftGenKitTests/AssetCatalogTests.swift
+++ b/Tests/SwiftGenKitTests/AssetCatalogTests.swift
@@ -4,9 +4,9 @@
 // MIT Licence
 //
 
-import XCTest
-import SwiftGenKit
 import PathKit
+import SwiftGenKit
+import XCTest
 
 class AssetCatalogTests: XCTestCase {
   func testEmpty() {

--- a/Tests/SwiftGenKitTests/ColorsCLRFileTests.swift
+++ b/Tests/SwiftGenKitTests/ColorsCLRFileTests.swift
@@ -4,9 +4,9 @@
 // MIT Licence
 //
 
-import XCTest
 import PathKit
 @testable import SwiftGenKit
+import XCTest
 
 class ColorsCLRFileTests: XCTestCase {
   func testFileWithDefaults() throws {

--- a/Tests/SwiftGenKitTests/ColorsJSONFileTests.swift
+++ b/Tests/SwiftGenKitTests/ColorsJSONFileTests.swift
@@ -4,9 +4,9 @@
 // MIT Licence
 //
 
-import XCTest
 import PathKit
 @testable import SwiftGenKit
+import XCTest
 
 class ColorsJSONFileTests: XCTestCase {
   func testFileWithDefaults() throws {

--- a/Tests/SwiftGenKitTests/ColorsTests.swift
+++ b/Tests/SwiftGenKitTests/ColorsTests.swift
@@ -5,8 +5,8 @@
 //
 
 import PathKit
-import XCTest
 @testable import SwiftGenKit
+import XCTest
 
 final class TestFileParser1: ColorsFileTypeParser {
   static let extensions = ["test1"]

--- a/Tests/SwiftGenKitTests/ColorsTextFileTests.swift
+++ b/Tests/SwiftGenKitTests/ColorsTextFileTests.swift
@@ -4,9 +4,9 @@
 // MIT Licence
 //
 
-import XCTest
 import PathKit
 @testable import SwiftGenKit
+import XCTest
 
 class ColorsTextFileTests: XCTestCase {
   func testFileWithDefaults() throws {

--- a/Tests/SwiftGenKitTests/ColorsXMLFileTests.swift
+++ b/Tests/SwiftGenKitTests/ColorsXMLFileTests.swift
@@ -4,9 +4,9 @@
 // MIT Licence
 //
 
-import XCTest
 import PathKit
 @testable import SwiftGenKit
+import XCTest
 
 class ColorsXMLFileTests: XCTestCase {
   func testFileWithDefaults() throws {

--- a/Tests/SwiftGenKitTests/FontsTests.swift
+++ b/Tests/SwiftGenKitTests/FontsTests.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2017 AliSoftware. All rights reserved.
 //
 
-import XCTest
-@testable import SwiftGenKit
-import PathKit
 import AppKit.NSFont
+import PathKit
+@testable import SwiftGenKit
+import XCTest
 
 class FontsTests: XCTestCase {
   func testEmpty() {

--- a/Tests/SwiftGenKitTests/StoryboardsMacOSTests.swift
+++ b/Tests/SwiftGenKitTests/StoryboardsMacOSTests.swift
@@ -4,8 +4,8 @@
 // MIT Licence
 //
 
-import XCTest
 import SwiftGenKit
+import XCTest
 
 /**
  * Important: In order for the "*.storyboard" files in fixtures/ to be copied as-is in the test bundle

--- a/Tests/SwiftGenKitTests/StoryboardsiOSTests.swift
+++ b/Tests/SwiftGenKitTests/StoryboardsiOSTests.swift
@@ -4,8 +4,8 @@
 // MIT Licence
 //
 
-import XCTest
 import SwiftGenKit
+import XCTest
 
 /**
  * Important: In order for the "*.storyboard" files in fixtures/ to be copied as-is in the test bundle

--- a/Tests/SwiftGenKitTests/StringParserTests.swift
+++ b/Tests/SwiftGenKitTests/StringParserTests.swift
@@ -4,8 +4,8 @@
 // MIT Licence
 //
 
-import XCTest
 import SwiftGenKit
+import XCTest
 
 class StringParserTests: XCTestCase {
   func testParseStringPlaceholder() throws {

--- a/Tests/SwiftGenKitTests/StringsTests.swift
+++ b/Tests/SwiftGenKitTests/StringsTests.swift
@@ -4,8 +4,8 @@
 // MIT Licence
 //
 
-import XCTest
 import SwiftGenKit
+import XCTest
 
 /**
  * Important: In order for the "*.strings" files in fixtures/ to be copied as-is in the test bundle

--- a/Tests/SwiftGenKitTests/TestsHelper.swift
+++ b/Tests/SwiftGenKitTests/TestsHelper.swift
@@ -70,7 +70,14 @@ func diff(_ result: [String: Any], _ expected: [String: Any], path: String = "")
     let lhs = result.keys.map { " - \($0): \(result[$0] ?? "")" }.joined(separator: "\n")
     let rhs = expected.keys.map { " - \($0): \(expected[$0] ?? "")" }.joined(separator: "\n")
     let path = (path != "") ? " at '\(path)'" : ""
-    return "\(msgColor)Keys do not match\(path):\(reset)\n>>>>>> result\n\(lhs)\n======\n\(rhs)\n<<<<<< expected"
+    return """
+      \(msgColor)Keys do not match\(path):\(reset)
+      >>>>>> result
+      \(lhs)
+      ======
+      \(rhs)
+      <<<<<< expected
+      """
   }
 
   // check values

--- a/Tests/SwiftGenKitTests/TestsHelper.swift
+++ b/Tests/SwiftGenKitTests/TestsHelper.swift
@@ -5,8 +5,8 @@
 //
 
 import Foundation
-import XCTest
 import PathKit
+import XCTest
 
 private let colorCode: (String) -> String =
   ProcessInfo().environment["XcodeColors"] == "YES" ? { "\u{001b}[\($0);" } : { _ in "" }
@@ -32,14 +32,14 @@ private func diff(_ result: String, _ expected: String) -> String? {
   }
   if let badLineIdx = firstDiff {
     let slice = { (lines: [String], context: Int) -> ArraySlice<String> in
-      let start = max(0, badLineIdx-context)
-      let end = min(badLineIdx+context, lines.count-1)
+      let start = max(0, badLineIdx - context)
+      let end = min(badLineIdx + context, lines.count - 1)
       return lines[start...end]
     }
     let addLineNumbers = { (slice: ArraySlice) -> [String] in
       slice.enumerated().map { (idx: Int, line: String) in
         let num = idx + slice.startIndex
-        let lineNum = "\(num+1)".padding(toLength: 3, withPad: " ", startingAt: 0) + "|"
+        let lineNum = "\(num + 1)".padding(toLength: 3, withPad: " ", startingAt: 0) + "|"
         let clr = num == badLineIdx ? koCode : okCode
         return "\(clr.num)\(lineNum)\(reset)\(clr.code)\(line)\(reset)"
       }

--- a/Tests/SwiftGenTests/ConfigLintTests.swift
+++ b/Tests/SwiftGenTests/ConfigLintTests.swift
@@ -34,9 +34,11 @@ class ConfigLintTests: XCTestCase {
     }
     XCTAssertTrue(
       missingLogs.isEmpty,
-      "\(assertionMessage)\n" +
-        "The following logs were expected but never received:\n" +
-        missingLogs.map { "\($0) - \($1)" }.joined(separator: "\n"),
+      """
+      \(assertionMessage)
+      The following logs were expected but never received:
+      \(missingLogs.map { "\($0) - \($1)" }.joined(separator: "\n"))
+      """,
       file: file,
       line: line
     )
@@ -85,8 +87,11 @@ class ConfigLintTests: XCTestCase {
   }
 
   func testLintMissingTemplateNameAndPath() {
-    let errorMsg = "You must specify a template name (-t) or path (-p).\n\n" +
-    "To list all the available named templates, use 'swiftgen templates list'."
+    let errorMsg = """
+      You must specify a template name (-t) or path (-p).
+
+      To list all the available named templates, use 'swiftgen templates list'.
+      """
     _testLint(
       fixture: "config-missing-template",
       expectedLogs: [(.error, errorMsg)],
@@ -95,8 +100,10 @@ class ConfigLintTests: XCTestCase {
   }
 
   func testLintBothTemplateNameAndPath() {
-    let errorMsg = "You need to choose EITHER a named template OR a template path. " +
-    "Found name 'template' and path 'template.swift'"
+    let errorMsg = """
+      You need to choose EITHER a named template OR a template path. \
+      Found name 'template' and path 'template.swift'
+      """
     _testLint(
       fixture: "config-both-templates",
       expectedLogs: [(.error, errorMsg)],

--- a/Tests/SwiftGenTests/ConfigLintTests.swift
+++ b/Tests/SwiftGenTests/ConfigLintTests.swift
@@ -4,12 +4,15 @@
 // MIT Licence
 //
 
-import XCTest
 import PathKit
+import XCTest
 
 class ConfigLintTests: XCTestCase {
-  private func _testLint(fixture: String, expectedLogs: [(LogLevel, String)], assertionMessage: String,
-                         file: StaticString = #file, line: UInt = #line) {
+  private func _testLint(fixture: String,
+                         expectedLogs: [(LogLevel, String)],
+                         assertionMessage: String,
+                         file: StaticString = #file,
+                         line: UInt = #line) {
     guard let path = Bundle(for: type(of: self)).path(forResource: fixture, ofType: "yml") else {
       fatalError("Fixture \(fixture) not found")
     }
@@ -33,8 +36,9 @@ class ConfigLintTests: XCTestCase {
       missingLogs.isEmpty,
       "\(assertionMessage)\n" +
         "The following logs were expected but never received:\n" +
-        missingLogs.map({ "\($0) - \($1)" }).joined(separator: "\n"),
-      file: file, line: line
+        missingLogs.map { "\($0) - \($1)" }.joined(separator: "\n"),
+      file: file,
+      line: line
     )
   }
 

--- a/Tests/SwiftGenTests/ConfigReadTests.swift
+++ b/Tests/SwiftGenTests/ConfigReadTests.swift
@@ -93,10 +93,15 @@ class ConfigReadTests: XCTestCase {
   func testReadInvalidConfigThrows() {
     let badConfigs = [
       "config-missing-paths": "Missing entry for key strings.paths.",
-      "config-missing-template": "You must specify a template name (-t) or path (-p).\n\n" +
-      "To list all the available named templates, use 'swiftgen templates list'.",
-      "config-both-templates": "You need to choose EITHER a named template OR a template path. " +
-      "Found name 'template' and path 'template.swift'",
+      "config-missing-template": """
+        You must specify a template name (-t) or path (-p).
+
+        To list all the available named templates, use 'swiftgen templates list'.
+        """,
+      "config-both-templates": """
+        You need to choose EITHER a named template OR a template path. \
+        Found name 'template' and path 'template.swift'
+        """,
       "config-missing-output": "Missing entry for key strings.output.",
       "config-invalid-structure": "Wrong type for key strings.paths: expected Path or array of Paths, got Array<Any>.",
       "config-invalid-template": "Wrong type for key strings.templateName: expected String, got Array<Any>.",
@@ -108,14 +113,18 @@ class ConfigReadTests: XCTestCase {
           fatalError("Fixture not found")
         }
         _ = try Config(file: Path(path))
-        XCTFail("Trying to parse config file \(configFile) should have thrown " +
-          "error \(expectedError) but didn't throw at all")
+        XCTFail("""
+          Trying to parse config file \(configFile) should have thrown \
+          error \(expectedError) but didn't throw at all
+          """)
       } catch let e {
         XCTAssertEqual(
           String(describing: e),
           expectedError,
-          "Trying to parse config file \(configFile) should have thrown " +
-          "error \(expectedError) but threw \(e) instead."
+          """
+          Trying to parse config file \(configFile) should have thrown \
+          error \(expectedError) but threw \(e) instead.
+          """
         )
       }
     }

--- a/Tests/SwiftGenTests/ConfigReadTests.swift
+++ b/Tests/SwiftGenTests/ConfigReadTests.swift
@@ -4,8 +4,8 @@
 // MIT Licence
 //
 
-import XCTest
 import PathKit
+import XCTest
 
 class ConfigReadTests: XCTestCase {
 
@@ -33,8 +33,7 @@ class ConfigReadTests: XCTestCase {
         "foo": 5,
         "bar": ["bar1": 1, "bar2": 2, "bar3": [3, 4, ["bar3a": 50]]],
         "baz": ["hello", "world"]
-        ]
-      )
+      ])
       XCTAssertEqual(entry.output, "strings.swift")
     } catch let e {
       XCTFail("Error: \(e)")
@@ -113,7 +112,8 @@ class ConfigReadTests: XCTestCase {
           "error \(expectedError) but didn't throw at all")
       } catch let e {
         XCTAssertEqual(
-          String(describing: e), expectedError,
+          String(describing: e),
+          expectedError,
           "Trying to parse config file \(configFile) should have thrown " +
           "error \(expectedError) but threw \(e) instead."
         )

--- a/Tests/SwiftGenTests/TestsHelper.swift
+++ b/Tests/SwiftGenTests/TestsHelper.swift
@@ -5,8 +5,8 @@
 //
 
 import Foundation
-import XCTest
 import PathKit
+import XCTest
 
 private let colorCode: (String) -> String =
   ProcessInfo().environment["XcodeColors"] == "YES" ? { "\u{001b}[\($0);" } : { _ in "" }
@@ -32,14 +32,14 @@ private func diff(_ result: String, _ expected: String) -> String? {
   }
   if let badLineIdx = firstDiff {
     let slice = { (lines: [String], context: Int) -> ArraySlice<String> in
-      let start = max(0, badLineIdx-context)
-      let end = min(badLineIdx+context, lines.count-1)
+      let start = max(0, badLineIdx - context)
+      let end = min(badLineIdx + context, lines.count - 1)
       return lines[start...end]
     }
     let addLineNumbers = { (slice: ArraySlice) -> [String] in
       slice.enumerated().map { (idx: Int, line: String) in
         let num = idx + slice.startIndex
-        let lineNum = "\(num+1)".padding(toLength: 3, withPad: " ", startingAt: 0) + "|"
+        let lineNum = "\(num + 1)".padding(toLength: 3, withPad: " ", startingAt: 0) + "|"
         let clr = num == badLineIdx ? koCode : okCode
         return "\(clr.num)\(lineNum)\(reset)\(clr.code)\(line)\(reset)"
       }
@@ -63,11 +63,15 @@ func XCTDiffStrings(_ result: String, _ expected: String, file: StaticString = #
   XCTFail(error, file: file, line: line)
 }
 
-func XCTAssertEqualDict(_ result: [String: Any]?, _ expected: [String: Any],
-                        file: StaticString = #file, line: UInt = #line) {
+func XCTAssertEqualDict(_ result: [String: Any]?,
+                        _ expected: [String: Any],
+                        file: StaticString = #file,
+                        line: UInt = #line) {
   if let dict = result {
     XCTAssertTrue(NSDictionary(dictionary: dict).isEqual(to: expected),
-                  "expected \(expected), got \(dict)", file: file, line: line)
+                  "expected \(expected), got \(dict)",
+                  file: file,
+                  line: line)
   } else {
     XCTAssertNotNil(result, file: file, line: line)
   }
@@ -76,8 +80,8 @@ func XCTAssertEqualDict(_ result: [String: Any]?, _ expected: [String: Any],
 extension TemplateRef: Equatable {
   static func == (lhs: TemplateRef, rhs: TemplateRef) -> Bool {
     switch (lhs, rhs) {
-    case (.name(let lname), .name(let rname)): return lname == rname
-    case (.path(let lpath), .path(let rpath)): return lpath == rpath
+    case let (.name(lname), .name(rname)): return lname == rname
+    case let (.path(lpath), .path(rpath)): return lpath == rpath
     case (.name, .path), (.path, .name): return false
     }
   }

--- a/Tests/SwiftGenTests/TestsHelper.swift
+++ b/Tests/SwiftGenTests/TestsHelper.swift
@@ -80,8 +80,8 @@ func XCTAssertEqualDict(_ result: [String: Any]?,
 extension TemplateRef: Equatable {
   static func == (lhs: TemplateRef, rhs: TemplateRef) -> Bool {
     switch (lhs, rhs) {
-    case let (.name(lname), .name(rname)): return lname == rname
-    case let (.path(lpath), .path(rpath)): return lpath == rpath
+    case (.name(let lname), .name(let rname)): return lname == rname
+    case (.path(let lpath), .path(let rpath)): return lpath == rpath
     case (.name, .path), (.path, .name): return false
     }
   }

--- a/Tests/TemplatesTests/TestsHelper.swift
+++ b/Tests/TemplatesTests/TestsHelper.swift
@@ -5,9 +5,9 @@
 //
 
 import Foundation
-import XCTest
 import PathKit
 import StencilSwiftKit
+import XCTest
 
 private let colorCode: (String) -> String =
   ProcessInfo().environment["XcodeColors"] == "YES" ? { "\u{001b}[\($0);" } : { _ in "" }
@@ -33,14 +33,14 @@ private func diff(_ result: String, _ expected: String) -> String? {
   }
   if let badLineIdx = firstDiff {
     let slice = { (lines: [String], context: Int) -> ArraySlice<String> in
-      let start = max(0, badLineIdx-context)
-      let end = min(badLineIdx+context, lines.count-1)
+      let start = max(0, badLineIdx - context)
+      let end = min(badLineIdx + context, lines.count - 1)
       return lines[start...end]
     }
     let addLineNumbers = { (slice: ArraySlice) -> [String] in
       slice.enumerated().map { (idx: Int, line: String) in
         let num = idx + slice.startIndex
-        let lineNum = "\(num+1)".padding(toLength: 3, withPad: " ", startingAt: 0) + "|"
+        let lineNum = "\(num + 1)".padding(toLength: 3, withPad: " ", startingAt: 0) + "|"
         let clr = num == badLineIdx ? koCode : okCode
         return "\(clr.num)\(lineNum)\(reset)\(clr.code)\(line)\(reset)"
       }


### PR DESCRIPTION
Been wanting to do this for a while, this enables a bunch of optional SwiftLint rules that ensures the codebase is a bit more consistent.

Note: built on top of #401, wait until that is merged.
Note: similar StencilSwiftKit PR is https://github.com/SwiftGen/StencilSwiftKit/pull/79