### PR TITLE
Disabled function_parameter_count rule SwiftLint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,9 +66,9 @@
   [David Jennes](https://github.com/djbe) 
   [#417](https://github.com/SwiftGen/SwiftGen/pull/417)
   [#422](https://github.com/SwiftGen/SwiftGen/pull/422)
-* Disabled a SwiftLint rule for function parameter count.
+* Disabled a SwiftLint rule for function parameter count.  
   [Oleg Gorbatchev](https://github.com/gorbat-o)
-  [#427](https://github.com/SwiftGen/SwiftGen/pull/417)
+  [#428](https://github.com/SwiftGen/SwiftGen/pull/428)
 
 ## 5.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@
   [David Jennes](https://github.com/djbe) 
   [#417](https://github.com/SwiftGen/SwiftGen/pull/417)
   [#422](https://github.com/SwiftGen/SwiftGen/pull/422)
+* Disabled a SwiftLint rule for function parameter count.
+  [Oleg Gorbatchev](https://github.com/gorbat-o)
+  [#427](https://github.com/SwiftGen/SwiftGen/pull/417)
 
 ## 5.3.0
 

--- a/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable-customname.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable-customname.swift
@@ -4,9 +4,8 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
-// swiftlint:disable function_parameter_count
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 internal enum XCTLoc {
   /// Some alert body there
   internal static let alertMessage = XCTLoc.tr("Localizable", "alert_message")
@@ -39,7 +38,7 @@ internal enum XCTLoc {
   /// User Profile Settings
   internal static let settingsUserProfileSectionHEADERTITLE = XCTLoc.tr("Localizable", "settings.user_profile_section.HEADER_TITLE")
 }
-// swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable function_parameter_count identifier_name line_length type_body_length
 
 extension XCTLoc {
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable-customname.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable-customname.swift
@@ -4,6 +4,7 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
+// swiftlint:disable function_parameter_count
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal enum XCTLoc {

--- a/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable-no-comments.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable-no-comments.swift
@@ -4,9 +4,8 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
-// swiftlint:disable function_parameter_count
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 internal enum L10n {
   internal static let alertMessage = L10n.tr("Localizable", "alert_message")
   internal static let alertTitle = L10n.tr("Localizable", "alert_title")
@@ -28,7 +27,7 @@ internal enum L10n {
   internal static let settingsUserProfileSectionFooterText = L10n.tr("Localizable", "settings.user_profile_section.footer_text")
   internal static let settingsUserProfileSectionHEADERTITLE = L10n.tr("Localizable", "settings.user_profile_section.HEADER_TITLE")
 }
-// swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable function_parameter_count identifier_name line_length type_body_length
 
 extension L10n {
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable-no-comments.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable-no-comments.swift
@@ -4,6 +4,7 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
+// swiftlint:disable function_parameter_count
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal enum L10n {

--- a/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable-publicAccess.swift
@@ -4,9 +4,8 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
-// swiftlint:disable function_parameter_count
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 public enum L10n {
   /// Some alert body there
   public static let alertMessage = L10n.tr("Localizable", "alert_message")
@@ -39,7 +38,7 @@ public enum L10n {
   /// User Profile Settings
   public static let settingsUserProfileSectionHEADERTITLE = L10n.tr("Localizable", "settings.user_profile_section.HEADER_TITLE")
 }
-// swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable function_parameter_count identifier_name line_length type_body_length
 
 extension L10n {
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable-publicAccess.swift
@@ -4,6 +4,7 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
+// swiftlint:disable function_parameter_count
 
 // swiftlint:disable identifier_name line_length type_body_length
 public enum L10n {

--- a/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable.swift
@@ -4,9 +4,8 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
-// swiftlint:disable function_parameter_count
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 internal enum L10n {
   /// Some alert body there
   internal static let alertMessage = L10n.tr("Localizable", "alert_message")
@@ -39,7 +38,7 @@ internal enum L10n {
   /// User Profile Settings
   internal static let settingsUserProfileSectionHEADERTITLE = L10n.tr("Localizable", "settings.user_profile_section.HEADER_TITLE")
 }
-// swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable function_parameter_count identifier_name line_length type_body_length
 
 extension L10n {
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable.swift
@@ -4,6 +4,7 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
+// swiftlint:disable function_parameter_count
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal enum L10n {

--- a/Tests/Fixtures/Generated/Strings/flat-swift3-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift3-context-multiple.swift
@@ -4,9 +4,8 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
-// swiftlint:disable function_parameter_count
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 internal enum L10n {
   internal enum Localizable {
     /// Some alert body there
@@ -53,7 +52,7 @@ internal enum L10n {
     internal static let singleline2 = L10n.tr("LocMultiline", "SINGLELINE2")
   }
 }
-// swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable function_parameter_count identifier_name line_length type_body_length
 
 extension L10n {
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/flat-swift3-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift3-context-multiple.swift
@@ -4,6 +4,7 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
+// swiftlint:disable function_parameter_count
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal enum L10n {

--- a/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable-customname.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable-customname.swift
@@ -4,9 +4,8 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
-// swiftlint:disable function_parameter_count
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 internal enum XCTLoc {
   /// Some alert body there
   internal static let alertMessage = XCTLoc.tr("Localizable", "alert_message")
@@ -39,7 +38,7 @@ internal enum XCTLoc {
   /// User Profile Settings
   internal static let settingsUserProfileSectionHEADERTITLE = XCTLoc.tr("Localizable", "settings.user_profile_section.HEADER_TITLE")
 }
-// swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable function_parameter_count identifier_name line_length type_body_length
 
 extension XCTLoc {
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable-customname.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable-customname.swift
@@ -4,6 +4,7 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
+// swiftlint:disable function_parameter_count
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal enum XCTLoc {

--- a/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable-no-comments.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable-no-comments.swift
@@ -4,9 +4,8 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
-// swiftlint:disable function_parameter_count
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 internal enum L10n {
   internal static let alertMessage = L10n.tr("Localizable", "alert_message")
   internal static let alertTitle = L10n.tr("Localizable", "alert_title")
@@ -28,7 +27,7 @@ internal enum L10n {
   internal static let settingsUserProfileSectionFooterText = L10n.tr("Localizable", "settings.user_profile_section.footer_text")
   internal static let settingsUserProfileSectionHEADERTITLE = L10n.tr("Localizable", "settings.user_profile_section.HEADER_TITLE")
 }
-// swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable function_parameter_count identifier_name line_length type_body_length
 
 extension L10n {
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable-no-comments.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable-no-comments.swift
@@ -4,6 +4,7 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
+// swiftlint:disable function_parameter_count
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal enum L10n {

--- a/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable-publicAccess.swift
@@ -4,6 +4,7 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
+// swiftlint:disable function_parameter_count
 
 // swiftlint:disable identifier_name line_length type_body_length
 public enum L10n {

--- a/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable-publicAccess.swift
@@ -4,9 +4,8 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
-// swiftlint:disable function_parameter_count
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 public enum L10n {
   /// Some alert body there
   public static let alertMessage = L10n.tr("Localizable", "alert_message")
@@ -39,7 +38,7 @@ public enum L10n {
   /// User Profile Settings
   public static let settingsUserProfileSectionHEADERTITLE = L10n.tr("Localizable", "settings.user_profile_section.HEADER_TITLE")
 }
-// swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable function_parameter_count identifier_name line_length type_body_length
 
 extension L10n {
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable.swift
@@ -4,9 +4,8 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
-// swiftlint:disable function_parameter_count
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 internal enum L10n {
   /// Some alert body there
   internal static let alertMessage = L10n.tr("Localizable", "alert_message")
@@ -39,7 +38,7 @@ internal enum L10n {
   /// User Profile Settings
   internal static let settingsUserProfileSectionHEADERTITLE = L10n.tr("Localizable", "settings.user_profile_section.HEADER_TITLE")
 }
-// swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable function_parameter_count identifier_name line_length type_body_length
 
 extension L10n {
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable.swift
@@ -4,6 +4,7 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
+// swiftlint:disable function_parameter_count
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal enum L10n {

--- a/Tests/Fixtures/Generated/Strings/flat-swift4-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift4-context-multiple.swift
@@ -4,9 +4,8 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
-// swiftlint:disable function_parameter_count
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 internal enum L10n {
   internal enum Localizable {
     /// Some alert body there
@@ -53,7 +52,7 @@ internal enum L10n {
     internal static let singleline2 = L10n.tr("LocMultiline", "SINGLELINE2")
   }
 }
-// swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable function_parameter_count identifier_name line_length type_body_length
 
 extension L10n {
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/flat-swift4-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift4-context-multiple.swift
@@ -4,6 +4,7 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
+// swiftlint:disable function_parameter_count
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal enum L10n {

--- a/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable-customname.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable-customname.swift
@@ -4,9 +4,9 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
-// swiftlint:disable function_parameter_count
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:disable nesting type_body_length type_name
 internal enum XCTLoc {
   /// Some alert body there
   internal static let alertMessage = XCTLoc.tr("Localizable", "alert_message")
@@ -74,7 +74,8 @@ internal enum XCTLoc {
     }
   }
 }
-// swiftlint:enable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:enable nesting type_body_length type_name
 
 extension XCTLoc {
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable-customname.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable-customname.swift
@@ -4,6 +4,7 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
+// swiftlint:disable function_parameter_count
 
 // swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 internal enum XCTLoc {

--- a/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable-no-comments.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable-no-comments.swift
@@ -4,6 +4,7 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
+// swiftlint:disable function_parameter_count
 
 // swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 internal enum L10n {

--- a/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable-no-comments.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable-no-comments.swift
@@ -4,9 +4,9 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
-// swiftlint:disable function_parameter_count
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:disable nesting type_body_length type_name
 internal enum L10n {
   internal static let alertMessage = L10n.tr("Localizable", "alert_message")
   internal static let alertTitle = L10n.tr("Localizable", "alert_title")
@@ -63,7 +63,8 @@ internal enum L10n {
     }
   }
 }
-// swiftlint:enable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:enable nesting type_body_length type_name
 
 extension L10n {
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable-publicAccess.swift
@@ -4,9 +4,9 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
-// swiftlint:disable function_parameter_count
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:disable nesting type_body_length type_name
 public enum L10n {
   /// Some alert body there
   public static let alertMessage = L10n.tr("Localizable", "alert_message")
@@ -74,7 +74,8 @@ public enum L10n {
     }
   }
 }
-// swiftlint:enable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:enable nesting type_body_length type_name
 
 extension L10n {
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable-publicAccess.swift
@@ -4,6 +4,7 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
+// swiftlint:disable function_parameter_count
 
 // swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 public enum L10n {

--- a/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable.swift
@@ -4,9 +4,9 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
-// swiftlint:disable function_parameter_count
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:disable nesting type_body_length type_name
 internal enum L10n {
   /// Some alert body there
   internal static let alertMessage = L10n.tr("Localizable", "alert_message")
@@ -74,7 +74,8 @@ internal enum L10n {
     }
   }
 }
-// swiftlint:enable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:enable nesting type_body_length type_name
 
 extension L10n {
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable.swift
@@ -4,6 +4,7 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
+// swiftlint:disable function_parameter_count
 
 // swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 internal enum L10n {

--- a/Tests/Fixtures/Generated/Strings/structured-swift3-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift3-context-multiple.swift
@@ -4,6 +4,7 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
+// swiftlint:disable function_parameter_count
 
 // swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 internal enum L10n {

--- a/Tests/Fixtures/Generated/Strings/structured-swift3-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift3-context-multiple.swift
@@ -4,9 +4,9 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
-// swiftlint:disable function_parameter_count
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:disable nesting type_body_length type_name
 internal enum L10n {
   internal enum Localizable {
     /// Some alert body there
@@ -85,7 +85,8 @@ internal enum L10n {
     internal static let singleline2 = L10n.tr("LocMultiline", "SINGLELINE2")
   }
 }
-// swiftlint:enable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:enable nesting type_body_length type_name
 
 extension L10n {
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable-customname.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable-customname.swift
@@ -4,9 +4,9 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
-// swiftlint:disable function_parameter_count
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:disable nesting type_body_length type_name
 internal enum XCTLoc {
   /// Some alert body there
   internal static let alertMessage = XCTLoc.tr("Localizable", "alert_message")
@@ -74,7 +74,8 @@ internal enum XCTLoc {
     }
   }
 }
-// swiftlint:enable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:enable nesting type_body_length type_name
 
 extension XCTLoc {
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable-customname.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable-customname.swift
@@ -4,6 +4,7 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
+// swiftlint:disable function_parameter_count
 
 // swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 internal enum XCTLoc {

--- a/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable-no-comments.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable-no-comments.swift
@@ -4,6 +4,7 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
+// swiftlint:disable function_parameter_count
 
 // swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 internal enum L10n {

--- a/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable-no-comments.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable-no-comments.swift
@@ -4,9 +4,9 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
-// swiftlint:disable function_parameter_count
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:disable nesting type_body_length type_name
 internal enum L10n {
   internal static let alertMessage = L10n.tr("Localizable", "alert_message")
   internal static let alertTitle = L10n.tr("Localizable", "alert_title")
@@ -63,7 +63,8 @@ internal enum L10n {
     }
   }
 }
-// swiftlint:enable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:enable nesting type_body_length type_name
 
 extension L10n {
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable-publicAccess.swift
@@ -4,9 +4,9 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
-// swiftlint:disable function_parameter_count
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:disable nesting type_body_length type_name
 public enum L10n {
   /// Some alert body there
   public static let alertMessage = L10n.tr("Localizable", "alert_message")
@@ -74,7 +74,8 @@ public enum L10n {
     }
   }
 }
-// swiftlint:enable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:enable nesting type_body_length type_name
 
 extension L10n {
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable-publicAccess.swift
@@ -4,6 +4,7 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
+// swiftlint:disable function_parameter_count
 
 // swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 public enum L10n {

--- a/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable.swift
@@ -4,6 +4,7 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
+// swiftlint:disable function_parameter_count
 
 // swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 internal enum L10n {

--- a/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable.swift
@@ -4,9 +4,9 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
-// swiftlint:disable function_parameter_count
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:disable nesting type_body_length type_name
 internal enum L10n {
   /// Some alert body there
   internal static let alertMessage = L10n.tr("Localizable", "alert_message")
@@ -74,7 +74,8 @@ internal enum L10n {
     }
   }
 }
-// swiftlint:enable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:enable nesting type_body_length type_name
 
 extension L10n {
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/structured-swift4-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift4-context-multiple.swift
@@ -4,6 +4,7 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
+// swiftlint:disable function_parameter_count
 
 // swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 internal enum L10n {

--- a/Tests/Fixtures/Generated/Strings/structured-swift4-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift4-context-multiple.swift
@@ -4,9 +4,9 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
-// swiftlint:disable function_parameter_count
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:disable nesting type_body_length type_name
 internal enum L10n {
   internal enum Localizable {
     /// Some alert body there
@@ -85,7 +85,8 @@ internal enum L10n {
     internal static let singleline2 = L10n.tr("LocMultiline", "SINGLELINE2")
   }
 }
-// swiftlint:enable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:enable nesting type_body_length type_name
 
 extension L10n {
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/templates/strings/flat-swift3.stencil
+++ b/templates/strings/flat-swift3.stencil
@@ -6,7 +6,6 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
-// swiftlint:disable function_parameter_count
 {% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
   {% for type in types %}
     _ p{{forloop.counter}}: {{type}}{% if not forloop.last %}, {% endif %}
@@ -35,7 +34,7 @@ import Foundation
   {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 {{accessModifier}} enum {{enumName}} {
   {% if tables.count > 1 %}
@@ -48,7 +47,7 @@ import Foundation
   {% call recursiveBlock tables.first.name tables.first.levels %}
   {% endif %}
 }
-// swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable function_parameter_count identifier_name line_length type_body_length
 
 extension {{enumName}} {
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/templates/strings/flat-swift3.stencil
+++ b/templates/strings/flat-swift3.stencil
@@ -6,6 +6,7 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
+// swiftlint:disable function_parameter_count
 {% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
   {% for type in types %}
     _ p{{forloop.counter}}: {{type}}{% if not forloop.last %}, {% endif %}

--- a/templates/strings/flat-swift4.stencil
+++ b/templates/strings/flat-swift4.stencil
@@ -6,7 +6,6 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
-// swiftlint:disable function_parameter_count
 {% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
   {% for type in types %}
     _ p{{forloop.counter}}: {{type}}{% if not forloop.last %}, {% endif %}
@@ -35,7 +34,7 @@ import Foundation
   {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 {{accessModifier}} enum {{enumName}} {
   {% if tables.count > 1 %}
@@ -48,7 +47,7 @@ import Foundation
   {% call recursiveBlock tables.first.name tables.first.levels %}
   {% endif %}
 }
-// swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable function_parameter_count identifier_name line_length type_body_length
 
 extension {{enumName}} {
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/templates/strings/flat-swift4.stencil
+++ b/templates/strings/flat-swift4.stencil
@@ -6,6 +6,7 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
+// swiftlint:disable function_parameter_count
 {% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
   {% for type in types %}
     _ p{{forloop.counter}}: {{type}}{% if not forloop.last %}, {% endif %}

--- a/templates/strings/structured-swift3.stencil
+++ b/templates/strings/structured-swift3.stencil
@@ -6,7 +6,6 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
-// swiftlint:disable function_parameter_count
 {% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
   {% for type in types %}
     _ p{{forloop.counter}}: {{type}}{% if not forloop.last %}, {% endif %}
@@ -38,7 +37,8 @@ import Foundation
   {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:disable nesting type_body_length type_name
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 {{accessModifier}} enum {{enumName}} {
   {% if tables.count > 1 %}
@@ -51,7 +51,8 @@ import Foundation
   {% call recursiveBlock tables.first.name tables.first.levels %}
   {% endif %}
 }
-// swiftlint:enable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:enable nesting type_body_length type_name
 
 extension {{enumName}} {
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/templates/strings/structured-swift3.stencil
+++ b/templates/strings/structured-swift3.stencil
@@ -6,6 +6,7 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
+// swiftlint:disable function_parameter_count
 {% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
   {% for type in types %}
     _ p{{forloop.counter}}: {{type}}{% if not forloop.last %}, {% endif %}

--- a/templates/strings/structured-swift4.stencil
+++ b/templates/strings/structured-swift4.stencil
@@ -6,7 +6,6 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
-// swiftlint:disable function_parameter_count
 {% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
   {% for type in types %}
     _ p{{forloop.counter}}: {{type}}{% if not forloop.last %}, {% endif %}
@@ -38,7 +37,8 @@ import Foundation
   {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:disable nesting type_body_length type_name
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 {{accessModifier}} enum {{enumName}} {
   {% if tables.count > 1 %}
@@ -51,7 +51,8 @@ import Foundation
   {% call recursiveBlock tables.first.name tables.first.levels %}
   {% endif %}
 }
-// swiftlint:enable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
+// swiftlint:enable nesting type_body_length type_name
 
 extension {{enumName}} {
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/templates/strings/structured-swift4.stencil
+++ b/templates/strings/structured-swift4.stencil
@@ -6,6 +6,7 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
+// swiftlint:disable function_parameter_count
 {% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
   {% for type in types %}
     _ p{{forloop.counter}}: {{type}}{% if not forloop.last %}, {% endif %}


### PR DESCRIPTION
  * [x] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself
  * [x] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
  * [x] Add a period and 2 spaces at the end of your short entry description
  * [x] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

This closes #427
Some keys generated by SwiftGen can have more then 5 parameters, it makes SwiftLint unhappy :'(