### PR TITLE
Colors: support P3 display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@
 * Add ability to list all custom fonts and register them using `FontFamily.registerAllCustomFonts`.  
   [Olivier Halligon](https://github.com/AliSoftware)
   [#394](https://github.com/SwiftGen/SwiftGen/issues/394)
-
+* Add support for P3 display colorspace.  
+  [noppefoxwolf](https://github.com/noppefoxwolf)
+  [#413](https://github.com/SwiftGen/SwiftGen/pull/413)
 ### Internal Changes
 
 * Migrated to CircleCI 2.0.  

--- a/Tests/Fixtures/Generated/Colors/swift2-context-defaults-customname.swift
+++ b/Tests/Fixtures/Generated/Colors/swift2-context-defaults-customname.swift
@@ -19,7 +19,11 @@ internal extension XCTColor {
     let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
     let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
 
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
+    if #available(iOS 10.0, *) {
+      self.init(displayP3Red: red, green: green, blue: blue, alpha: alpha)
+    } else {
+      self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
   }
 }
 // swiftlint:enable operator_usage_whitespace

--- a/Tests/Fixtures/Generated/Colors/swift2-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Colors/swift2-context-defaults-publicAccess.swift
@@ -19,7 +19,11 @@ public extension Color {
     let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
     let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
 
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
+    if #available(iOS 10.0, *) {
+      self.init(displayP3Red: red, green: green, blue: blue, alpha: alpha)
+    } else {
+      self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
   }
 }
 // swiftlint:enable operator_usage_whitespace

--- a/Tests/Fixtures/Generated/Colors/swift2-context-defaults.swift
+++ b/Tests/Fixtures/Generated/Colors/swift2-context-defaults.swift
@@ -19,7 +19,11 @@ internal extension Color {
     let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
     let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
 
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
+    if #available(iOS 10.0, *) {
+      self.init(displayP3Red: red, green: green, blue: blue, alpha: alpha)
+    } else {
+      self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
   }
 }
 // swiftlint:enable operator_usage_whitespace

--- a/Tests/Fixtures/Generated/Colors/swift2-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Colors/swift2-context-multiple.swift
@@ -19,7 +19,11 @@ internal extension Color {
     let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
     let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
 
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
+    if #available(iOS 10.0, *) {
+      self.init(displayP3Red: red, green: green, blue: blue, alpha: alpha)
+    } else {
+      self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
   }
 }
 // swiftlint:enable operator_usage_whitespace

--- a/Tests/Fixtures/Generated/Colors/swift3-context-defaults-customname.swift
+++ b/Tests/Fixtures/Generated/Colors/swift3-context-defaults-customname.swift
@@ -19,7 +19,11 @@ internal extension XCTColor {
     let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
     let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
 
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
+    if #available(iOS 10.0, *) {
+      self.init(displayP3Red: red, green: green, blue: blue, alpha: alpha)
+    } else {
+      self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
   }
 }
 // swiftlint:enable operator_usage_whitespace

--- a/Tests/Fixtures/Generated/Colors/swift3-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Colors/swift3-context-defaults-publicAccess.swift
@@ -19,7 +19,11 @@ public extension Color {
     let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
     let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
 
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
+    if #available(iOS 10.0, *) {
+      self.init(displayP3Red: red, green: green, blue: blue, alpha: alpha)
+    } else {
+      self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
   }
 }
 // swiftlint:enable operator_usage_whitespace

--- a/Tests/Fixtures/Generated/Colors/swift3-context-defaults.swift
+++ b/Tests/Fixtures/Generated/Colors/swift3-context-defaults.swift
@@ -19,7 +19,11 @@ internal extension Color {
     let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
     let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
 
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
+    if #available(iOS 10.0, *) {
+      self.init(displayP3Red: red, green: green, blue: blue, alpha: alpha)
+    } else {
+      self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
   }
 }
 // swiftlint:enable operator_usage_whitespace

--- a/Tests/Fixtures/Generated/Colors/swift3-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Colors/swift3-context-multiple.swift
@@ -19,7 +19,11 @@ internal extension Color {
     let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
     let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
 
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
+    if #available(iOS 10.0, *) {
+      self.init(displayP3Red: red, green: green, blue: blue, alpha: alpha)
+    } else {
+      self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
   }
 }
 // swiftlint:enable operator_usage_whitespace

--- a/Tests/Fixtures/Generated/Colors/swift4-context-defaults-customname.swift
+++ b/Tests/Fixtures/Generated/Colors/swift4-context-defaults-customname.swift
@@ -19,7 +19,11 @@ internal extension XCTColor {
     let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
     let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
 
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
+    if #available(iOS 10.0, *) {
+      self.init(displayP3Red: red, green: green, blue: blue, alpha: alpha)
+    } else {
+      self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
   }
 }
 // swiftlint:enable operator_usage_whitespace

--- a/Tests/Fixtures/Generated/Colors/swift4-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Colors/swift4-context-defaults-publicAccess.swift
@@ -19,7 +19,11 @@ public extension Color {
     let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
     let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
 
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
+    if #available(iOS 10.0, *) {
+      self.init(displayP3Red: red, green: green, blue: blue, alpha: alpha)
+    } else {
+      self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
   }
 }
 // swiftlint:enable operator_usage_whitespace

--- a/Tests/Fixtures/Generated/Colors/swift4-context-defaults.swift
+++ b/Tests/Fixtures/Generated/Colors/swift4-context-defaults.swift
@@ -19,7 +19,11 @@ internal extension Color {
     let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
     let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
 
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
+    if #available(iOS 10.0, *) {
+      self.init(displayP3Red: red, green: green, blue: blue, alpha: alpha)
+    } else {
+      self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
   }
 }
 // swiftlint:enable operator_usage_whitespace

--- a/Tests/Fixtures/Generated/Colors/swift4-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Colors/swift4-context-multiple.swift
@@ -19,7 +19,11 @@ internal extension Color {
     let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
     let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
 
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
+    if #available(iOS 10.0, *) {
+      self.init(displayP3Red: red, green: green, blue: blue, alpha: alpha)
+    } else {
+      self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
   }
 }
 // swiftlint:enable operator_usage_whitespace

--- a/templates/colors/swift2.stencil
+++ b/templates/colors/swift2.stencil
@@ -22,7 +22,11 @@
     let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
     let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
 
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
+    if #available(iOS 10.0, *) {
+      self.init(displayP3Red: red, green: green, blue: blue, alpha: alpha)
+    } else {
+      self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
   }
 }
 // swiftlint:enable operator_usage_whitespace

--- a/templates/colors/swift3.stencil
+++ b/templates/colors/swift3.stencil
@@ -22,7 +22,11 @@
     let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
     let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
 
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
+    if #available(iOS 10.0, *) {
+      self.init(displayP3Red: red, green: green, blue: blue, alpha: alpha)
+    } else {
+      self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
   }
 }
 // swiftlint:enable operator_usage_whitespace

--- a/templates/colors/swift4.stencil
+++ b/templates/colors/swift4.stencil
@@ -22,7 +22,11 @@
     let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
     let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
 
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
+    if #available(iOS 10.0, *) {
+      self.init(displayP3Red: red, green: green, blue: blue, alpha: alpha)
+    } else {
+      self.init(red: red, green: green, blue: blue, alpha: alpha)
+    }
   }
 }
 // swiftlint:enable operator_usage_whitespace


### PR DESCRIPTION
This added support for p3 display colorspace.
UIColor instance created by `UIColor.init(displayP3Red:green:blue:alpha)` when iOS10+.

TODO: 
- [x] fix test