### PR TITLE
Add mint installation (merge for 6.0 only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,21 @@ _Note: SwiftGen needs Xcode 8.3 to build, so installing via Homebrew requires yo
 ---
 </details>
 <details>
+<summary>Via <strong>Mint</strong></summary>
+
+To install SwiftGen via [Mint](https://github.com/yonaskolb/Mint), simply use:
+
+Note: Will work for Releases > 5.3.0 only.
+
+```sh
+$ brew install libxml2
+$ mint install SwiftGen/SwiftGen --global=false
+```
+
+---
+</details>
+
+<details>
 <summary><strong>Compile from source</strong> <em>(only recommended if you need features from master or want to test a PR)</em></summary>
 
 This solution is when you want to build and install the latest version from `master` and have access to features which might not have been released yet.

--- a/README.md
+++ b/README.md
@@ -101,17 +101,16 @@ _Note: SwiftGen needs Xcode 8.3 to build, so installing via Homebrew requires yo
 ---
 </details>
 <details>
-<summary>Via <strong>Mint</strong></summary>
+<summary>Via <strong>Mint</strong> <em>(system-wide installation)</em></summary>
+
+> ❗️SwiftGen 6.0 or higher only.
 
 To install SwiftGen via [Mint](https://github.com/yonaskolb/Mint), simply use:
 
 ```sh
 $ brew install libxml2
-$ mint install SwiftGen/SwiftGen --prevent-global
+$ mint install SwiftGen/SwiftGen
 ```
-
-Note: Will work for Releases > 5.3.0 only.
-
 ---
 </details>
 

--- a/README.md
+++ b/README.md
@@ -105,12 +105,12 @@ _Note: SwiftGen needs Xcode 8.3 to build, so installing via Homebrew requires yo
 
 To install SwiftGen via [Mint](https://github.com/yonaskolb/Mint), simply use:
 
-Note: Will work for Releases > 5.3.0 only.
-
 ```sh
 $ brew install libxml2
-$ mint install SwiftGen/SwiftGen --global=false
+$ mint install SwiftGen/SwiftGen --prevent-global
 ```
+
+Note: Will work for Releases > 5.3.0 only.
 
 ---
 </details>


### PR DESCRIPTION
Fixes #457.

Until the release of 6.0, this can be tested with:
```bash
mint install SwiftGen/SwiftGen@master --global=false
```
