### PR TITLE
SPM and Mint support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ defaults:
         BUNDLE_RETRY: 3
   - &store-gems
     save_cache:
-      key: v1-gems-{{ checksum "Gemfile.lock" }}
+      key: gems-{{ checksum "Gemfile.lock" }}
       paths:
         - vendor/bundle
   - &fetch-xcode-logs
@@ -91,10 +91,19 @@ jobs:
       - *restore-gems
       - *install-gems
       - *store-gems
+      - restore_cache:
+          keys:
+            - homebrew-{{ checksum ".circleci/config.yml" }}
+            - homebrew-
       - run:
           name: Install libxml2
           command: brew upgrade python && brew install libxml2 && brew link --force libxml2
+      -  save_cache:
+          key: homebrew-{{ checksum ".circleci/config.yml" }}
+          paths:
+            - /usr/local/Homebrew
       - run:
+          # TODO: This should run the tests once SPM supports testing an executable
           name: Build with SPM
           command: bundle exec rake spm:build
       - *store-artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
           command: bundle exec rake lint:output
       - *store-artifacts
 
-  build-and-test:
+  xcode-build-and-test:
     <<: *default-config
     steps:
       - *prepare-storage
@@ -81,6 +81,22 @@ jobs:
       - store_test_results:
           path: /tmp/circleci-test-results
       - *fetch-xcode-logs
+      - *store-artifacts
+
+  spm-build-and-test:
+    <<: *default-config
+    steps:
+      - *prepare-storage
+      - checkout
+      - *restore-gems
+      - *install-gems
+      - *store-gems
+      - run:
+          name: Install libxml2
+          command: brew upgrade python && brew install libxml2 && brew link --force libxml2
+      - run:
+          name: Build with SPM
+          command: bundle exec rake spm:build
       - *store-artifacts
 
   compile-output:
@@ -117,13 +133,16 @@ workflows:
   version: 2
   lint-buildandtest-compileoutput-checkdeploy:
     jobs:
-      - build-and-test
       - lint
+      - spm-build-and-test
+      - xcode-build-and-test
       - compile-output:
           requires:
-            - build-and-test
             - lint
+            - spm-build-and-test
+            - xcode-build-and-test
       - check-deploy:
           requires:
-            - build-and-test
             - lint
