### PR TITLE
Restrict SceneType to UIViewController in UIKit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
   [David Jennes](https://github.com/djbe)
   [#367](https://github.com/SwiftGen/SwiftGen/issues/367)
   [#429](https://github.com/SwiftGen/SwiftGen/pull/429)
+* Restrict `SceneType` and `InitialSceneType` to UIViewController when not targeting AppKit. When targeting AppKit, remove superfluous `Any`.  
+  [Darron Schall](https://github.com/darronschall)
+  [#463](https://github.com/SwiftGen/SwiftGen/issues/463)
+  [#464](https://github.com/SwiftGen/SwiftGen/pull/464)
 
 ### Breaking Changes
 

--- a/Tests/Fixtures/Generated/IB-iOS/swift3-context-all-customname.swift
+++ b/Tests/Fixtures/Generated/IB-iOS/swift3-context-all-customname.swift
@@ -22,7 +22,7 @@ internal extension StoryboardType {
   }
 }
 
-internal struct SceneType<T: Any> {
+internal struct SceneType<T: UIViewController> {
   internal let storyboard: StoryboardType.Type
   internal let identifier: String
 
@@ -34,7 +34,7 @@ internal struct SceneType<T: Any> {
   }
 }
 
-internal struct InitialSceneType<T: Any> {
+internal struct InitialSceneType<T: UIViewController> {
   internal let storyboard: StoryboardType.Type
 
   internal func instantiate() -> T {

--- a/Tests/Fixtures/Generated/IB-iOS/swift3-context-all-ignore-module-need-extra-definitions.swift
+++ b/Tests/Fixtures/Generated/IB-iOS/swift3-context-all-ignore-module-need-extra-definitions.swift
@@ -21,7 +21,7 @@ internal extension StoryboardType {
   }
 }
 
-internal struct SceneType<T: Any> {
+internal struct SceneType<T: UIViewController> {
   internal let storyboard: StoryboardType.Type
   internal let identifier: String
 
@@ -33,7 +33,7 @@ internal struct SceneType<T: Any> {
   }
 }
 
-internal struct InitialSceneType<T: Any> {
+internal struct InitialSceneType<T: UIViewController> {
   internal let storyboard: StoryboardType.Type
 
   internal func instantiate() -> T {

--- a/Tests/Fixtures/Generated/IB-iOS/swift3-context-all-ignore-module.swift
+++ b/Tests/Fixtures/Generated/IB-iOS/swift3-context-all-ignore-module.swift
@@ -21,7 +21,7 @@ internal extension StoryboardType {
   }
 }
 
-internal struct SceneType<T: Any> {
+internal struct SceneType<T: UIViewController> {
   internal let storyboard: StoryboardType.Type
   internal let identifier: String
 
@@ -33,7 +33,7 @@ internal struct SceneType<T: Any> {
   }
 }
 
-internal struct InitialSceneType<T: Any> {
+internal struct InitialSceneType<T: UIViewController> {
   internal let storyboard: StoryboardType.Type
 
   internal func instantiate() -> T {

--- a/Tests/Fixtures/Generated/IB-iOS/swift3-context-all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/IB-iOS/swift3-context-all-publicAccess.swift
@@ -22,7 +22,7 @@ public extension StoryboardType {
   }
 }
 
-public struct SceneType<T: Any> {
+public struct SceneType<T: UIViewController> {
   public let storyboard: StoryboardType.Type
   public let identifier: String
 
@@ -34,7 +34,7 @@ public struct SceneType<T: Any> {
   }
 }
 
-public struct InitialSceneType<T: Any> {
+public struct InitialSceneType<T: UIViewController> {
   public let storyboard: StoryboardType.Type
 
   public func instantiate() -> T {

--- a/Tests/Fixtures/Generated/IB-iOS/swift3-context-all.swift
+++ b/Tests/Fixtures/Generated/IB-iOS/swift3-context-all.swift
@@ -22,7 +22,7 @@ internal extension StoryboardType {
   }
 }
 
-internal struct SceneType<T: Any> {
+internal struct SceneType<T: UIViewController> {
   internal let storyboard: StoryboardType.Type
   internal let identifier: String
 
@@ -34,7 +34,7 @@ internal struct SceneType<T: Any> {
   }
 }
 
-internal struct InitialSceneType<T: Any> {
+internal struct InitialSceneType<T: UIViewController> {
   internal let storyboard: StoryboardType.Type
 
   internal func instantiate() -> T {

--- a/Tests/Fixtures/Generated/IB-iOS/swift4-context-all-customname.swift
+++ b/Tests/Fixtures/Generated/IB-iOS/swift4-context-all-customname.swift
@@ -23,7 +23,7 @@ internal extension StoryboardType {
   }
 }
 
-internal struct SceneType<T: Any> {
+internal struct SceneType<T: UIViewController> {
   internal let storyboard: StoryboardType.Type
   internal let identifier: String
 
@@ -36,7 +36,7 @@ internal struct SceneType<T: Any> {
   }
 }
 
-internal struct InitialSceneType<T: Any> {
+internal struct InitialSceneType<T: UIViewController> {
   internal let storyboard: StoryboardType.Type
 
   internal func instantiate() -> T {

--- a/Tests/Fixtures/Generated/IB-iOS/swift4-context-all-ignore-module-need-extra-definitions.swift
+++ b/Tests/Fixtures/Generated/IB-iOS/swift4-context-all-ignore-module-need-extra-definitions.swift
@@ -22,7 +22,7 @@ internal extension StoryboardType {
   }
 }
 
-internal struct SceneType<T: Any> {
+internal struct SceneType<T: UIViewController> {
   internal let storyboard: StoryboardType.Type
   internal let identifier: String
 
@@ -35,7 +35,7 @@ internal struct SceneType<T: Any> {
   }
 }
 
-internal struct InitialSceneType<T: Any> {
+internal struct InitialSceneType<T: UIViewController> {
   internal let storyboard: StoryboardType.Type
 
   internal func instantiate() -> T {

--- a/Tests/Fixtures/Generated/IB-iOS/swift4-context-all-ignore-module.swift
+++ b/Tests/Fixtures/Generated/IB-iOS/swift4-context-all-ignore-module.swift
@@ -22,7 +22,7 @@ internal extension StoryboardType {
   }
 }
 
-internal struct SceneType<T: Any> {
+internal struct SceneType<T: UIViewController> {
   internal let storyboard: StoryboardType.Type
   internal let identifier: String
 
@@ -35,7 +35,7 @@ internal struct SceneType<T: Any> {
   }
 }
 
-internal struct InitialSceneType<T: Any> {
+internal struct InitialSceneType<T: UIViewController> {
   internal let storyboard: StoryboardType.Type
 
   internal func instantiate() -> T {

--- a/Tests/Fixtures/Generated/IB-iOS/swift4-context-all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/IB-iOS/swift4-context-all-publicAccess.swift
@@ -23,7 +23,7 @@ public extension StoryboardType {
   }
 }
 
-public struct SceneType<T: Any> {
+public struct SceneType<T: UIViewController> {
   public let storyboard: StoryboardType.Type
   public let identifier: String
 
@@ -36,7 +36,7 @@ public struct SceneType<T: Any> {
   }
 }
 
-public struct InitialSceneType<T: Any> {
+public struct InitialSceneType<T: UIViewController> {
   public let storyboard: StoryboardType.Type
 
   public func instantiate() -> T {

--- a/Tests/Fixtures/Generated/IB-iOS/swift4-context-all.swift
+++ b/Tests/Fixtures/Generated/IB-iOS/swift4-context-all.swift
@@ -23,7 +23,7 @@ internal extension StoryboardType {
   }
 }
 
-internal struct SceneType<T: Any> {
+internal struct SceneType<T: UIViewController> {
   internal let storyboard: StoryboardType.Type
   internal let identifier: String
 
@@ -36,7 +36,7 @@ internal struct SceneType<T: Any> {
   }
 }
 
-internal struct InitialSceneType<T: Any> {
+internal struct InitialSceneType<T: UIViewController> {
   internal let storyboard: StoryboardType.Type
 
   internal func instantiate() -> T {

--- a/Tests/Fixtures/Generated/IB-macOS/swift3-context-all-customname.swift
+++ b/Tests/Fixtures/Generated/IB-macOS/swift3-context-all-customname.swift
@@ -19,7 +19,7 @@ internal extension StoryboardType {
   }
 }
 
-internal struct SceneType<T: Any> {
+internal struct SceneType<T> {
   internal let storyboard: StoryboardType.Type
   internal let identifier: String
 
@@ -31,7 +31,7 @@ internal struct SceneType<T: Any> {
   }
 }
 
-internal struct InitialSceneType<T: Any> {
+internal struct InitialSceneType<T> {
   internal let storyboard: StoryboardType.Type
 
   internal func instantiate() -> T {

--- a/Tests/Fixtures/Generated/IB-macOS/swift3-context-all-ignore-module-need-extra-definitions.swift
+++ b/Tests/Fixtures/Generated/IB-macOS/swift3-context-all-ignore-module-need-extra-definitions.swift
@@ -18,7 +18,7 @@ internal extension StoryboardType {
   }
 }
 
-internal struct SceneType<T: Any> {
+internal struct SceneType<T> {
   internal let storyboard: StoryboardType.Type
   internal let identifier: String
 
@@ -30,7 +30,7 @@ internal struct SceneType<T: Any> {
   }
 }
 
-internal struct InitialSceneType<T: Any> {
+internal struct InitialSceneType<T> {
   internal let storyboard: StoryboardType.Type
 
   internal func instantiate() -> T {

--- a/Tests/Fixtures/Generated/IB-macOS/swift3-context-all-ignore-module.swift
+++ b/Tests/Fixtures/Generated/IB-macOS/swift3-context-all-ignore-module.swift
@@ -18,7 +18,7 @@ internal extension StoryboardType {
   }
 }
 
-internal struct SceneType<T: Any> {
+internal struct SceneType<T> {
   internal let storyboard: StoryboardType.Type
   internal let identifier: String
 
@@ -30,7 +30,7 @@ internal struct SceneType<T: Any> {
   }
 }
 
-internal struct InitialSceneType<T: Any> {
+internal struct InitialSceneType<T> {
   internal let storyboard: StoryboardType.Type
 
   internal func instantiate() -> T {

--- a/Tests/Fixtures/Generated/IB-macOS/swift3-context-all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/IB-macOS/swift3-context-all-publicAccess.swift
@@ -19,7 +19,7 @@ public extension StoryboardType {
   }
 }
 
-public struct SceneType<T: Any> {
+public struct SceneType<T> {
   public let storyboard: StoryboardType.Type
   public let identifier: String
 
@@ -31,7 +31,7 @@ public struct SceneType<T: Any> {
   }
 }
 
-public struct InitialSceneType<T: Any> {
+public struct InitialSceneType<T> {
   public let storyboard: StoryboardType.Type
 
   public func instantiate() -> T {

--- a/Tests/Fixtures/Generated/IB-macOS/swift3-context-all.swift
+++ b/Tests/Fixtures/Generated/IB-macOS/swift3-context-all.swift
@@ -19,7 +19,7 @@ internal extension StoryboardType {
   }
 }
 
-internal struct SceneType<T: Any> {
+internal struct SceneType<T> {
   internal let storyboard: StoryboardType.Type
   internal let identifier: String
 
@@ -31,7 +31,7 @@ internal struct SceneType<T: Any> {
   }
 }
 
-internal struct InitialSceneType<T: Any> {
+internal struct InitialSceneType<T> {
   internal let storyboard: StoryboardType.Type
 
   internal func instantiate() -> T {

--- a/Tests/Fixtures/Generated/IB-macOS/swift4-context-all-customname.swift
+++ b/Tests/Fixtures/Generated/IB-macOS/swift4-context-all-customname.swift
@@ -20,7 +20,7 @@ internal extension StoryboardType {
   }
 }
 
-internal struct SceneType<T: Any> {
+internal struct SceneType<T> {
   internal let storyboard: StoryboardType.Type
   internal let identifier: String
 
@@ -33,7 +33,7 @@ internal struct SceneType<T: Any> {
   }
 }
 
-internal struct InitialSceneType<T: Any> {
+internal struct InitialSceneType<T> {
   internal let storyboard: StoryboardType.Type
 
   internal func instantiate() -> T {

--- a/Tests/Fixtures/Generated/IB-macOS/swift4-context-all-ignore-module-need-extra-definitions.swift
+++ b/Tests/Fixtures/Generated/IB-macOS/swift4-context-all-ignore-module-need-extra-definitions.swift
@@ -19,7 +19,7 @@ internal extension StoryboardType {
   }
 }
 
-internal struct SceneType<T: Any> {
+internal struct SceneType<T> {
   internal let storyboard: StoryboardType.Type
   internal let identifier: String
 
@@ -32,7 +32,7 @@ internal struct SceneType<T: Any> {
   }
 }
 
-internal struct InitialSceneType<T: Any> {
+internal struct InitialSceneType<T> {
   internal let storyboard: StoryboardType.Type
 
   internal func instantiate() -> T {

--- a/Tests/Fixtures/Generated/IB-macOS/swift4-context-all-ignore-module.swift
+++ b/Tests/Fixtures/Generated/IB-macOS/swift4-context-all-ignore-module.swift
@@ -19,7 +19,7 @@ internal extension StoryboardType {
   }
 }
 
-internal struct SceneType<T: Any> {
+internal struct SceneType<T> {
   internal let storyboard: StoryboardType.Type
   internal let identifier: String
 
@@ -32,7 +32,7 @@ internal struct SceneType<T: Any> {
   }
 }
 
-internal struct InitialSceneType<T: Any> {
+internal struct InitialSceneType<T> {
   internal let storyboard: StoryboardType.Type
 
   internal func instantiate() -> T {

--- a/Tests/Fixtures/Generated/IB-macOS/swift4-context-all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/IB-macOS/swift4-context-all-publicAccess.swift
@@ -20,7 +20,7 @@ public extension StoryboardType {
   }
 }
 
-public struct SceneType<T: Any> {
+public struct SceneType<T> {
   public let storyboard: StoryboardType.Type
   public let identifier: String
 
@@ -33,7 +33,7 @@ public struct SceneType<T: Any> {
   }
 }
 
-public struct InitialSceneType<T: Any> {
+public struct InitialSceneType<T> {
   public let storyboard: StoryboardType.Type
 
   public func instantiate() -> T {

--- a/Tests/Fixtures/Generated/IB-macOS/swift4-context-all.swift
+++ b/Tests/Fixtures/Generated/IB-macOS/swift4-context-all.swift
@@ -20,7 +20,7 @@ internal extension StoryboardType {
   }
 }
 
-internal struct SceneType<T: Any> {
+internal struct SceneType<T> {
   internal let storyboard: StoryboardType.Type
   internal let identifier: String
 
@@ -33,7 +33,7 @@ internal struct SceneType<T: Any> {
   }
 }
 
-internal struct InitialSceneType<T: Any> {
+internal struct InitialSceneType<T> {
   internal let storyboard: StoryboardType.Type
 
   internal func instantiate() -> T {

--- a/templates/ib/swift3.stencil
+++ b/templates/ib/swift3.stencil
@@ -25,7 +25,7 @@ import {{module}}
   }
 }
 
-{{accessModifier}} struct SceneType<T: Any> {
+{{accessModifier}} struct SceneType<T{% if not isAppKit %}: UIViewController{% endif %}> {
   {{accessModifier}} let storyboard: StoryboardType.Type
   {{accessModifier}} let identifier: String
 
@@ -37,7 +37,7 @@ import {{module}}
   }
 }
 
-{{accessModifier}} struct InitialSceneType<T: Any> {
+{{accessModifier}} struct InitialSceneType<T{% if not isAppKit %}: UIViewController{% endif %}> {
   {{accessModifier}} let storyboard: StoryboardType.Type
 
   {{accessModifier}} func instantiate() -> T {

--- a/templates/ib/swift4.stencil
+++ b/templates/ib/swift4.stencil
@@ -26,7 +26,7 @@ import {{module}}
   }
 }
 
-{{accessModifier}} struct SceneType<T: Any> {
+{{accessModifier}} struct SceneType<T{% if not isAppKit %}: UIViewController{% endif %}> {
   {{accessModifier}} let storyboard: StoryboardType.Type
   {{accessModifier}} let identifier: String
 
@@ -39,7 +39,7 @@ import {{module}}
   }
 }
 
-{{accessModifier}} struct InitialSceneType<T: Any> {
+{{accessModifier}} struct InitialSceneType<T{% if not isAppKit %}: UIViewController{% endif %}> {
   {{accessModifier}} let storyboard: StoryboardType.Type
 
   {{accessModifier}} func instantiate() -> T {


### PR DESCRIPTION
This change resolves https://github.com/SwiftGen/SwiftGen/issues/463.

Both `instantiateViewController` and `instantiateInitialViewController` in UIKit return `UIViewController` instances. In AppKit, the corresponding `instantiateController` and `instantiateInitialController` still return `Any`.

 * [x] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself
 * [x] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
 * [x] Add a period and 2 spaces at the end of your short entry description
 * [x] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