+            - spm-build-and-test
+            - xcode-build-and-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@
 * Add ability to list all custom fonts and register them using `FontFamily.registerAllCustomFonts`.  
   [Olivier Halligon](https://github.com/AliSoftware)
   [#394](https://github.com/SwiftGen/SwiftGen/issues/394)
+* Add support for Swift Package Manager and Mint.  
+  [Yonas Kolb](https://github.com/yonaskolb)
+  [#411](https://github.com/SwiftGen/SwiftGen/pull/411)
 
 ### Internal Changes
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,79 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Commander",
+        "repositoryURL": "https://github.com/kylef/Commander.git",
+        "state": {
+          "branch": null,
+          "revision": "e5b50ad7b2e91eeb828393e89b03577b16be7db9",
+          "version": "0.8.0"
+        }
+      },
+      {
+        "package": "Kanna",
+        "repositoryURL": "https://github.com/tid-kijyun/Kanna.git",
+        "state": {
+          "branch": null,
+          "revision": "44b169e1698d596f2eed698d8a67558fb0542b2a",
+          "version": "4.0.0"
+        }
+      },
+      {
+        "package": "PathKit",
+        "repositoryURL": "https://github.com/kylef/PathKit.git",
+        "state": {
+          "branch": null,
+          "revision": "fa81fa9e3a9f59645159c4ea45c0c46ee6558f71",
+          "version": "0.9.1"
+        }
+      },
+      {
+        "package": "Spectre",
+        "repositoryURL": "https://github.com/kylef/Spectre.git",
+        "state": {
+          "branch": null,
+          "revision": "e34d5687e1e9d865e3527dd58bc2f7464ef6d936",
+          "version": "0.8.0"
+        }
+      },
+      {
+        "package": "Stencil",
+        "repositoryURL": "https://github.com/kylef/Stencil.git",
+        "state": {
+          "branch": null,
+          "revision": "c2e25f25acfbe24442809c055141d8323af8f6cc",
+          "version": "0.11.0"
+        }
+      },
+      {
+        "package": "StencilSwiftKit",
+        "repositoryURL": "https://github.com/SwiftGen/StencilSwiftKit.git",
+        "state": {
+          "branch": "master",
+          "revision": "008100ad4ca1a89269a53f03f8a65c1e5ec2a052",
+          "version": null
+        }
+      },
+      {
+        "package": "SwiftClibxml2",
+        "repositoryURL": "https://github.com/tid-kijyun/SwiftClibxml2.git",
+        "state": {
+          "branch": null,
+          "revision": "c4e67cc970273fc2bee978d12e422974ff184de7",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "package": "Yams",
+        "repositoryURL": "https://github.com/jpsim/Yams.git",
+        "state": {
+          "branch": null,
+          "revision": "6652aa7b793d3c8a075db0614acb575fcaecf457",
+          "version": "0.7.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.resources
+++ b/Package.resources
@@ -1,0 +1,1 @@
+templates

--- a/Package.swift
+++ b/Package.swift
@@ -27,13 +27,17 @@ let package = Package(
         ]),
         .target(name: "SwiftGenKit", dependencies: [
           "PathKit",
-          "StencilSwiftKit",
-        ]),
-        .testTarget(name: "SwiftGenTests", dependencies: [
-          "SwiftGen",
+          "StencilSwiftKit"
         ]),
         .testTarget(name: "SwiftGenKitTests", dependencies: [
-          "SwiftGenKit",
+          "SwiftGenKit"
+        ]),
+        .testTarget(name: "SwiftGenTests", dependencies: [
+          "SwiftGen"
+        ]),
+        .testTarget(name: "TemplatesTests", dependencies: [
+          "StencilSwiftKit",
+          "SwiftGenKit"
         ])
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,39 @@
+// swift-tools-version:4.0
+import PackageDescription
+
+let package = Package(
+    name: "SwiftGen",
+    products: [
+        .executable(name: "swiftgen", targets: ["SwiftGen"]),
+        .library(name: "SwiftGenKit", targets: ["SwiftGenKit"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/kylef/Commander.git", from: "0.8.0"),
+        .package(url: "https://github.com/kylef/PathKit.git", from: "0.8.0"),
+        .package(url: "https://github.com/kylef/Stencil.git", from: "0.11.0"),
+        .package(url: "https://github.com/jpsim/Yams.git", from: "0.7.0"),
+        .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", .branchItem("master")),
+        .package(url: "https://github.com/tid-kijyun/Kanna.git", from: "4.0.0"),
+        .package(url: "https://github.com/tid-kijyun/SwiftClibxml2.git", from: "1.0.0")
+    ],
+    targets: [
+        .target(name: "SwiftGen", dependencies: [
+          "Commander",
+          "Kanna",
+          "PathKit",
+          "Stencil",
+          "SwiftGenKit",
+          "Yams"
+        ]),
+        .target(name: "SwiftGenKit", dependencies: [
+          "PathKit",
+          "StencilSwiftKit",
+        ]),
+        .testTarget(name: "SwiftGenTests", dependencies: [
+          "SwiftGen",
+        ]),
+        .testTarget(name: "SwiftGenKitTests", dependencies: [
+          "SwiftGenKit",
+        ])
+    ]
+)

--- a/Sources/SwiftGen/Commander/ConfigCommands.swift
+++ b/Sources/SwiftGen/Commander/ConfigCommands.swift
@@ -11,7 +11,7 @@ import PathKit
 import StencilSwiftKit
 import SwiftGenKit
 
-extension Config.Entry {
+extension ConfigEntry {
   func checkPaths() throws {
     for inputPath in self.paths {
       guard inputPath.exists else {

--- a/Sources/SwiftGen/Common.swift
+++ b/Sources/SwiftGen/Common.swift
@@ -1,0 +1,15 @@
+//
+// SwiftGen
+// Copyright (c) 2015 Olivier Halligon
+// MIT Licence
+//
+
+import Commander
+import Foundation
+
+let outputOption = Option(
+  "output",
+  default: OutputDestination.console,
+  flag: "o",
+  description: "The path to the file to generate (Omit to generate to stdout)"
+)

--- a/Sources/SwiftGen/Config/Config.swift
+++ b/Sources/SwiftGen/Config/Config.swift
@@ -19,7 +19,7 @@ struct Config {
 
   let inputDir: Path?
   let outputDir: Path?
-  let commands: [String: [Config.Entry]]
+  let commands: [String: [ConfigEntry]]
 }
 
 extension Config {
@@ -34,11 +34,11 @@ extension Config {
     }
     self.inputDir = (config[Keys.inputDir] as? String).map { Path($0) }
     self.outputDir = (config[Keys.outputDir] as? String).map { Path($0) }
-    var cmds: [String: [Config.Entry]] = [:]
+    var cmds: [String: [ConfigEntry]] = [:]
     for parserCmd in allParserCommands {
       if let cmdEntry = config[parserCmd.name] {
         do {
-          cmds[parserCmd.name] = try Config.Entry.parseCommandEntry(yaml: cmdEntry)
+          cmds[parserCmd.name] = try ConfigEntry.parseCommandEntry(yaml: cmdEntry)
         } catch let error as Config.Error {
           // Prefix the name of the command for a better error message
           throw error.withKeyPrefixed(by: parserCmd.name)

--- a/Sources/SwiftGen/Config/ConfigEntry.swift
+++ b/Sources/SwiftGen/Config/ConfigEntry.swift
@@ -11,6 +11,10 @@ import enum StencilSwiftKit.Parameters
 
 // MARK: - Config.Entry
 
+// Note: there's a bug in SPM which causes compilation to fail because of the compilation order.
+// Once it is fixed, we should move `ConfigEntry` back into an extension of `Config`.
+// https://bugs.swift.org/browse/SR-5734
+
 struct ConfigEntry {
   enum Keys {
     static let paths = "paths"

--- a/Sources/SwiftGen/Path+AppSupport.swift
+++ b/Sources/SwiftGen/Path+AppSupport.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2017 AliSoftware. All rights reserved.
 //
 
+import Foundation
 import PathKit
 
 extension Path {

--- a/Sources/SwiftGen/main.swift
+++ b/Sources/SwiftGen/main.swift
@@ -5,6 +5,7 @@
 //
 
 import Commander
+import Foundation
 import PathKit
 import Stencil
 import StencilSwiftKit

--- a/Sources/SwiftGen/main.swift
+++ b/Sources/SwiftGen/main.swift
@@ -11,15 +11,6 @@ import Stencil
 import StencilSwiftKit
 import SwiftGenKit
 
-// MARK: Common
-
-let outputOption = Option(
-  "output",
-  default: OutputDestination.console,
-  flag: "o",
-  description: "The path to the file to generate (Omit to generate to stdout)"
-)
-
 // MARK: - Main
 
 let main = Group {

--- a/Sources/SwiftGenKit/Parsers/Colors/ColorsCLRFileParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Colors/ColorsCLRFileParser.swift
@@ -4,6 +4,7 @@
 // MIT Licence
 //
 
+import AppKit
 import Foundation
 import PathKit
 

--- a/Sources/SwiftGenKit/Parsers/Colors/ColorsFileTypeParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Colors/ColorsFileTypeParser.swift
@@ -4,6 +4,7 @@
 // MIT Licence
 //
 
+import AppKit
 import Foundation
 import PathKit
 

--- a/SwiftGen.xcodeproj/project.pbxproj
+++ b/SwiftGen.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		DD428E261FC50FBF001649D6 /* InterfaceBuilderContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD428E161FC50FBF001649D6 /* InterfaceBuilderContext.swift */; };
 		DD428E271FC50FBF001649D6 /* StringsContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD428E171FC50FBF001649D6 /* StringsContext.swift */; };
 		DD4738A81FE07596006CB6BB /* StencilContexts in Resources */ = {isa = PBXBuildFile; fileRef = DDDE52761FAF81DB004203BE /* StencilContexts */; };
+		DD59D13C2097E7B6000445E4 /* Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD59D13B2097E7B6000445E4 /* Common.swift */; };
 		DD906FA81EE777C600C29B8A /* ParserCLICommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD906FA71EE777C600C29B8A /* ParserCLICommands.swift */; };
 		DD9F687420955D0C004EB720 /* ColorsFileTypeParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9F687320955D0B004EB720 /* ColorsFileTypeParser.swift */; };
 		DD9F687A20955D51004EB720 /* CatalogEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9F687720955D51004EB720 /* CatalogEntry.swift */; };
@@ -293,6 +294,7 @@
 		DD428E161FC50FBF001649D6 /* InterfaceBuilderContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterfaceBuilderContext.swift; sourceTree = "<group>"; };
 		DD428E171FC50FBF001649D6 /* StringsContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringsContext.swift; sourceTree = "<group>"; };
 		DD428E181FC50FBF001649D6 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DD59D13B2097E7B6000445E4 /* Common.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Common.swift; sourceTree = "<group>"; };
 		DD906FA71EE777C600C29B8A /* ParserCLICommands.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParserCLICommands.swift; sourceTree = "<group>"; };
 		DD9F687320955D0B004EB720 /* ColorsFileTypeParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorsFileTypeParser.swift; sourceTree = "<group>"; };
 		DD9F687720955D51004EB720 /* CatalogEntry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CatalogEntry.swift; sourceTree = "<group>"; };
@@ -517,13 +519,14 @@
 		DD428DF21FC50D34001649D6 /* SwiftGen */ = {
 			isa = PBXGroup;
 			children = (
+				379C7E901F8ECB9700267096 /* Commander */,
+				09D00A001F9BB8730026A755 /* Config */,
 				09C7B2D31BCC382800D7F488 /* main.swift */,
+				DD59D13B2097E7B6000445E4 /* Common.swift */,
+				379C7E911F8ECC1A00267096 /* Logs.swift */,
 				0934050D1F815A8C00187787 /* ParserCLI.swift */,
 				379C7E8C1F8ECB2400267096 /* Path+AppSupport.swift */,
 				379C7E861F8ECA0C00267096 /* TemplateRef.swift */,
-				379C7E901F8ECB9700267096 /* Commander */,
-				09D00A001F9BB8730026A755 /* Config */,
-				379C7E911F8ECC1A00267096 /* Logs.swift */,
 			);
 			path = SwiftGen;
 			sourceTree = "<group>";
@@ -1323,6 +1326,7 @@
 			files = (
 				379C7E891F8ECA7000267096 /* OutputDestination.swift in Sources */,
 				234F7E7D1DEBD765001B3C10 /* main.swift in Sources */,
+				DD59D13C2097E7B6000445E4 /* Common.swift in Sources */,
 				234F7E7E1DEBD765001B3C10 /* Path+Commander.swift in Sources */,
 				234F7E7F1DEBD765001B3C10 /* TemplatesCommands.swift in Sources */,
 				09D009FF1F9BB3450026A755 /* ConfigEntry.swift in Sources */,

--- a/Tests/SwiftGenTests/ConfigLintTests.swift
+++ b/Tests/SwiftGenTests/ConfigLintTests.swift
@@ -5,6 +5,9 @@
 //
 
 import PathKit
+#if canImport(SwiftGen)
+@testable import SwiftGen
+#endif
 import XCTest
 
 class ConfigLintTests: XCTestCase {

--- a/Tests/SwiftGenTests/ConfigReadTests.swift
+++ b/Tests/SwiftGenTests/ConfigReadTests.swift
@@ -5,6 +5,9 @@
 //
 
 import PathKit
+#if canImport(SwiftGen)
+@testable import SwiftGen
+#endif
 import XCTest
 
 class ConfigReadTests: XCTestCase {

--- a/Tests/SwiftGenTests/TestsHelper.swift
+++ b/Tests/SwiftGenTests/TestsHelper.swift
@@ -6,6 +6,9 @@
 
 import Foundation
 import PathKit
+#if canImport(SwiftGen)
+@testable import SwiftGen
+#endif
 import XCTest
 
 private let colorCode: (String) -> String =
@@ -74,7 +77,7 @@ func XCTAssertEqualDict(_ result: [String: Any],
 }
 
 extension TemplateRef: Equatable {
-  static func == (lhs: TemplateRef, rhs: TemplateRef) -> Bool {
+  public static func == (lhs: TemplateRef, rhs: TemplateRef) -> Bool {
     switch (lhs, rhs) {
     case (.name(let lname), .name(let rname)): return lname == rname
     case (.path(let lpath), .path(let rpath)): return lpath == rpath


### PR DESCRIPTION
Resolves #335 

This adds support for building with the Swift Package Manager. It also adds a `Package.resources` file so that [Mint](https://github.com/yonaskolb/Mint) installations include all the bundled templates.

A couple of changes outside of the Package I had to make for this were:
* adding some explicit framework imports
* Moving `Config.Entry` to `ConfigEntry`. For some reason this wasn't building with SPM. Anyone know why? Luckily this is an internal API.

This can be tested with Mint
```
mint run swiftgen/swiftgen@spm swiftgen templates list
```

**Caveats**
At the moment `swift test` doesn't work, as there are some files manually included in the tests in the Xcode project that aren't adhering to the implied folder/module structure (eg Config). This would require some larger changes to get working. But these tests shouldn't really be needed anyway