### PR TITLE
Templates: Organise generated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@
 * XCAssets: Added support for `NSDataAssets`.  
   [Oliver Jones](https://github.com/orj)
   [#444](https://github.com/SwiftGen/SwiftGen/issues/444)
+* Organised the generated code in sections for better readability, with all generated constants at the top of the file.  
+  [David Jennes](https://github.com/djbe)
+  [#481](https://github.com/SwiftGen/SwiftGen/pull/481)
 
 ### Internal Changes
 

--- a/Tests/Fixtures/Generated/Colors/literals-swift3-context-defaults-customname.swift
+++ b/Tests/Fixtures/Generated/Colors/literals-swift3-context-defaults-customname.swift
@@ -11,6 +11,8 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Colors
+
 // swiftlint:disable identifier_name line_length type_body_length
 internal extension UIColor {
   /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)

--- a/Tests/Fixtures/Generated/Colors/literals-swift3-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Colors/literals-swift3-context-defaults-publicAccess.swift
@@ -12,6 +12,8 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Colors
+
 // swiftlint:disable identifier_name line_length type_body_length
 public extension ColorName {
   /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)

--- a/Tests/Fixtures/Generated/Colors/literals-swift3-context-defaults.swift
+++ b/Tests/Fixtures/Generated/Colors/literals-swift3-context-defaults.swift
@@ -12,6 +12,8 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Colors
+
 // swiftlint:disable identifier_name line_length type_body_length
 internal extension ColorName {
   /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)

--- a/Tests/Fixtures/Generated/Colors/literals-swift3-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Colors/literals-swift3-context-multiple.swift
@@ -12,6 +12,8 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Colors
+
 // swiftlint:disable identifier_name line_length type_body_length
 internal extension ColorName {
   enum Colors {

--- a/Tests/Fixtures/Generated/Colors/literals-swift4-context-defaults-customname.swift
+++ b/Tests/Fixtures/Generated/Colors/literals-swift4-context-defaults-customname.swift
@@ -11,6 +11,8 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Colors
+
 // swiftlint:disable identifier_name line_length type_body_length
 internal extension UIColor {
   /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)

--- a/Tests/Fixtures/Generated/Colors/literals-swift4-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Colors/literals-swift4-context-defaults-publicAccess.swift
@@ -12,6 +12,8 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Colors
+
 // swiftlint:disable identifier_name line_length type_body_length
 public extension ColorName {
   /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)

--- a/Tests/Fixtures/Generated/Colors/literals-swift4-context-defaults.swift
+++ b/Tests/Fixtures/Generated/Colors/literals-swift4-context-defaults.swift
@@ -12,6 +12,8 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Colors
+
 // swiftlint:disable identifier_name line_length type_body_length
 internal extension ColorName {
   /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)

--- a/Tests/Fixtures/Generated/Colors/literals-swift4-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Colors/literals-swift4-context-multiple.swift
@@ -12,6 +12,8 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Colors
+
 // swiftlint:disable identifier_name line_length type_body_length
 internal extension ColorName {
   enum Colors {

--- a/Tests/Fixtures/Generated/Colors/swift3-context-defaults-customname.swift
+++ b/Tests/Fixtures/Generated/Colors/swift3-context-defaults-customname.swift
@@ -12,18 +12,7 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-// swiftlint:disable operator_usage_whitespace
-internal extension XCTColor {
-  convenience init(rgbaValue: UInt32) {
-    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
-    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
-    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
-    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
-
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
-  }
-}
-// swiftlint:enable operator_usage_whitespace
+// MARK: - Colors
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal struct XCTColors {
@@ -44,6 +33,21 @@ internal struct XCTColors {
   internal static let `private` = XCTColors(rgbaValue: 0xffffffcc)
 }
 // swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+// swiftlint:disable operator_usage_whitespace
+internal extension XCTColor {
+  convenience init(rgbaValue: UInt32) {
+    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
+    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
+    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
+    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
+
+    self.init(red: red, green: green, blue: blue, alpha: alpha)
+  }
+}
+// swiftlint:enable operator_usage_whitespace
 
 internal extension XCTColor {
   convenience init(named color: XCTColors) {

--- a/Tests/Fixtures/Generated/Colors/swift3-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Colors/swift3-context-defaults-publicAccess.swift
@@ -12,18 +12,7 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-// swiftlint:disable operator_usage_whitespace
-public extension Color {
-  convenience init(rgbaValue: UInt32) {
-    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
-    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
-    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
-    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
-
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
-  }
-}
-// swiftlint:enable operator_usage_whitespace
+// MARK: - Colors
 
 // swiftlint:disable identifier_name line_length type_body_length
 public struct ColorName {
@@ -44,6 +33,21 @@ public struct ColorName {
   public static let `private` = ColorName(rgbaValue: 0xffffffcc)
 }
 // swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+// swiftlint:disable operator_usage_whitespace
+public extension Color {
+  convenience init(rgbaValue: UInt32) {
+    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
+    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
+    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
+    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
+
+    self.init(red: red, green: green, blue: blue, alpha: alpha)
+  }
+}
+// swiftlint:enable operator_usage_whitespace
 
 public extension Color {
   convenience init(named color: ColorName) {

--- a/Tests/Fixtures/Generated/Colors/swift3-context-defaults.swift
+++ b/Tests/Fixtures/Generated/Colors/swift3-context-defaults.swift
@@ -12,18 +12,7 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-// swiftlint:disable operator_usage_whitespace
-internal extension Color {
-  convenience init(rgbaValue: UInt32) {
-    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
-    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
-    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
-    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
-
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
-  }
-}
-// swiftlint:enable operator_usage_whitespace
+// MARK: - Colors
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal struct ColorName {
@@ -44,6 +33,21 @@ internal struct ColorName {
   internal static let `private` = ColorName(rgbaValue: 0xffffffcc)
 }
 // swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+// swiftlint:disable operator_usage_whitespace
+internal extension Color {
+  convenience init(rgbaValue: UInt32) {
+    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
+    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
+    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
+    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
+
+    self.init(red: red, green: green, blue: blue, alpha: alpha)
+  }
+}
+// swiftlint:enable operator_usage_whitespace
 
 internal extension Color {
   convenience init(named color: ColorName) {

--- a/Tests/Fixtures/Generated/Colors/swift3-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Colors/swift3-context-multiple.swift
@@ -12,18 +12,7 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-// swiftlint:disable operator_usage_whitespace
-internal extension Color {
-  convenience init(rgbaValue: UInt32) {
-    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
-    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
-    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
-    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
-
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
-  }
-}
-// swiftlint:enable operator_usage_whitespace
+// MARK: - Colors
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal struct ColorName {
@@ -69,6 +58,21 @@ internal struct ColorName {
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+// swiftlint:disable operator_usage_whitespace
+internal extension Color {
+  convenience init(rgbaValue: UInt32) {
+    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
+    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
+    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
+    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
+
+    self.init(red: red, green: green, blue: blue, alpha: alpha)
+  }
+}
+// swiftlint:enable operator_usage_whitespace
 
 internal extension Color {
   convenience init(named color: ColorName) {

--- a/Tests/Fixtures/Generated/Colors/swift4-context-defaults-customname.swift
+++ b/Tests/Fixtures/Generated/Colors/swift4-context-defaults-customname.swift
@@ -12,18 +12,7 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-// swiftlint:disable operator_usage_whitespace
-internal extension XCTColor {
-  convenience init(rgbaValue: UInt32) {
-    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
-    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
-    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
-    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
-
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
-  }
-}
-// swiftlint:enable operator_usage_whitespace
+// MARK: - Colors
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal struct XCTColors {
@@ -44,6 +33,21 @@ internal struct XCTColors {
   internal static let `private` = XCTColors(rgbaValue: 0xffffffcc)
 }
 // swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+// swiftlint:disable operator_usage_whitespace
+internal extension XCTColor {
+  convenience init(rgbaValue: UInt32) {
+    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
+    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
+    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
+    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
+
+    self.init(red: red, green: green, blue: blue, alpha: alpha)
+  }
+}
+// swiftlint:enable operator_usage_whitespace
 
 internal extension XCTColor {
   convenience init(named color: XCTColors) {

--- a/Tests/Fixtures/Generated/Colors/swift4-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Colors/swift4-context-defaults-publicAccess.swift
@@ -12,18 +12,7 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-// swiftlint:disable operator_usage_whitespace
-public extension Color {
-  convenience init(rgbaValue: UInt32) {
-    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
-    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
-    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
-    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
-
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
-  }
-}
-// swiftlint:enable operator_usage_whitespace
+// MARK: - Colors
 
 // swiftlint:disable identifier_name line_length type_body_length
 public struct ColorName {
@@ -44,6 +33,21 @@ public struct ColorName {
   public static let `private` = ColorName(rgbaValue: 0xffffffcc)
 }
 // swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+// swiftlint:disable operator_usage_whitespace
+public extension Color {
+  convenience init(rgbaValue: UInt32) {
+    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
+    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
+    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
+    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
+
+    self.init(red: red, green: green, blue: blue, alpha: alpha)
+  }
+}
+// swiftlint:enable operator_usage_whitespace
 
 public extension Color {
   convenience init(named color: ColorName) {

--- a/Tests/Fixtures/Generated/Colors/swift4-context-defaults.swift
+++ b/Tests/Fixtures/Generated/Colors/swift4-context-defaults.swift
@@ -12,18 +12,7 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-// swiftlint:disable operator_usage_whitespace
-internal extension Color {
-  convenience init(rgbaValue: UInt32) {
-    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
-    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
-    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
-    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
-
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
-  }
-}
-// swiftlint:enable operator_usage_whitespace
+// MARK: - Colors
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal struct ColorName {
@@ -44,6 +33,21 @@ internal struct ColorName {
   internal static let `private` = ColorName(rgbaValue: 0xffffffcc)
 }
 // swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+// swiftlint:disable operator_usage_whitespace
+internal extension Color {
+  convenience init(rgbaValue: UInt32) {
+    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
+    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
+    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
+    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
+
+    self.init(red: red, green: green, blue: blue, alpha: alpha)
+  }
+}
+// swiftlint:enable operator_usage_whitespace
 
 internal extension Color {
   convenience init(named color: ColorName) {

--- a/Tests/Fixtures/Generated/Colors/swift4-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Colors/swift4-context-multiple.swift
@@ -12,18 +12,7 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-// swiftlint:disable operator_usage_whitespace
-internal extension Color {
-  convenience init(rgbaValue: UInt32) {
-    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
-    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
-    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
-    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
-
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
-  }
-}
-// swiftlint:enable operator_usage_whitespace
+// MARK: - Colors
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal struct ColorName {
@@ -69,6 +58,21 @@ internal struct ColorName {
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+// swiftlint:disable operator_usage_whitespace
+internal extension Color {
+  convenience init(rgbaValue: UInt32) {
+    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
+    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
+    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
+    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
+
+    self.init(red: red, green: green, blue: blue, alpha: alpha)
+  }
+}
+// swiftlint:enable operator_usage_whitespace
 
 internal extension Color {
   convenience init(named color: ColorName) {

--- a/Tests/Fixtures/Generated/Fonts/swift3-context-defaults-customname.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift3-context-defaults-customname.swift
@@ -12,42 +12,7 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-internal struct FontConvertible {
-  internal let name: String
-  internal let family: String
-  internal let path: String
-
-  internal func font(size: CGFloat) -> Font! {
-    return Font(font: self, size: size)
-  }
-
-  internal func register() {
-    // swiftlint:disable:next conditional_returns_on_newline
-    guard let url = url else { return }
-    CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
-  }
-
-  fileprivate var url: URL? {
-    let bundle = Bundle(for: BundleToken.self)
-    return bundle.url(forResource: path, withExtension: nil)
-  }
-}
-
-internal extension Font {
-  convenience init!(font: FontConvertible, size: CGFloat) {
-    #if os(iOS) || os(tvOS) || os(watchOS)
-    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
-      font.register()
-    }
-    #elseif os(OSX)
-    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
-      font.register()
-    }
-    #endif
-
-    self.init(name: font.name, size: size)
-  }
-}
+// MARK: - Fonts
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal enum CustomFamily {
@@ -93,5 +58,44 @@ internal enum CustomFamily {
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+internal struct FontConvertible {
+  internal let name: String
+  internal let family: String
+  internal let path: String
+
+  internal func font(size: CGFloat) -> Font! {
+    return Font(font: self, size: size)
+  }
+
+  internal func register() {
+    // swiftlint:disable:next conditional_returns_on_newline
+    guard let url = url else { return }
+    CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
+  }
+
+  fileprivate var url: URL? {
+    let bundle = Bundle(for: BundleToken.self)
+    return bundle.url(forResource: path, withExtension: nil)
+  }
+}
+
+internal extension Font {
+  convenience init!(font: FontConvertible, size: CGFloat) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
+      font.register()
+    }
+    #elseif os(OSX)
+    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
+      font.register()
+    }
+    #endif
+
+    self.init(name: font.name, size: size)
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/Fonts/swift3-context-defaults-preservepath.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift3-context-defaults-preservepath.swift
@@ -12,42 +12,7 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-internal struct FontConvertible {
-  internal let name: String
-  internal let family: String
-  internal let path: String
-
-  internal func font(size: CGFloat) -> Font! {
-    return Font(font: self, size: size)
-  }
-
-  internal func register() {
-    // swiftlint:disable:next conditional_returns_on_newline
-    guard let url = url else { return }
-    CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
-  }
-
-  fileprivate var url: URL? {
-    let bundle = Bundle(for: BundleToken.self)
-    return bundle.url(forResource: path, withExtension: nil)
-  }
-}
-
-internal extension Font {
-  convenience init!(font: FontConvertible, size: CGFloat) {
-    #if os(iOS) || os(tvOS) || os(watchOS)
-    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
-      font.register()
-    }
-    #elseif os(OSX)
-    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
-      font.register()
-    }
-    #endif
-
-    self.init(name: font.name, size: size)
-  }
-}
+// MARK: - Fonts
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal enum FontFamily {
@@ -93,5 +58,44 @@ internal enum FontFamily {
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+internal struct FontConvertible {
+  internal let name: String
+  internal let family: String
+  internal let path: String
+
+  internal func font(size: CGFloat) -> Font! {
+    return Font(font: self, size: size)
+  }
+
+  internal func register() {
+    // swiftlint:disable:next conditional_returns_on_newline
+    guard let url = url else { return }
+    CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
+  }
+
+  fileprivate var url: URL? {
+    let bundle = Bundle(for: BundleToken.self)
+    return bundle.url(forResource: path, withExtension: nil)
+  }
+}
+
+internal extension Font {
+  convenience init!(font: FontConvertible, size: CGFloat) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
+      font.register()
+    }
+    #elseif os(OSX)
+    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
+      font.register()
+    }
+    #endif
+
+    self.init(name: font.name, size: size)
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/Fonts/swift3-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift3-context-defaults-publicAccess.swift
@@ -12,42 +12,7 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-public struct FontConvertible {
-  public let name: String
-  public let family: String
-  public let path: String
-
-  public func font(size: CGFloat) -> Font! {
-    return Font(font: self, size: size)
-  }
-
-  public func register() {
-    // swiftlint:disable:next conditional_returns_on_newline
-    guard let url = url else { return }
-    CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
-  }
-
-  fileprivate var url: URL? {
-    let bundle = Bundle(for: BundleToken.self)
-    return bundle.url(forResource: path, withExtension: nil)
-  }
-}
-
-public extension Font {
-  convenience init!(font: FontConvertible, size: CGFloat) {
-    #if os(iOS) || os(tvOS) || os(watchOS)
-    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
-      font.register()
-    }
-    #elseif os(OSX)
-    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
-      font.register()
-    }
-    #endif
-
-    self.init(name: font.name, size: size)
-  }
-}
+// MARK: - Fonts
 
 // swiftlint:disable identifier_name line_length type_body_length
 public enum FontFamily {
@@ -93,5 +58,44 @@ public enum FontFamily {
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+public struct FontConvertible {
+  public let name: String
+  public let family: String
+  public let path: String
+
+  public func font(size: CGFloat) -> Font! {
+    return Font(font: self, size: size)
+  }
+
+  public func register() {
+    // swiftlint:disable:next conditional_returns_on_newline
+    guard let url = url else { return }
+    CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
+  }
+
+  fileprivate var url: URL? {
+    let bundle = Bundle(for: BundleToken.self)
+    return bundle.url(forResource: path, withExtension: nil)
+  }
+}
+
+public extension Font {
+  convenience init!(font: FontConvertible, size: CGFloat) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
+      font.register()
+    }
+    #elseif os(OSX)
+    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
+      font.register()
+    }
+    #endif
+
+    self.init(name: font.name, size: size)
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/Fonts/swift3-context-defaults.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift3-context-defaults.swift
@@ -12,42 +12,7 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-internal struct FontConvertible {
-  internal let name: String
-  internal let family: String
-  internal let path: String
-
-  internal func font(size: CGFloat) -> Font! {
-    return Font(font: self, size: size)
-  }
-
-  internal func register() {
-    // swiftlint:disable:next conditional_returns_on_newline
-    guard let url = url else { return }
-    CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
-  }
-
-  fileprivate var url: URL? {
-    let bundle = Bundle(for: BundleToken.self)
-    return bundle.url(forResource: path, withExtension: nil)
-  }
-}
-
-internal extension Font {
-  convenience init!(font: FontConvertible, size: CGFloat) {
-    #if os(iOS) || os(tvOS) || os(watchOS)
-    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
-      font.register()
-    }
-    #elseif os(OSX)
-    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
-      font.register()
-    }
-    #endif
-
-    self.init(name: font.name, size: size)
-  }
-}
+// MARK: - Fonts
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal enum FontFamily {
@@ -93,5 +58,44 @@ internal enum FontFamily {
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+internal struct FontConvertible {
+  internal let name: String
+  internal let family: String
+  internal let path: String
+
+  internal func font(size: CGFloat) -> Font! {
+    return Font(font: self, size: size)
+  }
+
+  internal func register() {
+    // swiftlint:disable:next conditional_returns_on_newline
+    guard let url = url else { return }
+    CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
+  }
+
+  fileprivate var url: URL? {
+    let bundle = Bundle(for: BundleToken.self)
+    return bundle.url(forResource: path, withExtension: nil)
+  }
+}
+
+internal extension Font {
+  convenience init!(font: FontConvertible, size: CGFloat) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
+      font.register()
+    }
+    #elseif os(OSX)
+    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
+      font.register()
+    }
+    #endif
+
+    self.init(name: font.name, size: size)
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/Fonts/swift4-context-defaults-customname.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift4-context-defaults-customname.swift
@@ -12,42 +12,7 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-internal struct FontConvertible {
-  internal let name: String
-  internal let family: String
-  internal let path: String
-
-  internal func font(size: CGFloat) -> Font! {
-    return Font(font: self, size: size)
-  }
-
-  internal func register() {
-    // swiftlint:disable:next conditional_returns_on_newline
-    guard let url = url else { return }
-    CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
-  }
-
-  fileprivate var url: URL? {
-    let bundle = Bundle(for: BundleToken.self)
-    return bundle.url(forResource: path, withExtension: nil)
-  }
-}
-
-internal extension Font {
-  convenience init!(font: FontConvertible, size: CGFloat) {
-    #if os(iOS) || os(tvOS) || os(watchOS)
-    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
-      font.register()
-    }
-    #elseif os(OSX)
-    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
-      font.register()
-    }
-    #endif
-
-    self.init(name: font.name, size: size)
-  }
-}
+// MARK: - Fonts
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal enum CustomFamily {
@@ -93,5 +58,44 @@ internal enum CustomFamily {
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+internal struct FontConvertible {
+  internal let name: String
+  internal let family: String
+  internal let path: String
+
+  internal func font(size: CGFloat) -> Font! {
+    return Font(font: self, size: size)
+  }
+
+  internal func register() {
+    // swiftlint:disable:next conditional_returns_on_newline
+    guard let url = url else { return }
+    CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
+  }
+
+  fileprivate var url: URL? {
+    let bundle = Bundle(for: BundleToken.self)
+    return bundle.url(forResource: path, withExtension: nil)
+  }
+}
+
+internal extension Font {
+  convenience init!(font: FontConvertible, size: CGFloat) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
+      font.register()
+    }
+    #elseif os(OSX)
+    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
+      font.register()
+    }
+    #endif
+
+    self.init(name: font.name, size: size)
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/Fonts/swift4-context-defaults-preservepath.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift4-context-defaults-preservepath.swift
@@ -12,42 +12,7 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-internal struct FontConvertible {
-  internal let name: String
-  internal let family: String
-  internal let path: String
-
-  internal func font(size: CGFloat) -> Font! {
-    return Font(font: self, size: size)
-  }
-
-  internal func register() {
-    // swiftlint:disable:next conditional_returns_on_newline
-    guard let url = url else { return }
-    CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
-  }
-
-  fileprivate var url: URL? {
-    let bundle = Bundle(for: BundleToken.self)
-    return bundle.url(forResource: path, withExtension: nil)
-  }
-}
-
-internal extension Font {
-  convenience init!(font: FontConvertible, size: CGFloat) {
-    #if os(iOS) || os(tvOS) || os(watchOS)
-    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
-      font.register()
-    }
-    #elseif os(OSX)
-    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
-      font.register()
-    }
-    #endif
-
-    self.init(name: font.name, size: size)
-  }
-}
+// MARK: - Fonts
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal enum FontFamily {
@@ -93,5 +58,44 @@ internal enum FontFamily {
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+internal struct FontConvertible {
+  internal let name: String
+  internal let family: String
+  internal let path: String
+
+  internal func font(size: CGFloat) -> Font! {
+    return Font(font: self, size: size)
+  }
+
+  internal func register() {
+    // swiftlint:disable:next conditional_returns_on_newline
+    guard let url = url else { return }
+    CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
+  }
+
+  fileprivate var url: URL? {
+    let bundle = Bundle(for: BundleToken.self)
+    return bundle.url(forResource: path, withExtension: nil)
+  }
+}
+
+internal extension Font {
+  convenience init!(font: FontConvertible, size: CGFloat) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
+      font.register()
+    }
+    #elseif os(OSX)
+    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
+      font.register()
+    }
+    #endif
+
+    self.init(name: font.name, size: size)
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/Fonts/swift4-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift4-context-defaults-publicAccess.swift
@@ -12,42 +12,7 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-public struct FontConvertible {
-  public let name: String
-  public let family: String
-  public let path: String
-
-  public func font(size: CGFloat) -> Font! {
-    return Font(font: self, size: size)
-  }
-
-  public func register() {
-    // swiftlint:disable:next conditional_returns_on_newline
-    guard let url = url else { return }
-    CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
-  }
-
-  fileprivate var url: URL? {
-    let bundle = Bundle(for: BundleToken.self)
-    return bundle.url(forResource: path, withExtension: nil)
-  }
-}
-
-public extension Font {
-  convenience init!(font: FontConvertible, size: CGFloat) {
-    #if os(iOS) || os(tvOS) || os(watchOS)
-    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
-      font.register()
-    }
-    #elseif os(OSX)
-    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
-      font.register()
-    }
-    #endif
-
-    self.init(name: font.name, size: size)
-  }
-}
+// MARK: - Fonts
 
 // swiftlint:disable identifier_name line_length type_body_length
 public enum FontFamily {
@@ -93,5 +58,44 @@ public enum FontFamily {
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+public struct FontConvertible {
+  public let name: String
+  public let family: String
+  public let path: String
+
+  public func font(size: CGFloat) -> Font! {
+    return Font(font: self, size: size)
+  }
+
+  public func register() {
+    // swiftlint:disable:next conditional_returns_on_newline
+    guard let url = url else { return }
+    CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
+  }
+
+  fileprivate var url: URL? {
+    let bundle = Bundle(for: BundleToken.self)
+    return bundle.url(forResource: path, withExtension: nil)
+  }
+}
+
+public extension Font {
+  convenience init!(font: FontConvertible, size: CGFloat) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
+      font.register()
+    }
+    #elseif os(OSX)
+    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
+      font.register()
+    }
+    #endif
+
+    self.init(name: font.name, size: size)
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/Fonts/swift4-context-defaults.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift4-context-defaults.swift
@@ -12,42 +12,7 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-internal struct FontConvertible {
-  internal let name: String
-  internal let family: String
-  internal let path: String
-
-  internal func font(size: CGFloat) -> Font! {
-    return Font(font: self, size: size)
-  }
-
-  internal func register() {
-    // swiftlint:disable:next conditional_returns_on_newline
-    guard let url = url else { return }
-    CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
-  }
-
-  fileprivate var url: URL? {
-    let bundle = Bundle(for: BundleToken.self)
-    return bundle.url(forResource: path, withExtension: nil)
-  }
-}
-
-internal extension Font {
-  convenience init!(font: FontConvertible, size: CGFloat) {
-    #if os(iOS) || os(tvOS) || os(watchOS)
-    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
-      font.register()
-    }
-    #elseif os(OSX)
-    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
-      font.register()
-    }
-    #endif
-
-    self.init(name: font.name, size: size)
-  }
-}
+// MARK: - Fonts
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal enum FontFamily {
@@ -93,5 +58,44 @@ internal enum FontFamily {
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+internal struct FontConvertible {
+  internal let name: String
+  internal let family: String
+  internal let path: String
+
+  internal func font(size: CGFloat) -> Font! {
+    return Font(font: self, size: size)
+  }
+
+  internal func register() {
+    // swiftlint:disable:next conditional_returns_on_newline
+    guard let url = url else { return }
+    CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
+  }
+
+  fileprivate var url: URL? {
+    let bundle = Bundle(for: BundleToken.self)
+    return bundle.url(forResource: path, withExtension: nil)
+  }
+}
+
+internal extension Font {
+  convenience init!(font: FontConvertible, size: CGFloat) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
+      font.register()
+    }
+    #elseif os(OSX)
+    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
+      font.register()
+    }
+    #endif
+
+    self.init(name: font.name, size: size)
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/IB-iOS/swift3-context-all-customname.swift
+++ b/Tests/Fixtures/Generated/IB-iOS/swift3-context-all-customname.swift
@@ -13,46 +13,7 @@ import UIKit
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-internal protocol StoryboardType {
-  static var storyboardName: String { get }
-}
-
-internal extension StoryboardType {
-  static var storyboard: UIStoryboard {
-    return UIStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
-  }
-}
-
-internal struct SceneType<T: UIViewController> {
-  internal let storyboard: StoryboardType.Type
-  internal let identifier: String
-
-  internal func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateViewController(withIdentifier: identifier) as? T else {
-      fatalError("ViewController '\(identifier)' is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal struct InitialSceneType<T: UIViewController> {
-  internal let storyboard: StoryboardType.Type
-
-  internal func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateInitialViewController() as? T else {
-      fatalError("ViewController is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal protocol SegueType: RawRepresentable { }
-
-internal extension UIViewController {
-  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
-    performSegue(withIdentifier: segue.rawValue, sender: sender)
-  }
-}
+// MARK: - Storyboards
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 internal enum XCTStoryboardsScene {
@@ -142,5 +103,48 @@ internal enum XCTStoryboardsSegue {
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
+internal protocol StoryboardType {
+  static var storyboardName: String { get }
+}
+
+internal extension StoryboardType {
+  static var storyboard: UIStoryboard {
+    return UIStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
+  }
+}
+
+internal struct SceneType<T: UIViewController> {
+  internal let storyboard: StoryboardType.Type
+  internal let identifier: String
+
+  internal func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateViewController(withIdentifier: identifier) as? T else {
+      fatalError("ViewController '\(identifier)' is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal struct InitialSceneType<T: UIViewController> {
+  internal let storyboard: StoryboardType.Type
+
+  internal func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateInitialViewController() as? T else {
+      fatalError("ViewController is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal protocol SegueType: RawRepresentable { }
+
+internal extension UIViewController {
+  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/IB-iOS/swift3-context-all-ignore-module-need-extra-definitions.swift
+++ b/Tests/Fixtures/Generated/IB-iOS/swift3-context-all-ignore-module-need-extra-definitions.swift
@@ -12,46 +12,7 @@ import UIKit
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-internal protocol StoryboardType {
-  static var storyboardName: String { get }
-}
-
-internal extension StoryboardType {
-  static var storyboard: UIStoryboard {
-    return UIStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
-  }
-}
-
-internal struct SceneType<T: UIViewController> {
-  internal let storyboard: StoryboardType.Type
-  internal let identifier: String
-
-  internal func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateViewController(withIdentifier: identifier) as? T else {
-      fatalError("ViewController '\(identifier)' is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal struct InitialSceneType<T: UIViewController> {
-  internal let storyboard: StoryboardType.Type
-
-  internal func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateInitialViewController() as? T else {
-      fatalError("ViewController is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal protocol SegueType: RawRepresentable { }
-
-internal extension UIViewController {
-  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
-    performSegue(withIdentifier: segue.rawValue, sender: sender)
-  }
-}
+// MARK: - Storyboards
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 internal enum StoryboardScene {
@@ -141,5 +102,48 @@ internal enum StoryboardSegue {
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
+internal protocol StoryboardType {
+  static var storyboardName: String { get }
+}
+
+internal extension StoryboardType {
+  static var storyboard: UIStoryboard {
+    return UIStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
+  }
+}
+
+internal struct SceneType<T: UIViewController> {
+  internal let storyboard: StoryboardType.Type
+  internal let identifier: String
+
+  internal func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateViewController(withIdentifier: identifier) as? T else {
+      fatalError("ViewController '\(identifier)' is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal struct InitialSceneType<T: UIViewController> {
+  internal let storyboard: StoryboardType.Type
+
+  internal func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateInitialViewController() as? T else {
+      fatalError("ViewController is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal protocol SegueType: RawRepresentable { }
+
+internal extension UIViewController {
+  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/IB-iOS/swift3-context-all-ignore-module.swift
+++ b/Tests/Fixtures/Generated/IB-iOS/swift3-context-all-ignore-module.swift
@@ -12,46 +12,7 @@ import UIKit
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-internal protocol StoryboardType {
-  static var storyboardName: String { get }
-}
-
-internal extension StoryboardType {
-  static var storyboard: UIStoryboard {
-    return UIStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
-  }
-}
-
-internal struct SceneType<T: UIViewController> {
-  internal let storyboard: StoryboardType.Type
-  internal let identifier: String
-
-  internal func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateViewController(withIdentifier: identifier) as? T else {
-      fatalError("ViewController '\(identifier)' is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal struct InitialSceneType<T: UIViewController> {
-  internal let storyboard: StoryboardType.Type
-
-  internal func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateInitialViewController() as? T else {
-      fatalError("ViewController is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal protocol SegueType: RawRepresentable { }
-
-internal extension UIViewController {
-  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
-    performSegue(withIdentifier: segue.rawValue, sender: sender)
-  }
-}
+// MARK: - Storyboards
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 internal enum StoryboardScene {
@@ -141,5 +102,48 @@ internal enum StoryboardSegue {
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
+internal protocol StoryboardType {
+  static var storyboardName: String { get }
+}
+
+internal extension StoryboardType {
+  static var storyboard: UIStoryboard {
+    return UIStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
+  }
+}
+
+internal struct SceneType<T: UIViewController> {
+  internal let storyboard: StoryboardType.Type
+  internal let identifier: String
+
+  internal func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateViewController(withIdentifier: identifier) as? T else {
+      fatalError("ViewController '\(identifier)' is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal struct InitialSceneType<T: UIViewController> {
+  internal let storyboard: StoryboardType.Type
+
+  internal func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateInitialViewController() as? T else {
+      fatalError("ViewController is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal protocol SegueType: RawRepresentable { }
+
+internal extension UIViewController {
+  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/IB-iOS/swift3-context-all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/IB-iOS/swift3-context-all-publicAccess.swift
@@ -13,46 +13,7 @@ import UIKit
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-public protocol StoryboardType {
-  static var storyboardName: String { get }
-}
-
-public extension StoryboardType {
-  static var storyboard: UIStoryboard {
-    return UIStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
-  }
-}
-
-public struct SceneType<T: UIViewController> {
-  public let storyboard: StoryboardType.Type
-  public let identifier: String
-
-  public func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateViewController(withIdentifier: identifier) as? T else {
-      fatalError("ViewController '\(identifier)' is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-public struct InitialSceneType<T: UIViewController> {
-  public let storyboard: StoryboardType.Type
-
-  public func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateInitialViewController() as? T else {
-      fatalError("ViewController is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-public protocol SegueType: RawRepresentable { }
-
-public extension UIViewController {
-  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
-    performSegue(withIdentifier: segue.rawValue, sender: sender)
-  }
-}
+// MARK: - Storyboards
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 public enum StoryboardScene {
@@ -142,5 +103,48 @@ public enum StoryboardSegue {
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
+public protocol StoryboardType {
+  static var storyboardName: String { get }
+}
+
+public extension StoryboardType {
+  static var storyboard: UIStoryboard {
+    return UIStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
+  }
+}
+
+public struct SceneType<T: UIViewController> {
+  public let storyboard: StoryboardType.Type
+  public let identifier: String
+
+  public func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateViewController(withIdentifier: identifier) as? T else {
+      fatalError("ViewController '\(identifier)' is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+public struct InitialSceneType<T: UIViewController> {
+  public let storyboard: StoryboardType.Type
+
+  public func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateInitialViewController() as? T else {
+      fatalError("ViewController is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+public protocol SegueType: RawRepresentable { }
+
+public extension UIViewController {
+  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/IB-iOS/swift3-context-all.swift
+++ b/Tests/Fixtures/Generated/IB-iOS/swift3-context-all.swift
@@ -13,46 +13,7 @@ import UIKit
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-internal protocol StoryboardType {
-  static var storyboardName: String { get }
-}
-
-internal extension StoryboardType {
-  static var storyboard: UIStoryboard {
-    return UIStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
-  }
-}
-
-internal struct SceneType<T: UIViewController> {
-  internal let storyboard: StoryboardType.Type
-  internal let identifier: String
-
-  internal func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateViewController(withIdentifier: identifier) as? T else {
-      fatalError("ViewController '\(identifier)' is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal struct InitialSceneType<T: UIViewController> {
-  internal let storyboard: StoryboardType.Type
-
-  internal func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateInitialViewController() as? T else {
-      fatalError("ViewController is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal protocol SegueType: RawRepresentable { }
-
-internal extension UIViewController {
-  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
-    performSegue(withIdentifier: segue.rawValue, sender: sender)
-  }
-}
+// MARK: - Storyboards
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 internal enum StoryboardScene {
@@ -142,5 +103,48 @@ internal enum StoryboardSegue {
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
+internal protocol StoryboardType {
+  static var storyboardName: String { get }
+}
+
+internal extension StoryboardType {
+  static var storyboard: UIStoryboard {
+    return UIStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
+  }
+}
+
+internal struct SceneType<T: UIViewController> {
+  internal let storyboard: StoryboardType.Type
+  internal let identifier: String
+
+  internal func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateViewController(withIdentifier: identifier) as? T else {
+      fatalError("ViewController '\(identifier)' is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal struct InitialSceneType<T: UIViewController> {
+  internal let storyboard: StoryboardType.Type
+
+  internal func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateInitialViewController() as? T else {
+      fatalError("ViewController is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal protocol SegueType: RawRepresentable { }
+
+internal extension UIViewController {
+  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
+    performSegue(withIdentifier: segue.rawValue, sender: sender)
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/IB-iOS/swift4-context-all-customname.swift
+++ b/Tests/Fixtures/Generated/IB-iOS/swift4-context-all-customname.swift
@@ -13,49 +13,7 @@ import UIKit
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-internal protocol StoryboardType {
-  static var storyboardName: String { get }
-}
-
-internal extension StoryboardType {
-  static var storyboard: UIStoryboard {
-    let name = self.storyboardName
-    return UIStoryboard(name: name, bundle: Bundle(for: BundleToken.self))
-  }
-}
-
-internal struct SceneType<T: UIViewController> {
-  internal let storyboard: StoryboardType.Type
-  internal let identifier: String
-
-  internal func instantiate() -> T {
-    let identifier = self.identifier
-    guard let controller = storyboard.storyboard.instantiateViewController(withIdentifier: identifier) as? T else {
-      fatalError("ViewController '\(identifier)' is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal struct InitialSceneType<T: UIViewController> {
-  internal let storyboard: StoryboardType.Type
-
-  internal func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateInitialViewController() as? T else {
-      fatalError("ViewController is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal protocol SegueType: RawRepresentable { }
-
-internal extension UIViewController {
-  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
-    let identifier = segue.rawValue
-    performSegue(withIdentifier: identifier, sender: sender)
-  }
-}
+// MARK: - Storyboards
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 internal enum XCTStoryboardsScene {
@@ -145,5 +103,51 @@ internal enum XCTStoryboardsSegue {
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
+internal protocol StoryboardType {
+  static var storyboardName: String { get }
+}
+
+internal extension StoryboardType {
+  static var storyboard: UIStoryboard {
+    let name = self.storyboardName
+    return UIStoryboard(name: name, bundle: Bundle(for: BundleToken.self))
+  }
+}
+
+internal struct SceneType<T: UIViewController> {
+  internal let storyboard: StoryboardType.Type
+  internal let identifier: String
+
+  internal func instantiate() -> T {
+    let identifier = self.identifier
+    guard let controller = storyboard.storyboard.instantiateViewController(withIdentifier: identifier) as? T else {
+      fatalError("ViewController '\(identifier)' is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal struct InitialSceneType<T: UIViewController> {
+  internal let storyboard: StoryboardType.Type
+
+  internal func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateInitialViewController() as? T else {
+      fatalError("ViewController is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal protocol SegueType: RawRepresentable { }
+
+internal extension UIViewController {
+  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/IB-iOS/swift4-context-all-ignore-module-need-extra-definitions.swift
+++ b/Tests/Fixtures/Generated/IB-iOS/swift4-context-all-ignore-module-need-extra-definitions.swift
@@ -12,49 +12,7 @@ import UIKit
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-internal protocol StoryboardType {
-  static var storyboardName: String { get }
-}
-
-internal extension StoryboardType {
-  static var storyboard: UIStoryboard {
-    let name = self.storyboardName
-    return UIStoryboard(name: name, bundle: Bundle(for: BundleToken.self))
-  }
-}
-
-internal struct SceneType<T: UIViewController> {
-  internal let storyboard: StoryboardType.Type
-  internal let identifier: String
-
-  internal func instantiate() -> T {
-    let identifier = self.identifier
-    guard let controller = storyboard.storyboard.instantiateViewController(withIdentifier: identifier) as? T else {
-      fatalError("ViewController '\(identifier)' is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal struct InitialSceneType<T: UIViewController> {
-  internal let storyboard: StoryboardType.Type
-
-  internal func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateInitialViewController() as? T else {
-      fatalError("ViewController is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal protocol SegueType: RawRepresentable { }
-
-internal extension UIViewController {
-  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
-    let identifier = segue.rawValue
-    performSegue(withIdentifier: identifier, sender: sender)
-  }
-}
+// MARK: - Storyboards
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 internal enum StoryboardScene {
@@ -144,5 +102,51 @@ internal enum StoryboardSegue {
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
+internal protocol StoryboardType {
+  static var storyboardName: String { get }
+}
+
+internal extension StoryboardType {
+  static var storyboard: UIStoryboard {
+    let name = self.storyboardName
+    return UIStoryboard(name: name, bundle: Bundle(for: BundleToken.self))
+  }
+}
+
+internal struct SceneType<T: UIViewController> {
+  internal let storyboard: StoryboardType.Type
+  internal let identifier: String
+
+  internal func instantiate() -> T {
+    let identifier = self.identifier
+    guard let controller = storyboard.storyboard.instantiateViewController(withIdentifier: identifier) as? T else {
+      fatalError("ViewController '\(identifier)' is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal struct InitialSceneType<T: UIViewController> {
+  internal let storyboard: StoryboardType.Type
+
+  internal func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateInitialViewController() as? T else {
+      fatalError("ViewController is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal protocol SegueType: RawRepresentable { }
+
+internal extension UIViewController {
+  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/IB-iOS/swift4-context-all-ignore-module.swift
+++ b/Tests/Fixtures/Generated/IB-iOS/swift4-context-all-ignore-module.swift
@@ -12,49 +12,7 @@ import UIKit
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-internal protocol StoryboardType {
-  static var storyboardName: String { get }
-}
-
-internal extension StoryboardType {
-  static var storyboard: UIStoryboard {
-    let name = self.storyboardName
-    return UIStoryboard(name: name, bundle: Bundle(for: BundleToken.self))
-  }
-}
-
-internal struct SceneType<T: UIViewController> {
-  internal let storyboard: StoryboardType.Type
-  internal let identifier: String
-
-  internal func instantiate() -> T {
-    let identifier = self.identifier
-    guard let controller = storyboard.storyboard.instantiateViewController(withIdentifier: identifier) as? T else {
-      fatalError("ViewController '\(identifier)' is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal struct InitialSceneType<T: UIViewController> {
-  internal let storyboard: StoryboardType.Type
-
-  internal func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateInitialViewController() as? T else {
-      fatalError("ViewController is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal protocol SegueType: RawRepresentable { }
-
-internal extension UIViewController {
-  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
-    let identifier = segue.rawValue
-    performSegue(withIdentifier: identifier, sender: sender)
-  }
-}
+// MARK: - Storyboards
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 internal enum StoryboardScene {
@@ -144,5 +102,51 @@ internal enum StoryboardSegue {
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
+internal protocol StoryboardType {
+  static var storyboardName: String { get }
+}
+
+internal extension StoryboardType {
+  static var storyboard: UIStoryboard {
+    let name = self.storyboardName
+    return UIStoryboard(name: name, bundle: Bundle(for: BundleToken.self))
+  }
+}
+
+internal struct SceneType<T: UIViewController> {
+  internal let storyboard: StoryboardType.Type
+  internal let identifier: String
+
+  internal func instantiate() -> T {
+    let identifier = self.identifier
+    guard let controller = storyboard.storyboard.instantiateViewController(withIdentifier: identifier) as? T else {
+      fatalError("ViewController '\(identifier)' is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal struct InitialSceneType<T: UIViewController> {
+  internal let storyboard: StoryboardType.Type
+
+  internal func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateInitialViewController() as? T else {
+      fatalError("ViewController is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal protocol SegueType: RawRepresentable { }
+
+internal extension UIViewController {
+  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/IB-iOS/swift4-context-all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/IB-iOS/swift4-context-all-publicAccess.swift
@@ -13,49 +13,7 @@ import UIKit
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-public protocol StoryboardType {
-  static var storyboardName: String { get }
-}
-
-public extension StoryboardType {
-  static var storyboard: UIStoryboard {
-    let name = self.storyboardName
-    return UIStoryboard(name: name, bundle: Bundle(for: BundleToken.self))
-  }
-}
-
-public struct SceneType<T: UIViewController> {
-  public let storyboard: StoryboardType.Type
-  public let identifier: String
-
-  public func instantiate() -> T {
-    let identifier = self.identifier
-    guard let controller = storyboard.storyboard.instantiateViewController(withIdentifier: identifier) as? T else {
-      fatalError("ViewController '\(identifier)' is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-public struct InitialSceneType<T: UIViewController> {
-  public let storyboard: StoryboardType.Type
-
-  public func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateInitialViewController() as? T else {
-      fatalError("ViewController is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-public protocol SegueType: RawRepresentable { }
-
-public extension UIViewController {
-  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
-    let identifier = segue.rawValue
-    performSegue(withIdentifier: identifier, sender: sender)
-  }
-}
+// MARK: - Storyboards
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 public enum StoryboardScene {
@@ -145,5 +103,51 @@ public enum StoryboardSegue {
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
+public protocol StoryboardType {
+  static var storyboardName: String { get }
+}
+
+public extension StoryboardType {
+  static var storyboard: UIStoryboard {
+    let name = self.storyboardName
+    return UIStoryboard(name: name, bundle: Bundle(for: BundleToken.self))
+  }
+}
+
+public struct SceneType<T: UIViewController> {
+  public let storyboard: StoryboardType.Type
+  public let identifier: String
+
+  public func instantiate() -> T {
+    let identifier = self.identifier
+    guard let controller = storyboard.storyboard.instantiateViewController(withIdentifier: identifier) as? T else {
+      fatalError("ViewController '\(identifier)' is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+public struct InitialSceneType<T: UIViewController> {
+  public let storyboard: StoryboardType.Type
+
+  public func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateInitialViewController() as? T else {
+      fatalError("ViewController is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+public protocol SegueType: RawRepresentable { }
+
+public extension UIViewController {
+  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/IB-iOS/swift4-context-all.swift
+++ b/Tests/Fixtures/Generated/IB-iOS/swift4-context-all.swift
@@ -13,49 +13,7 @@ import UIKit
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-internal protocol StoryboardType {
-  static var storyboardName: String { get }
-}
-
-internal extension StoryboardType {
-  static var storyboard: UIStoryboard {
-    let name = self.storyboardName
-    return UIStoryboard(name: name, bundle: Bundle(for: BundleToken.self))
-  }
-}
-
-internal struct SceneType<T: UIViewController> {
-  internal let storyboard: StoryboardType.Type
-  internal let identifier: String
-
-  internal func instantiate() -> T {
-    let identifier = self.identifier
-    guard let controller = storyboard.storyboard.instantiateViewController(withIdentifier: identifier) as? T else {
-      fatalError("ViewController '\(identifier)' is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal struct InitialSceneType<T: UIViewController> {
-  internal let storyboard: StoryboardType.Type
-
-  internal func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateInitialViewController() as? T else {
-      fatalError("ViewController is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal protocol SegueType: RawRepresentable { }
-
-internal extension UIViewController {
-  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
-    let identifier = segue.rawValue
-    performSegue(withIdentifier: identifier, sender: sender)
-  }
-}
+// MARK: - Storyboards
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 internal enum StoryboardScene {
@@ -145,5 +103,51 @@ internal enum StoryboardSegue {
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
+internal protocol StoryboardType {
+  static var storyboardName: String { get }
+}
+
+internal extension StoryboardType {
+  static var storyboard: UIStoryboard {
+    let name = self.storyboardName
+    return UIStoryboard(name: name, bundle: Bundle(for: BundleToken.self))
+  }
+}
+
+internal struct SceneType<T: UIViewController> {
+  internal let storyboard: StoryboardType.Type
+  internal let identifier: String
+
+  internal func instantiate() -> T {
+    let identifier = self.identifier
+    guard let controller = storyboard.storyboard.instantiateViewController(withIdentifier: identifier) as? T else {
+      fatalError("ViewController '\(identifier)' is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal struct InitialSceneType<T: UIViewController> {
+  internal let storyboard: StoryboardType.Type
+
+  internal func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateInitialViewController() as? T else {
+      fatalError("ViewController is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal protocol SegueType: RawRepresentable { }
+
+internal extension UIViewController {
+  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
+    let identifier = segue.rawValue
+    performSegue(withIdentifier: identifier, sender: sender)
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/IB-macOS/swift3-context-all-customname.swift
+++ b/Tests/Fixtures/Generated/IB-macOS/swift3-context-all-customname.swift
@@ -10,46 +10,7 @@ import PrefsWindowController
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-internal protocol StoryboardType {
-  static var storyboardName: String { get }
-}
-
-internal extension StoryboardType {
-  static var storyboard: NSStoryboard {
-    return NSStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
-  }
-}
-
-internal struct SceneType<T> {
-  internal let storyboard: StoryboardType.Type
-  internal let identifier: String
-
-  internal func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateController(withIdentifier: identifier) as? T else {
-      fatalError("Controller '\(identifier)' is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal struct InitialSceneType<T> {
-  internal let storyboard: StoryboardType.Type
-
-  internal func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateInitialController() as? T else {
-      fatalError("Controller is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal protocol SegueType: RawRepresentable { }
-
-internal extension NSSeguePerforming {
-  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
-    performSegue?(withIdentifier: segue.rawValue, sender: sender)
-  }
-}
+// MARK: - Storyboards
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 internal enum XCTStoryboardsScene {
@@ -112,5 +73,48 @@ internal enum XCTStoryboardsSegue {
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
+internal protocol StoryboardType {
+  static var storyboardName: String { get }
+}
+
+internal extension StoryboardType {
+  static var storyboard: NSStoryboard {
+    return NSStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
+  }
+}
+
+internal struct SceneType<T> {
+  internal let storyboard: StoryboardType.Type
+  internal let identifier: String
+
+  internal func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateController(withIdentifier: identifier) as? T else {
+      fatalError("Controller '\(identifier)' is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal struct InitialSceneType<T> {
+  internal let storyboard: StoryboardType.Type
+
+  internal func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateInitialController() as? T else {
+      fatalError("Controller is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal protocol SegueType: RawRepresentable { }
+
+internal extension NSSeguePerforming {
+  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
+    performSegue?(withIdentifier: segue.rawValue, sender: sender)
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/IB-macOS/swift3-context-all-ignore-module-need-extra-definitions.swift
+++ b/Tests/Fixtures/Generated/IB-macOS/swift3-context-all-ignore-module-need-extra-definitions.swift
@@ -9,46 +9,7 @@ import FadeSegue
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-internal protocol StoryboardType {
-  static var storyboardName: String { get }
-}
-
-internal extension StoryboardType {
-  static var storyboard: NSStoryboard {
-    return NSStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
-  }
-}
-
-internal struct SceneType<T> {
-  internal let storyboard: StoryboardType.Type
-  internal let identifier: String
-
-  internal func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateController(withIdentifier: identifier) as? T else {
-      fatalError("Controller '\(identifier)' is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal struct InitialSceneType<T> {
-  internal let storyboard: StoryboardType.Type
-
-  internal func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateInitialController() as? T else {
-      fatalError("Controller is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal protocol SegueType: RawRepresentable { }
-
-internal extension NSSeguePerforming {
-  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
-    performSegue?(withIdentifier: segue.rawValue, sender: sender)
-  }
-}
+// MARK: - Storyboards
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 internal enum StoryboardScene {
@@ -111,5 +72,48 @@ internal enum StoryboardSegue {
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
+internal protocol StoryboardType {
+  static var storyboardName: String { get }
+}
+
+internal extension StoryboardType {
+  static var storyboard: NSStoryboard {
+    return NSStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
+  }
+}
+
+internal struct SceneType<T> {
+  internal let storyboard: StoryboardType.Type
+  internal let identifier: String
+
+  internal func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateController(withIdentifier: identifier) as? T else {
+      fatalError("Controller '\(identifier)' is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal struct InitialSceneType<T> {
+  internal let storyboard: StoryboardType.Type
+
+  internal func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateInitialController() as? T else {
+      fatalError("Controller is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal protocol SegueType: RawRepresentable { }
+
+internal extension NSSeguePerforming {
+  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
+    performSegue?(withIdentifier: segue.rawValue, sender: sender)
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/IB-macOS/swift3-context-all-ignore-module.swift
+++ b/Tests/Fixtures/Generated/IB-macOS/swift3-context-all-ignore-module.swift
@@ -9,46 +9,7 @@ import PrefsWindowController
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-internal protocol StoryboardType {
-  static var storyboardName: String { get }
-}
-
-internal extension StoryboardType {
-  static var storyboard: NSStoryboard {
-    return NSStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
-  }
-}
-
-internal struct SceneType<T> {
-  internal let storyboard: StoryboardType.Type
-  internal let identifier: String
-
-  internal func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateController(withIdentifier: identifier) as? T else {
-      fatalError("Controller '\(identifier)' is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal struct InitialSceneType<T> {
-  internal let storyboard: StoryboardType.Type
-
-  internal func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateInitialController() as? T else {
-      fatalError("Controller is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal protocol SegueType: RawRepresentable { }
-
-internal extension NSSeguePerforming {
-  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
-    performSegue?(withIdentifier: segue.rawValue, sender: sender)
-  }
-}
+// MARK: - Storyboards
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 internal enum StoryboardScene {
@@ -111,5 +72,48 @@ internal enum StoryboardSegue {
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
+internal protocol StoryboardType {
+  static var storyboardName: String { get }
+}
+
+internal extension StoryboardType {
+  static var storyboard: NSStoryboard {
+    return NSStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
+  }
+}
+
+internal struct SceneType<T> {
+  internal let storyboard: StoryboardType.Type
+  internal let identifier: String
+
+  internal func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateController(withIdentifier: identifier) as? T else {
+      fatalError("Controller '\(identifier)' is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal struct InitialSceneType<T> {
+  internal let storyboard: StoryboardType.Type
+
+  internal func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateInitialController() as? T else {
+      fatalError("Controller is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal protocol SegueType: RawRepresentable { }
+
+internal extension NSSeguePerforming {
+  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
+    performSegue?(withIdentifier: segue.rawValue, sender: sender)
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/IB-macOS/swift3-context-all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/IB-macOS/swift3-context-all-publicAccess.swift
@@ -10,46 +10,7 @@ import PrefsWindowController
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-public protocol StoryboardType {
-  static var storyboardName: String { get }
-}
-
-public extension StoryboardType {
-  static var storyboard: NSStoryboard {
-    return NSStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
-  }
-}
-
-public struct SceneType<T> {
-  public let storyboard: StoryboardType.Type
-  public let identifier: String
-
-  public func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateController(withIdentifier: identifier) as? T else {
-      fatalError("Controller '\(identifier)' is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-public struct InitialSceneType<T> {
-  public let storyboard: StoryboardType.Type
-
-  public func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateInitialController() as? T else {
-      fatalError("Controller is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-public protocol SegueType: RawRepresentable { }
-
-public extension NSSeguePerforming {
-  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
-    performSegue?(withIdentifier: segue.rawValue, sender: sender)
-  }
-}
+// MARK: - Storyboards
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 public enum StoryboardScene {
@@ -112,5 +73,48 @@ public enum StoryboardSegue {
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
+public protocol StoryboardType {
+  static var storyboardName: String { get }
+}
+
+public extension StoryboardType {
+  static var storyboard: NSStoryboard {
+    return NSStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
+  }
+}
+
+public struct SceneType<T> {
+  public let storyboard: StoryboardType.Type
+  public let identifier: String
+
+  public func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateController(withIdentifier: identifier) as? T else {
+      fatalError("Controller '\(identifier)' is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+public struct InitialSceneType<T> {
+  public let storyboard: StoryboardType.Type
+
+  public func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateInitialController() as? T else {
+      fatalError("Controller is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+public protocol SegueType: RawRepresentable { }
+
+public extension NSSeguePerforming {
+  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
+    performSegue?(withIdentifier: segue.rawValue, sender: sender)
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/IB-macOS/swift3-context-all.swift
+++ b/Tests/Fixtures/Generated/IB-macOS/swift3-context-all.swift
@@ -10,46 +10,7 @@ import PrefsWindowController
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-internal protocol StoryboardType {
-  static var storyboardName: String { get }
-}
-
-internal extension StoryboardType {
-  static var storyboard: NSStoryboard {
-    return NSStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
-  }
-}
-
-internal struct SceneType<T> {
-  internal let storyboard: StoryboardType.Type
-  internal let identifier: String
-
-  internal func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateController(withIdentifier: identifier) as? T else {
-      fatalError("Controller '\(identifier)' is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal struct InitialSceneType<T> {
-  internal let storyboard: StoryboardType.Type
-
-  internal func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateInitialController() as? T else {
-      fatalError("Controller is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal protocol SegueType: RawRepresentable { }
-
-internal extension NSSeguePerforming {
-  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
-    performSegue?(withIdentifier: segue.rawValue, sender: sender)
-  }
-}
+// MARK: - Storyboards
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 internal enum StoryboardScene {
@@ -112,5 +73,48 @@ internal enum StoryboardSegue {
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
+internal protocol StoryboardType {
+  static var storyboardName: String { get }
+}
+
+internal extension StoryboardType {
+  static var storyboard: NSStoryboard {
+    return NSStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
+  }
+}
+
+internal struct SceneType<T> {
+  internal let storyboard: StoryboardType.Type
+  internal let identifier: String
+
+  internal func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateController(withIdentifier: identifier) as? T else {
+      fatalError("Controller '\(identifier)' is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal struct InitialSceneType<T> {
+  internal let storyboard: StoryboardType.Type
+
+  internal func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateInitialController() as? T else {
+      fatalError("Controller is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal protocol SegueType: RawRepresentable { }
+
+internal extension NSSeguePerforming {
+  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
+    performSegue?(withIdentifier: segue.rawValue, sender: sender)
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/IB-macOS/swift4-context-all-customname.swift
+++ b/Tests/Fixtures/Generated/IB-macOS/swift4-context-all-customname.swift
@@ -10,49 +10,7 @@ import PrefsWindowController
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-internal protocol StoryboardType {
-  static var storyboardName: String { get }
-}
-
-internal extension StoryboardType {
-  static var storyboard: NSStoryboard {
-    let name = NSStoryboard.Name(self.storyboardName)
-    return NSStoryboard(name: name, bundle: Bundle(for: BundleToken.self))
-  }
-}
-
-internal struct SceneType<T> {
-  internal let storyboard: StoryboardType.Type
-  internal let identifier: String
-
-  internal func instantiate() -> T {
-    let identifier = NSStoryboard.SceneIdentifier(self.identifier)
-    guard let controller = storyboard.storyboard.instantiateController(withIdentifier: identifier) as? T else {
-      fatalError("Controller '\(identifier)' is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal struct InitialSceneType<T> {
-  internal let storyboard: StoryboardType.Type
-
-  internal func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateInitialController() as? T else {
-      fatalError("Controller is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal protocol SegueType: RawRepresentable { }
-
-internal extension NSSeguePerforming {
-  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
-    let identifier = NSStoryboardSegue.Identifier(segue.rawValue)
-    performSegue?(withIdentifier: identifier, sender: sender)
-  }
-}
+// MARK: - Storyboards
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 internal enum XCTStoryboardsScene {
@@ -115,5 +73,51 @@ internal enum XCTStoryboardsSegue {
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
+internal protocol StoryboardType {
+  static var storyboardName: String { get }
+}
+
+internal extension StoryboardType {
+  static var storyboard: NSStoryboard {
+    let name = NSStoryboard.Name(self.storyboardName)
+    return NSStoryboard(name: name, bundle: Bundle(for: BundleToken.self))
+  }
+}
+
+internal struct SceneType<T> {
+  internal let storyboard: StoryboardType.Type
+  internal let identifier: String
+
+  internal func instantiate() -> T {
+    let identifier = NSStoryboard.SceneIdentifier(self.identifier)
+    guard let controller = storyboard.storyboard.instantiateController(withIdentifier: identifier) as? T else {
+      fatalError("Controller '\(identifier)' is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal struct InitialSceneType<T> {
+  internal let storyboard: StoryboardType.Type
+
+  internal func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateInitialController() as? T else {
+      fatalError("Controller is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal protocol SegueType: RawRepresentable { }
+
+internal extension NSSeguePerforming {
+  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
+    let identifier = NSStoryboardSegue.Identifier(segue.rawValue)
+    performSegue?(withIdentifier: identifier, sender: sender)
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/IB-macOS/swift4-context-all-ignore-module-need-extra-definitions.swift
+++ b/Tests/Fixtures/Generated/IB-macOS/swift4-context-all-ignore-module-need-extra-definitions.swift
@@ -9,49 +9,7 @@ import FadeSegue
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-internal protocol StoryboardType {
-  static var storyboardName: String { get }
-}
-
-internal extension StoryboardType {
-  static var storyboard: NSStoryboard {
-    let name = NSStoryboard.Name(self.storyboardName)
-    return NSStoryboard(name: name, bundle: Bundle(for: BundleToken.self))
-  }
-}
-
-internal struct SceneType<T> {
-  internal let storyboard: StoryboardType.Type
-  internal let identifier: String
-
-  internal func instantiate() -> T {
-    let identifier = NSStoryboard.SceneIdentifier(self.identifier)
-    guard let controller = storyboard.storyboard.instantiateController(withIdentifier: identifier) as? T else {
-      fatalError("Controller '\(identifier)' is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal struct InitialSceneType<T> {
-  internal let storyboard: StoryboardType.Type
-
-  internal func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateInitialController() as? T else {
-      fatalError("Controller is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal protocol SegueType: RawRepresentable { }
-
-internal extension NSSeguePerforming {
-  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
-    let identifier = NSStoryboardSegue.Identifier(segue.rawValue)
-    performSegue?(withIdentifier: identifier, sender: sender)
-  }
-}
+// MARK: - Storyboards
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 internal enum StoryboardScene {
@@ -114,5 +72,51 @@ internal enum StoryboardSegue {
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
+internal protocol StoryboardType {
+  static var storyboardName: String { get }
+}
+
+internal extension StoryboardType {
+  static var storyboard: NSStoryboard {
+    let name = NSStoryboard.Name(self.storyboardName)
+    return NSStoryboard(name: name, bundle: Bundle(for: BundleToken.self))
+  }
+}
+
+internal struct SceneType<T> {
+  internal let storyboard: StoryboardType.Type
+  internal let identifier: String
+
+  internal func instantiate() -> T {
+    let identifier = NSStoryboard.SceneIdentifier(self.identifier)
+    guard let controller = storyboard.storyboard.instantiateController(withIdentifier: identifier) as? T else {
+      fatalError("Controller '\(identifier)' is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal struct InitialSceneType<T> {
+  internal let storyboard: StoryboardType.Type
+
+  internal func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateInitialController() as? T else {
+      fatalError("Controller is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal protocol SegueType: RawRepresentable { }
+
+internal extension NSSeguePerforming {
+  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
+    let identifier = NSStoryboardSegue.Identifier(segue.rawValue)
+    performSegue?(withIdentifier: identifier, sender: sender)
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/IB-macOS/swift4-context-all-ignore-module.swift
+++ b/Tests/Fixtures/Generated/IB-macOS/swift4-context-all-ignore-module.swift
@@ -9,49 +9,7 @@ import PrefsWindowController
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-internal protocol StoryboardType {
-  static var storyboardName: String { get }
-}
-
-internal extension StoryboardType {
-  static var storyboard: NSStoryboard {
-    let name = NSStoryboard.Name(self.storyboardName)
-    return NSStoryboard(name: name, bundle: Bundle(for: BundleToken.self))
-  }
-}
-
-internal struct SceneType<T> {
-  internal let storyboard: StoryboardType.Type
-  internal let identifier: String
-
-  internal func instantiate() -> T {
-    let identifier = NSStoryboard.SceneIdentifier(self.identifier)
-    guard let controller = storyboard.storyboard.instantiateController(withIdentifier: identifier) as? T else {
-      fatalError("Controller '\(identifier)' is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal struct InitialSceneType<T> {
-  internal let storyboard: StoryboardType.Type
-
-  internal func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateInitialController() as? T else {
-      fatalError("Controller is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal protocol SegueType: RawRepresentable { }
-
-internal extension NSSeguePerforming {
-  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
-    let identifier = NSStoryboardSegue.Identifier(segue.rawValue)
-    performSegue?(withIdentifier: identifier, sender: sender)
-  }
-}
+// MARK: - Storyboards
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 internal enum StoryboardScene {
@@ -114,5 +72,51 @@ internal enum StoryboardSegue {
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
+internal protocol StoryboardType {
+  static var storyboardName: String { get }
+}
+
+internal extension StoryboardType {
+  static var storyboard: NSStoryboard {
+    let name = NSStoryboard.Name(self.storyboardName)
+    return NSStoryboard(name: name, bundle: Bundle(for: BundleToken.self))
+  }
+}
+
+internal struct SceneType<T> {
+  internal let storyboard: StoryboardType.Type
+  internal let identifier: String
+
+  internal func instantiate() -> T {
+    let identifier = NSStoryboard.SceneIdentifier(self.identifier)
+    guard let controller = storyboard.storyboard.instantiateController(withIdentifier: identifier) as? T else {
+      fatalError("Controller '\(identifier)' is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal struct InitialSceneType<T> {
+  internal let storyboard: StoryboardType.Type
+
+  internal func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateInitialController() as? T else {
+      fatalError("Controller is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal protocol SegueType: RawRepresentable { }
+
+internal extension NSSeguePerforming {
+  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
+    let identifier = NSStoryboardSegue.Identifier(segue.rawValue)
+    performSegue?(withIdentifier: identifier, sender: sender)
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/IB-macOS/swift4-context-all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/IB-macOS/swift4-context-all-publicAccess.swift
@@ -10,49 +10,7 @@ import PrefsWindowController
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-public protocol StoryboardType {
-  static var storyboardName: String { get }
-}
-
-public extension StoryboardType {
-  static var storyboard: NSStoryboard {
-    let name = NSStoryboard.Name(self.storyboardName)
-    return NSStoryboard(name: name, bundle: Bundle(for: BundleToken.self))
-  }
-}
-
-public struct SceneType<T> {
-  public let storyboard: StoryboardType.Type
-  public let identifier: String
-
-  public func instantiate() -> T {
-    let identifier = NSStoryboard.SceneIdentifier(self.identifier)
-    guard let controller = storyboard.storyboard.instantiateController(withIdentifier: identifier) as? T else {
-      fatalError("Controller '\(identifier)' is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-public struct InitialSceneType<T> {
-  public let storyboard: StoryboardType.Type
-
-  public func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateInitialController() as? T else {
-      fatalError("Controller is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-public protocol SegueType: RawRepresentable { }
-
-public extension NSSeguePerforming {
-  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
-    let identifier = NSStoryboardSegue.Identifier(segue.rawValue)
-    performSegue?(withIdentifier: identifier, sender: sender)
-  }
-}
+// MARK: - Storyboards
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 public enum StoryboardScene {
@@ -115,5 +73,51 @@ public enum StoryboardSegue {
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
+public protocol StoryboardType {
+  static var storyboardName: String { get }
+}
+
+public extension StoryboardType {
+  static var storyboard: NSStoryboard {
+    let name = NSStoryboard.Name(self.storyboardName)
+    return NSStoryboard(name: name, bundle: Bundle(for: BundleToken.self))
+  }
+}
+
+public struct SceneType<T> {
+  public let storyboard: StoryboardType.Type
+  public let identifier: String
+
+  public func instantiate() -> T {
+    let identifier = NSStoryboard.SceneIdentifier(self.identifier)
+    guard let controller = storyboard.storyboard.instantiateController(withIdentifier: identifier) as? T else {
+      fatalError("Controller '\(identifier)' is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+public struct InitialSceneType<T> {
+  public let storyboard: StoryboardType.Type
+
+  public func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateInitialController() as? T else {
+      fatalError("Controller is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+public protocol SegueType: RawRepresentable { }
+
+public extension NSSeguePerforming {
+  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
+    let identifier = NSStoryboardSegue.Identifier(segue.rawValue)
+    performSegue?(withIdentifier: identifier, sender: sender)
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/IB-macOS/swift4-context-all.swift
+++ b/Tests/Fixtures/Generated/IB-macOS/swift4-context-all.swift
@@ -10,49 +10,7 @@ import PrefsWindowController
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-internal protocol StoryboardType {
-  static var storyboardName: String { get }
-}
-
-internal extension StoryboardType {
-  static var storyboard: NSStoryboard {
-    let name = NSStoryboard.Name(self.storyboardName)
-    return NSStoryboard(name: name, bundle: Bundle(for: BundleToken.self))
-  }
-}
-
-internal struct SceneType<T> {
-  internal let storyboard: StoryboardType.Type
-  internal let identifier: String
-
-  internal func instantiate() -> T {
-    let identifier = NSStoryboard.SceneIdentifier(self.identifier)
-    guard let controller = storyboard.storyboard.instantiateController(withIdentifier: identifier) as? T else {
-      fatalError("Controller '\(identifier)' is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal struct InitialSceneType<T> {
-  internal let storyboard: StoryboardType.Type
-
-  internal func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateInitialController() as? T else {
-      fatalError("Controller is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-internal protocol SegueType: RawRepresentable { }
-
-internal extension NSSeguePerforming {
-  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
-    let identifier = NSStoryboardSegue.Identifier(segue.rawValue)
-    performSegue?(withIdentifier: identifier, sender: sender)
-  }
-}
+// MARK: - Storyboards
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 internal enum StoryboardScene {
@@ -115,5 +73,51 @@ internal enum StoryboardSegue {
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
+internal protocol StoryboardType {
+  static var storyboardName: String { get }
+}
+
+internal extension StoryboardType {
+  static var storyboard: NSStoryboard {
+    let name = NSStoryboard.Name(self.storyboardName)
+    return NSStoryboard(name: name, bundle: Bundle(for: BundleToken.self))
+  }
+}
+
+internal struct SceneType<T> {
+  internal let storyboard: StoryboardType.Type
+  internal let identifier: String
+
+  internal func instantiate() -> T {
+    let identifier = NSStoryboard.SceneIdentifier(self.identifier)
+    guard let controller = storyboard.storyboard.instantiateController(withIdentifier: identifier) as? T else {
+      fatalError("Controller '\(identifier)' is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal struct InitialSceneType<T> {
+  internal let storyboard: StoryboardType.Type
+
+  internal func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateInitialController() as? T else {
+      fatalError("Controller is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal protocol SegueType: RawRepresentable { }
+
+internal extension NSSeguePerforming {
+  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
+    let identifier = NSStoryboardSegue.Identifier(segue.rawValue)
+    performSegue?(withIdentifier: identifier, sender: sender)
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable-customname.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable-customname.swift
@@ -6,6 +6,8 @@ import Foundation
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Strings
+
 // swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 internal enum XCTLoc {
   /// Some alert body there
@@ -40,6 +42,8 @@ internal enum XCTLoc {
   internal static let settingsUserProfileSectionHEADERTITLE = XCTLoc.tr("Localizable", "settings.user_profile_section.HEADER_TITLE")
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
 
 extension XCTLoc {
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable-no-comments.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable-no-comments.swift
@@ -6,6 +6,8 @@ import Foundation
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Strings
+
 // swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 internal enum L10n {
   internal static let alertMessage = L10n.tr("Localizable", "alert_message")
@@ -29,6 +31,8 @@ internal enum L10n {
   internal static let settingsUserProfileSectionHEADERTITLE = L10n.tr("Localizable", "settings.user_profile_section.HEADER_TITLE")
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
 
 extension L10n {
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable-publicAccess.swift
@@ -6,6 +6,8 @@ import Foundation
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Strings
+
 // swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 public enum L10n {
   /// Some alert body there
@@ -40,6 +42,8 @@ public enum L10n {
   public static let settingsUserProfileSectionHEADERTITLE = L10n.tr("Localizable", "settings.user_profile_section.HEADER_TITLE")
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
 
 extension L10n {
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable.swift
@@ -6,6 +6,8 @@ import Foundation
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Strings
+
 // swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 internal enum L10n {
   /// Some alert body there
@@ -40,6 +42,8 @@ internal enum L10n {
   internal static let settingsUserProfileSectionHEADERTITLE = L10n.tr("Localizable", "settings.user_profile_section.HEADER_TITLE")
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
 
 extension L10n {
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/flat-swift3-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift3-context-multiple.swift
@@ -6,6 +6,8 @@ import Foundation
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Strings
+
 // swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 internal enum L10n {
   internal enum Localizable {
@@ -54,6 +56,8 @@ internal enum L10n {
   }
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
 
 extension L10n {
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable-customname.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable-customname.swift
@@ -6,6 +6,8 @@ import Foundation
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Strings
+
 // swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 internal enum XCTLoc {
   /// Some alert body there
@@ -40,6 +42,8 @@ internal enum XCTLoc {
   internal static let settingsUserProfileSectionHEADERTITLE = XCTLoc.tr("Localizable", "settings.user_profile_section.HEADER_TITLE")
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
 
 extension XCTLoc {
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable-no-comments.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable-no-comments.swift
@@ -6,6 +6,8 @@ import Foundation
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Strings
+
 // swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 internal enum L10n {
   internal static let alertMessage = L10n.tr("Localizable", "alert_message")
@@ -29,6 +31,8 @@ internal enum L10n {
   internal static let settingsUserProfileSectionHEADERTITLE = L10n.tr("Localizable", "settings.user_profile_section.HEADER_TITLE")
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
 
 extension L10n {
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable-publicAccess.swift
@@ -6,6 +6,8 @@ import Foundation
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Strings
+
 // swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 public enum L10n {
   /// Some alert body there
@@ -40,6 +42,8 @@ public enum L10n {
   public static let settingsUserProfileSectionHEADERTITLE = L10n.tr("Localizable", "settings.user_profile_section.HEADER_TITLE")
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
 
 extension L10n {
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable.swift
@@ -6,6 +6,8 @@ import Foundation
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Strings
+
 // swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 internal enum L10n {
   /// Some alert body there
@@ -40,6 +42,8 @@ internal enum L10n {
   internal static let settingsUserProfileSectionHEADERTITLE = L10n.tr("Localizable", "settings.user_profile_section.HEADER_TITLE")
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
 
 extension L10n {
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/flat-swift4-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift4-context-multiple.swift
@@ -6,6 +6,8 @@ import Foundation
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Strings
+
 // swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 internal enum L10n {
   internal enum Localizable {
@@ -54,6 +56,8 @@ internal enum L10n {
   }
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
 
 extension L10n {
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable-customname.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable-customname.swift
@@ -6,6 +6,8 @@ import Foundation
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Strings
+
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name
 internal enum XCTLoc {
@@ -77,6 +79,8 @@ internal enum XCTLoc {
 }
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:enable nesting type_body_length type_name
+
+// MARK: - Implementation Details
 
 extension XCTLoc {
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable-no-comments.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable-no-comments.swift
@@ -6,6 +6,8 @@ import Foundation
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Strings
+
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name
 internal enum L10n {
@@ -66,6 +68,8 @@ internal enum L10n {
 }
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:enable nesting type_body_length type_name
+
+// MARK: - Implementation Details
 
 extension L10n {
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable-publicAccess.swift
@@ -6,6 +6,8 @@ import Foundation
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Strings
+
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name
 public enum L10n {
@@ -77,6 +79,8 @@ public enum L10n {
 }
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:enable nesting type_body_length type_name
+
+// MARK: - Implementation Details
 
 extension L10n {
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable.swift
@@ -6,6 +6,8 @@ import Foundation
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Strings
+
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name
 internal enum L10n {
@@ -77,6 +79,8 @@ internal enum L10n {
 }
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:enable nesting type_body_length type_name
+
+// MARK: - Implementation Details
 
 extension L10n {
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/structured-swift3-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift3-context-multiple.swift
@@ -6,6 +6,8 @@ import Foundation
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Strings
+
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name
 internal enum L10n {
@@ -88,6 +90,8 @@ internal enum L10n {
 }
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:enable nesting type_body_length type_name
+
+// MARK: - Implementation Details
 
 extension L10n {
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable-customname.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable-customname.swift
@@ -6,6 +6,8 @@ import Foundation
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Strings
+
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name
 internal enum XCTLoc {
@@ -77,6 +79,8 @@ internal enum XCTLoc {
 }
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:enable nesting type_body_length type_name
+
+// MARK: - Implementation Details
 
 extension XCTLoc {
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable-no-comments.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable-no-comments.swift
@@ -6,6 +6,8 @@ import Foundation
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Strings
+
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name
 internal enum L10n {
@@ -66,6 +68,8 @@ internal enum L10n {
 }
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:enable nesting type_body_length type_name
+
+// MARK: - Implementation Details
 
 extension L10n {
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable-publicAccess.swift
@@ -6,6 +6,8 @@ import Foundation
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Strings
+
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name
 public enum L10n {
@@ -77,6 +79,8 @@ public enum L10n {
 }
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:enable nesting type_body_length type_name
+
+// MARK: - Implementation Details
 
 extension L10n {
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable.swift
@@ -6,6 +6,8 @@ import Foundation
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Strings
+
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name
 internal enum L10n {
@@ -77,6 +79,8 @@ internal enum L10n {
 }
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:enable nesting type_body_length type_name
+
+// MARK: - Implementation Details
 
 extension L10n {
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/Strings/structured-swift4-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift4-context-multiple.swift
@@ -6,6 +6,8 @@ import Foundation
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Strings
+
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name
 internal enum L10n {
@@ -88,6 +90,8 @@ internal enum L10n {
 }
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:enable nesting type_body_length type_name
+
+// MARK: - Implementation Details
 
 extension L10n {
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Fixtures/Generated/XCAssets/swift3-context-all-customname.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift3-context-all-customname.swift
@@ -17,6 +17,93 @@ internal typealias XCTData = NSDataAsset
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Asset Catalogs
+
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
+internal enum XCTAssets {
+  internal enum Colors {
+    internal enum _24Vision {
+      internal static let background = XCTColorAsset(name: "24Vision/Background")
+      internal static let primary = XCTColorAsset(name: "24Vision/Primary")
+    }
+    internal static let orange = XCTImageAsset(name: "Orange")
+    internal enum Vengo {
+      internal static let primary = XCTColorAsset(name: "Vengo/Primary")
+      internal static let tint = XCTColorAsset(name: "Vengo/Tint")
+    }
+    // swiftlint:disable trailing_comma
+    internal static let allColors: [XCTColorAsset] = [
+      _24Vision.background,
+      _24Vision.primary,
+      Vengo.primary,
+      Vengo.tint,
+    ]
+    internal static let allDataAssets: [XCTDataAsset] = [
+    ]
+    internal static let allImages: [XCTImageAsset] = [
+      orange,
+    ]
+    // swiftlint:enable trailing_comma
+    @available(*, deprecated, renamed: "allImages")
+    internal static let allValues: [XCTAssetsType] = allImages
+  }
+  internal enum Data {
+    internal static let data = XCTDataAsset(name: "Data")
+    internal enum Json {
+      internal static let data = XCTDataAsset(name: "Json/Data")
+    }
+    internal static let readme = XCTDataAsset(name: "README")
+    // swiftlint:disable trailing_comma
+    internal static let allColors: [XCTColorAsset] = [
+    ]
+    internal static let allDataAssets: [XCTDataAsset] = [
+      data,
+      Json.data,
+      readme,
+    ]
+    internal static let allImages: [XCTImageAsset] = [
+    ]
+    // swiftlint:enable trailing_comma
+    @available(*, deprecated, renamed: "allImages")
+    internal static let allValues: [XCTAssetsType] = allImages
+  }
+  internal enum Images {
+    internal enum Exotic {
+      internal static let banana = XCTImageAsset(name: "Exotic/Banana")
+      internal static let mango = XCTImageAsset(name: "Exotic/Mango")
+    }
+    internal enum Round {
+      internal static let apricot = XCTImageAsset(name: "Round/Apricot")
+      internal static let apple = XCTImageAsset(name: "Round/Apple")
+      internal enum Double {
+        internal static let cherry = XCTImageAsset(name: "Round/Double/Cherry")
+      }
+      internal static let tomato = XCTImageAsset(name: "Round/Tomato")
+    }
+    internal static let `private` = XCTImageAsset(name: "private")
+    // swiftlint:disable trailing_comma
+    internal static let allColors: [XCTColorAsset] = [
+    ]
+    internal static let allDataAssets: [XCTDataAsset] = [
+    ]
+    internal static let allImages: [XCTImageAsset] = [
+      Exotic.banana,
+      Exotic.mango,
+      Round.apricot,
+      Round.apple,
+      Round.Double.cherry,
+      Round.tomato,
+      `private`,
+    ]
+    // swiftlint:enable trailing_comma
+    @available(*, deprecated, renamed: "allImages")
+    internal static let allValues: [XCTAssetsType] = allImages
+  }
+}
+// swiftlint:enable identifier_name line_length nesting type_body_length type_name
+
+// MARK: - Implementation Details
+
 internal struct XCTColorAsset {
   internal fileprivate(set) var name: String
 
@@ -102,90 +189,5 @@ internal extension XCTImage {
     #endif
   }
 }
-
-// MARK: Assets
-
-// swiftlint:disable identifier_name line_length nesting type_body_length type_name
-internal enum XCTAssets {
-  internal enum Colors {
-    internal enum _24Vision {
-      internal static let background = XCTColorAsset(name: "24Vision/Background")
-      internal static let primary = XCTColorAsset(name: "24Vision/Primary")
-    }
-    internal static let orange = XCTImageAsset(name: "Orange")
-    internal enum Vengo {
-      internal static let primary = XCTColorAsset(name: "Vengo/Primary")
-      internal static let tint = XCTColorAsset(name: "Vengo/Tint")
-    }
-    // swiftlint:disable trailing_comma
-    internal static let allColors: [XCTColorAsset] = [
-      _24Vision.background,
-      _24Vision.primary,
-      Vengo.primary,
-      Vengo.tint,
-    ]
-    internal static let allDataAssets: [XCTDataAsset] = [
-    ]
-    internal static let allImages: [XCTImageAsset] = [
-      orange,
-    ]
-    // swiftlint:enable trailing_comma
-    @available(*, deprecated, renamed: "allImages")
-    internal static let allValues: [XCTAssetsType] = allImages
-  }
-  internal enum Data {
-    internal static let data = XCTDataAsset(name: "Data")
-    internal enum Json {
-      internal static let data = XCTDataAsset(name: "Json/Data")
-    }
-    internal static let readme = XCTDataAsset(name: "README")
-    // swiftlint:disable trailing_comma
-    internal static let allColors: [XCTColorAsset] = [
-    ]
-    internal static let allDataAssets: [XCTDataAsset] = [
-      data,
-      Json.data,
-      readme,
-    ]
-    internal static let allImages: [XCTImageAsset] = [
-    ]
-    // swiftlint:enable trailing_comma
-    @available(*, deprecated, renamed: "allImages")
-    internal static let allValues: [XCTAssetsType] = allImages
-  }
-  internal enum Images {
-    internal enum Exotic {
-      internal static let banana = XCTImageAsset(name: "Exotic/Banana")
-      internal static let mango = XCTImageAsset(name: "Exotic/Mango")
-    }
-    internal enum Round {
-      internal static let apricot = XCTImageAsset(name: "Round/Apricot")
-      internal static let apple = XCTImageAsset(name: "Round/Apple")
-      internal enum Double {
-        internal static let cherry = XCTImageAsset(name: "Round/Double/Cherry")
-      }
-      internal static let tomato = XCTImageAsset(name: "Round/Tomato")
-    }
-    internal static let `private` = XCTImageAsset(name: "private")
-    // swiftlint:disable trailing_comma
-    internal static let allColors: [XCTColorAsset] = [
-    ]
-    internal static let allDataAssets: [XCTDataAsset] = [
-    ]
-    internal static let allImages: [XCTImageAsset] = [
-      Exotic.banana,
-      Exotic.mango,
-      Round.apricot,
-      Round.apple,
-      Round.Double.cherry,
-      Round.tomato,
-      `private`,
-    ]
-    // swiftlint:enable trailing_comma
-    @available(*, deprecated, renamed: "allImages")
-    internal static let allValues: [XCTAssetsType] = allImages
-  }
-}
-// swiftlint:enable identifier_name line_length nesting type_body_length type_name
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/XCAssets/swift3-context-all-forceNamespaces.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift3-context-all-forceNamespaces.swift
@@ -17,93 +17,7 @@ internal typealias AssetDataTypeAlias = NSDataAsset
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-internal struct ColorAsset {
-  internal fileprivate(set) var name: String
-
-  #if swift(>=3.2)
-  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
-  internal var color: AssetColorTypeAlias {
-    return AssetColorTypeAlias(asset: self)
-  }
-  #endif
-}
-
-internal extension AssetColorTypeAlias {
-  #if swift(>=3.2)
-  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
-  convenience init!(asset: ColorAsset) {
-    let bundle = Bundle(for: BundleToken.self)
-    #if os(iOS) || os(tvOS)
-    self.init(named: asset.name, in: bundle, compatibleWith: nil)
-    #elseif os(OSX)
-    self.init(named: asset.name, bundle: bundle)
-    #elseif os(watchOS)
-    self.init(named: asset.name)
-    #endif
-  }
-  #endif
-}
-
-internal struct DataAsset {
-  internal fileprivate(set) var name: String
-
-  #if os(iOS) || os(tvOS) || os(OSX)
-  #if swift(>=3.2)
-  @available(iOS 9.0, tvOS 9.0, OSX 10.11, *)
-  internal var data: AssetDataTypeAlias {
-    return AssetDataTypeAlias(asset: self)
-  }
-  #endif
-  #endif
-}
-
-#if os(iOS) || os(tvOS) || os(OSX)
-internal extension AssetDataTypeAlias {
-  #if swift(>=3.2)
-  @available(iOS 9.0, tvOS 9.0, OSX 10.11, *)
-  convenience init!(asset: DataAsset) {
-    let bundle = Bundle(for: BundleToken.self)
-    self.init(name: asset.name, bundle: bundle)
-  }
-  #endif
-}
-#endif
-
-@available(*, deprecated, renamed: "ImageAsset")
-internal typealias AssetType = ImageAsset
-
-internal struct ImageAsset {
-  internal fileprivate(set) var name: String
-
-  internal var image: Image {
-    let bundle = Bundle(for: BundleToken.self)
-    #if os(iOS) || os(tvOS)
-    let image = Image(named: name, in: bundle, compatibleWith: nil)
-    #elseif os(OSX)
-    let image = bundle.image(forResource: name)
-    #elseif os(watchOS)
-    let image = Image(named: name)
-    #endif
-    guard let result = image else { fatalError("Unable to load image named \(name).") }
-    return result
-  }
-}
-
-internal extension Image {
-  @available(iOS 1.0, tvOS 1.0, watchOS 1.0, *)
-  @available(OSX, deprecated,
-    message: "This initializer is unsafe on macOS, please use the ImageAsset.image property")
-  convenience init!(asset: ImageAsset) {
-    #if os(iOS) || os(tvOS)
-    let bundle = Bundle(for: BundleToken.self)
-    self.init(named: asset.name, in: bundle, compatibleWith: nil)
-    #elseif os(OSX) || os(watchOS)
-    self.init(named: asset.name)
-    #endif
-  }
-}
-
-// MARK: Assets
+// MARK: - Asset Catalogs
 
 // swiftlint:disable identifier_name line_length nesting type_body_length type_name
 internal enum Asset {
@@ -189,5 +103,93 @@ internal enum Asset {
   }
 }
 // swiftlint:enable identifier_name line_length nesting type_body_length type_name
+
+// MARK: - Implementation Details
+
+internal struct ColorAsset {
+  internal fileprivate(set) var name: String
+
+  #if swift(>=3.2)
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
+  internal var color: AssetColorTypeAlias {
+    return AssetColorTypeAlias(asset: self)
+  }
+  #endif
+}
+
+internal extension AssetColorTypeAlias {
+  #if swift(>=3.2)
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
+  convenience init!(asset: ColorAsset) {
+    let bundle = Bundle(for: BundleToken.self)
+    #if os(iOS) || os(tvOS)
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    #elseif os(OSX)
+    self.init(named: asset.name, bundle: bundle)
+    #elseif os(watchOS)
+    self.init(named: asset.name)
+    #endif
+  }
+  #endif
+}
+
+internal struct DataAsset {
+  internal fileprivate(set) var name: String
+
+  #if os(iOS) || os(tvOS) || os(OSX)
+  #if swift(>=3.2)
+  @available(iOS 9.0, tvOS 9.0, OSX 10.11, *)
+  internal var data: AssetDataTypeAlias {
+    return AssetDataTypeAlias(asset: self)
+  }
+  #endif
+  #endif
+}
+
+#if os(iOS) || os(tvOS) || os(OSX)
+internal extension AssetDataTypeAlias {
+  #if swift(>=3.2)
+  @available(iOS 9.0, tvOS 9.0, OSX 10.11, *)
+  convenience init!(asset: DataAsset) {
+    let bundle = Bundle(for: BundleToken.self)
+    self.init(name: asset.name, bundle: bundle)
+  }
+  #endif
+}
+#endif
+
+@available(*, deprecated, renamed: "ImageAsset")
+internal typealias AssetType = ImageAsset
+
+internal struct ImageAsset {
+  internal fileprivate(set) var name: String
+
+  internal var image: Image {
+    let bundle = Bundle(for: BundleToken.self)
+    #if os(iOS) || os(tvOS)
+    let image = Image(named: name, in: bundle, compatibleWith: nil)
+    #elseif os(OSX)
+    let image = bundle.image(forResource: name)
+    #elseif os(watchOS)
+    let image = Image(named: name)
+    #endif
+    guard let result = image else { fatalError("Unable to load image named \(name).") }
+    return result
+  }
+}
+
+internal extension Image {
+  @available(iOS 1.0, tvOS 1.0, watchOS 1.0, *)
+  @available(OSX, deprecated,
+    message: "This initializer is unsafe on macOS, please use the ImageAsset.image property")
+  convenience init!(asset: ImageAsset) {
+    #if os(iOS) || os(tvOS)
+    let bundle = Bundle(for: BundleToken.self)
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    #elseif os(OSX) || os(watchOS)
+    self.init(named: asset.name)
+    #endif
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/XCAssets/swift3-context-all-no-all-values.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift3-context-all-no-all-values.swift
@@ -17,6 +17,48 @@ internal typealias AssetDataTypeAlias = NSDataAsset
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Asset Catalogs
+
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
+internal enum Asset {
+  internal enum Colors {
+    internal enum _24Vision {
+      internal static let background = ColorAsset(name: "24Vision/Background")
+      internal static let primary = ColorAsset(name: "24Vision/Primary")
+    }
+    internal static let orange = ImageAsset(name: "Orange")
+    internal enum Vengo {
+      internal static let primary = ColorAsset(name: "Vengo/Primary")
+      internal static let tint = ColorAsset(name: "Vengo/Tint")
+    }
+  }
+  internal enum Data {
+    internal static let data = DataAsset(name: "Data")
+    internal enum Json {
+      internal static let data = DataAsset(name: "Json/Data")
+    }
+    internal static let readme = DataAsset(name: "README")
+  }
+  internal enum Images {
+    internal enum Exotic {
+      internal static let banana = ImageAsset(name: "Exotic/Banana")
+      internal static let mango = ImageAsset(name: "Exotic/Mango")
+    }
+    internal enum Round {
+      internal static let apricot = ImageAsset(name: "Round/Apricot")
+      internal static let apple = ImageAsset(name: "Round/Apple")
+      internal enum Double {
+        internal static let cherry = ImageAsset(name: "Round/Double/Cherry")
+      }
+      internal static let tomato = ImageAsset(name: "Round/Tomato")
+    }
+    internal static let `private` = ImageAsset(name: "private")
+  }
+}
+// swiftlint:enable identifier_name line_length nesting type_body_length type_name
+
+// MARK: - Implementation Details
+
 internal struct ColorAsset {
   internal fileprivate(set) var name: String
 
@@ -102,45 +144,5 @@ internal extension Image {
     #endif
   }
 }
-
-// MARK: Assets
-
-// swiftlint:disable identifier_name line_length nesting type_body_length type_name
-internal enum Asset {
-  internal enum Colors {
-    internal enum _24Vision {
-      internal static let background = ColorAsset(name: "24Vision/Background")
-      internal static let primary = ColorAsset(name: "24Vision/Primary")
-    }
-    internal static let orange = ImageAsset(name: "Orange")
-    internal enum Vengo {
-      internal static let primary = ColorAsset(name: "Vengo/Primary")
-      internal static let tint = ColorAsset(name: "Vengo/Tint")
-    }
-  }
-  internal enum Data {
-    internal static let data = DataAsset(name: "Data")
-    internal enum Json {
-      internal static let data = DataAsset(name: "Json/Data")
-    }
-    internal static let readme = DataAsset(name: "README")
-  }
-  internal enum Images {
-    internal enum Exotic {
-      internal static let banana = ImageAsset(name: "Exotic/Banana")
-      internal static let mango = ImageAsset(name: "Exotic/Mango")
-    }
-    internal enum Round {
-      internal static let apricot = ImageAsset(name: "Round/Apricot")
-      internal static let apple = ImageAsset(name: "Round/Apple")
-      internal enum Double {
-        internal static let cherry = ImageAsset(name: "Round/Double/Cherry")
-      }
-      internal static let tomato = ImageAsset(name: "Round/Tomato")
-    }
-    internal static let `private` = ImageAsset(name: "private")
-  }
-}
-// swiftlint:enable identifier_name line_length nesting type_body_length type_name
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/XCAssets/swift3-context-all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift3-context-all-publicAccess.swift
@@ -17,6 +17,93 @@ public typealias AssetDataTypeAlias = NSDataAsset
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Asset Catalogs
+
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
+public enum Asset {
+  public enum Colors {
+    public enum _24Vision {
+      public static let background = ColorAsset(name: "24Vision/Background")
+      public static let primary = ColorAsset(name: "24Vision/Primary")
+    }
+    public static let orange = ImageAsset(name: "Orange")
+    public enum Vengo {
+      public static let primary = ColorAsset(name: "Vengo/Primary")
+      public static let tint = ColorAsset(name: "Vengo/Tint")
+    }
+    // swiftlint:disable trailing_comma
+    public static let allColors: [ColorAsset] = [
+      _24Vision.background,
+      _24Vision.primary,
+      Vengo.primary,
+      Vengo.tint,
+    ]
+    public static let allDataAssets: [DataAsset] = [
+    ]
+    public static let allImages: [ImageAsset] = [
+      orange,
+    ]
+    // swiftlint:enable trailing_comma
+    @available(*, deprecated, renamed: "allImages")
+    public static let allValues: [AssetType] = allImages
+  }
+  public enum Data {
+    public static let data = DataAsset(name: "Data")
+    public enum Json {
+      public static let data = DataAsset(name: "Json/Data")
+    }
+    public static let readme = DataAsset(name: "README")
+    // swiftlint:disable trailing_comma
+    public static let allColors: [ColorAsset] = [
+    ]
+    public static let allDataAssets: [DataAsset] = [
+      data,
+      Json.data,
+      readme,
+    ]
+    public static let allImages: [ImageAsset] = [
+    ]
+    // swiftlint:enable trailing_comma
+    @available(*, deprecated, renamed: "allImages")
+    public static let allValues: [AssetType] = allImages
+  }
+  public enum Images {
+    public enum Exotic {
+      public static let banana = ImageAsset(name: "Exotic/Banana")
+      public static let mango = ImageAsset(name: "Exotic/Mango")
+    }
+    public enum Round {
+      public static let apricot = ImageAsset(name: "Round/Apricot")
+      public static let apple = ImageAsset(name: "Round/Apple")
+      public enum Double {
+        public static let cherry = ImageAsset(name: "Round/Double/Cherry")
+      }
+      public static let tomato = ImageAsset(name: "Round/Tomato")
+    }
+    public static let `private` = ImageAsset(name: "private")
+    // swiftlint:disable trailing_comma
+    public static let allColors: [ColorAsset] = [
+    ]
+    public static let allDataAssets: [DataAsset] = [
+    ]
+    public static let allImages: [ImageAsset] = [
+      Exotic.banana,
+      Exotic.mango,
+      Round.apricot,
+      Round.apple,
+      Round.Double.cherry,
+      Round.tomato,
+      `private`,
+    ]
+    // swiftlint:enable trailing_comma
+    @available(*, deprecated, renamed: "allImages")
+    public static let allValues: [AssetType] = allImages
+  }
+}
+// swiftlint:enable identifier_name line_length nesting type_body_length type_name
+
+// MARK: - Implementation Details
+
 public struct ColorAsset {
   public fileprivate(set) var name: String
 
@@ -102,90 +189,5 @@ public extension Image {
     #endif
   }
 }
-
-// MARK: Assets
-
-// swiftlint:disable identifier_name line_length nesting type_body_length type_name
-public enum Asset {
-  public enum Colors {
-    public enum _24Vision {
-      public static let background = ColorAsset(name: "24Vision/Background")
-      public static let primary = ColorAsset(name: "24Vision/Primary")
-    }
-    public static let orange = ImageAsset(name: "Orange")
-    public enum Vengo {
-      public static let primary = ColorAsset(name: "Vengo/Primary")
-      public static let tint = ColorAsset(name: "Vengo/Tint")
-    }
-    // swiftlint:disable trailing_comma
-    public static let allColors: [ColorAsset] = [
-      _24Vision.background,
-      _24Vision.primary,
-      Vengo.primary,
-      Vengo.tint,
-    ]
-    public static let allDataAssets: [DataAsset] = [
-    ]
-    public static let allImages: [ImageAsset] = [
-      orange,
-    ]
-    // swiftlint:enable trailing_comma
-    @available(*, deprecated, renamed: "allImages")
-    public static let allValues: [AssetType] = allImages
-  }
-  public enum Data {
-    public static let data = DataAsset(name: "Data")
-    public enum Json {
-      public static let data = DataAsset(name: "Json/Data")
-    }
-    public static let readme = DataAsset(name: "README")
-    // swiftlint:disable trailing_comma
-    public static let allColors: [ColorAsset] = [
-    ]
-    public static let allDataAssets: [DataAsset] = [
-      data,
-      Json.data,
-      readme,
-    ]
-    public static let allImages: [ImageAsset] = [
-    ]
-    // swiftlint:enable trailing_comma
-    @available(*, deprecated, renamed: "allImages")
-    public static let allValues: [AssetType] = allImages
-  }
-  public enum Images {
-    public enum Exotic {
-      public static let banana = ImageAsset(name: "Exotic/Banana")
-      public static let mango = ImageAsset(name: "Exotic/Mango")
-    }
-    public enum Round {
-      public static let apricot = ImageAsset(name: "Round/Apricot")
-      public static let apple = ImageAsset(name: "Round/Apple")
-      public enum Double {
-        public static let cherry = ImageAsset(name: "Round/Double/Cherry")
-      }
-      public static let tomato = ImageAsset(name: "Round/Tomato")
-    }
-    public static let `private` = ImageAsset(name: "private")
-    // swiftlint:disable trailing_comma
-    public static let allColors: [ColorAsset] = [
-    ]
-    public static let allDataAssets: [DataAsset] = [
-    ]
-    public static let allImages: [ImageAsset] = [
-      Exotic.banana,
-      Exotic.mango,
-      Round.apricot,
-      Round.apple,
-      Round.Double.cherry,
-      Round.tomato,
-      `private`,
-    ]
-    // swiftlint:enable trailing_comma
-    @available(*, deprecated, renamed: "allImages")
-    public static let allValues: [AssetType] = allImages
-  }
-}
-// swiftlint:enable identifier_name line_length nesting type_body_length type_name
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/XCAssets/swift3-context-all.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift3-context-all.swift
@@ -17,6 +17,93 @@ internal typealias AssetDataTypeAlias = NSDataAsset
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Asset Catalogs
+
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
+internal enum Asset {
+  internal enum Colors {
+    internal enum _24Vision {
+      internal static let background = ColorAsset(name: "24Vision/Background")
+      internal static let primary = ColorAsset(name: "24Vision/Primary")
+    }
+    internal static let orange = ImageAsset(name: "Orange")
+    internal enum Vengo {
+      internal static let primary = ColorAsset(name: "Vengo/Primary")
+      internal static let tint = ColorAsset(name: "Vengo/Tint")
+    }
+    // swiftlint:disable trailing_comma
+    internal static let allColors: [ColorAsset] = [
+      _24Vision.background,
+      _24Vision.primary,
+      Vengo.primary,
+      Vengo.tint,
+    ]
+    internal static let allDataAssets: [DataAsset] = [
+    ]
+    internal static let allImages: [ImageAsset] = [
+      orange,
+    ]
+    // swiftlint:enable trailing_comma
+    @available(*, deprecated, renamed: "allImages")
+    internal static let allValues: [AssetType] = allImages
+  }
+  internal enum Data {
+    internal static let data = DataAsset(name: "Data")
+    internal enum Json {
+      internal static let data = DataAsset(name: "Json/Data")
+    }
+    internal static let readme = DataAsset(name: "README")
+    // swiftlint:disable trailing_comma
+    internal static let allColors: [ColorAsset] = [
+    ]
+    internal static let allDataAssets: [DataAsset] = [
+      data,
+      Json.data,
+      readme,
+    ]
+    internal static let allImages: [ImageAsset] = [
+    ]
+    // swiftlint:enable trailing_comma
+    @available(*, deprecated, renamed: "allImages")
+    internal static let allValues: [AssetType] = allImages
+  }
+  internal enum Images {
+    internal enum Exotic {
+      internal static let banana = ImageAsset(name: "Exotic/Banana")
+      internal static let mango = ImageAsset(name: "Exotic/Mango")
+    }
+    internal enum Round {
+      internal static let apricot = ImageAsset(name: "Round/Apricot")
+      internal static let apple = ImageAsset(name: "Round/Apple")
+      internal enum Double {
+        internal static let cherry = ImageAsset(name: "Round/Double/Cherry")
+      }
+      internal static let tomato = ImageAsset(name: "Round/Tomato")
+    }
+    internal static let `private` = ImageAsset(name: "private")
+    // swiftlint:disable trailing_comma
+    internal static let allColors: [ColorAsset] = [
+    ]
+    internal static let allDataAssets: [DataAsset] = [
+    ]
+    internal static let allImages: [ImageAsset] = [
+      Exotic.banana,
+      Exotic.mango,
+      Round.apricot,
+      Round.apple,
+      Round.Double.cherry,
+      Round.tomato,
+      `private`,
+    ]
+    // swiftlint:enable trailing_comma
+    @available(*, deprecated, renamed: "allImages")
+    internal static let allValues: [AssetType] = allImages
+  }
+}
+// swiftlint:enable identifier_name line_length nesting type_body_length type_name
+
+// MARK: - Implementation Details
+
 internal struct ColorAsset {
   internal fileprivate(set) var name: String
 
@@ -102,90 +189,5 @@ internal extension Image {
     #endif
   }
 }
-
-// MARK: Assets
-
-// swiftlint:disable identifier_name line_length nesting type_body_length type_name
-internal enum Asset {
-  internal enum Colors {
-    internal enum _24Vision {
-      internal static let background = ColorAsset(name: "24Vision/Background")
-      internal static let primary = ColorAsset(name: "24Vision/Primary")
-    }
-    internal static let orange = ImageAsset(name: "Orange")
-    internal enum Vengo {
-      internal static let primary = ColorAsset(name: "Vengo/Primary")
-      internal static let tint = ColorAsset(name: "Vengo/Tint")
-    }
-    // swiftlint:disable trailing_comma
-    internal static let allColors: [ColorAsset] = [
-      _24Vision.background,
-      _24Vision.primary,
-      Vengo.primary,
-      Vengo.tint,
-    ]
-    internal static let allDataAssets: [DataAsset] = [
-    ]
-    internal static let allImages: [ImageAsset] = [
-      orange,
-    ]
-    // swiftlint:enable trailing_comma
-    @available(*, deprecated, renamed: "allImages")
-    internal static let allValues: [AssetType] = allImages
-  }
-  internal enum Data {
-    internal static let data = DataAsset(name: "Data")
-    internal enum Json {
-      internal static let data = DataAsset(name: "Json/Data")
-    }
-    internal static let readme = DataAsset(name: "README")
-    // swiftlint:disable trailing_comma
-    internal static let allColors: [ColorAsset] = [
-    ]
-    internal static let allDataAssets: [DataAsset] = [
-      data,
-      Json.data,
-      readme,
-    ]
-    internal static let allImages: [ImageAsset] = [
-    ]
-    // swiftlint:enable trailing_comma
-    @available(*, deprecated, renamed: "allImages")
-    internal static let allValues: [AssetType] = allImages
-  }
-  internal enum Images {
-    internal enum Exotic {
-      internal static let banana = ImageAsset(name: "Exotic/Banana")
-      internal static let mango = ImageAsset(name: "Exotic/Mango")
-    }
-    internal enum Round {
-      internal static let apricot = ImageAsset(name: "Round/Apricot")
-      internal static let apple = ImageAsset(name: "Round/Apple")
-      internal enum Double {
-        internal static let cherry = ImageAsset(name: "Round/Double/Cherry")
-      }
-      internal static let tomato = ImageAsset(name: "Round/Tomato")
-    }
-    internal static let `private` = ImageAsset(name: "private")
-    // swiftlint:disable trailing_comma
-    internal static let allColors: [ColorAsset] = [
-    ]
-    internal static let allDataAssets: [DataAsset] = [
-    ]
-    internal static let allImages: [ImageAsset] = [
-      Exotic.banana,
-      Exotic.mango,
-      Round.apricot,
-      Round.apple,
-      Round.Double.cherry,
-      Round.tomato,
-      `private`,
-    ]
-    // swiftlint:enable trailing_comma
-    @available(*, deprecated, renamed: "allImages")
-    internal static let allValues: [AssetType] = allImages
-  }
-}
-// swiftlint:enable identifier_name line_length nesting type_body_length type_name
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/XCAssets/swift4-context-all-customname.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift4-context-all-customname.swift
@@ -17,91 +17,7 @@ internal typealias XCTData = NSDataAsset
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-internal struct XCTColorAsset {
-  internal fileprivate(set) var name: String
-
-  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
-  internal var color: XCTColor {
-    return XCTColor(asset: self)
-  }
-}
-
-internal extension XCTColor {
-  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
-  convenience init!(asset: XCTColorAsset) {
-    let bundle = Bundle(for: BundleToken.self)
-    #if os(iOS) || os(tvOS)
-    self.init(named: asset.name, in: bundle, compatibleWith: nil)
-    #elseif os(OSX)
-    self.init(named: NSColor.Name(asset.name), bundle: bundle)
-    #elseif os(watchOS)
-    self.init(named: asset.name)
-    #endif
-  }
-}
-
-internal struct XCTDataAsset {
-  internal fileprivate(set) var name: String
-
-  #if os(iOS) || os(tvOS) || os(OSX)
-  @available(iOS 9.0, tvOS 9.0, OSX 10.11, *)
-  internal var data: XCTData {
-    return XCTData(asset: self)
-  }
-  #endif
-}
-
-#if os(iOS) || os(tvOS) || os(OSX)
-internal extension XCTData {
-  @available(iOS 9.0, tvOS 9.0, OSX 10.11, *)
-  convenience init!(asset: XCTDataAsset) {
-    let bundle = Bundle(for: BundleToken.self)
-    #if os(iOS) || os(tvOS)
-    self.init(name: asset.name, bundle: bundle)
-    #elseif os(OSX)
-    self.init(name: NSDataAsset.Name(asset.name), bundle: bundle)
-    #endif
-  }
-}
-#endif
-
-@available(*, deprecated, renamed: "XCTImageAsset")
-internal typealias XCTAssetsType = XCTImageAsset
-
-internal struct XCTImageAsset {
-  internal fileprivate(set) var name: String
-
-  internal var image: XCTImage {
-    let bundle = Bundle(for: BundleToken.self)
-    #if os(iOS) || os(tvOS)
-    let image = XCTImage(named: name, in: bundle, compatibleWith: nil)
-    #elseif os(OSX)
-    let image = bundle.image(forResource: NSImage.Name(name))
-    #elseif os(watchOS)
-    let image = XCTImage(named: name)
-    #endif
-    guard let result = image else { fatalError("Unable to load image named \(name).") }
-    return result
-  }
-}
-
-internal extension XCTImage {
-  @available(iOS 1.0, tvOS 1.0, watchOS 1.0, *)
-  @available(OSX, deprecated,
-    message: "This initializer is unsafe on macOS, please use the XCTImageAsset.image property")
-  convenience init!(asset: XCTImageAsset) {
-    #if os(iOS) || os(tvOS)
-    let bundle = Bundle(for: BundleToken.self)
-    self.init(named: asset.name, in: bundle, compatibleWith: nil)
-    #elseif os(OSX)
-    self.init(named: NSImage.Name(asset.name))
-    #elseif os(watchOS)
-    self.init(named: asset.name)
-    #endif
-  }
-}
-
-// MARK: Assets
+// MARK: - Asset Catalogs
 
 // swiftlint:disable identifier_name line_length nesting type_body_length type_name
 internal enum XCTAssets {
@@ -185,5 +101,91 @@ internal enum XCTAssets {
   }
 }
 // swiftlint:enable identifier_name line_length nesting type_body_length type_name
+
+// MARK: - Implementation Details
+
+internal struct XCTColorAsset {
+  internal fileprivate(set) var name: String
+
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
+  internal var color: XCTColor {
+    return XCTColor(asset: self)
+  }
+}
+
+internal extension XCTColor {
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
+  convenience init!(asset: XCTColorAsset) {
+    let bundle = Bundle(for: BundleToken.self)
+    #if os(iOS) || os(tvOS)
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    #elseif os(OSX)
+    self.init(named: NSColor.Name(asset.name), bundle: bundle)
+    #elseif os(watchOS)
+    self.init(named: asset.name)
+    #endif
+  }
+}
+
+internal struct XCTDataAsset {
+  internal fileprivate(set) var name: String
+
+  #if os(iOS) || os(tvOS) || os(OSX)
+  @available(iOS 9.0, tvOS 9.0, OSX 10.11, *)
+  internal var data: XCTData {
+    return XCTData(asset: self)
+  }
+  #endif
+}
+
+#if os(iOS) || os(tvOS) || os(OSX)
+internal extension XCTData {
+  @available(iOS 9.0, tvOS 9.0, OSX 10.11, *)
+  convenience init!(asset: XCTDataAsset) {
+    let bundle = Bundle(for: BundleToken.self)
+    #if os(iOS) || os(tvOS)
+    self.init(name: asset.name, bundle: bundle)
+    #elseif os(OSX)
+    self.init(name: NSDataAsset.Name(asset.name), bundle: bundle)
+    #endif
+  }
+}
+#endif
+
+@available(*, deprecated, renamed: "XCTImageAsset")
+internal typealias XCTAssetsType = XCTImageAsset
+
+internal struct XCTImageAsset {
+  internal fileprivate(set) var name: String
+
+  internal var image: XCTImage {
+    let bundle = Bundle(for: BundleToken.self)
+    #if os(iOS) || os(tvOS)
+    let image = XCTImage(named: name, in: bundle, compatibleWith: nil)
+    #elseif os(OSX)
+    let image = bundle.image(forResource: NSImage.Name(name))
+    #elseif os(watchOS)
+    let image = XCTImage(named: name)
+    #endif
+    guard let result = image else { fatalError("Unable to load image named \(name).") }
+    return result
+  }
+}
+
+internal extension XCTImage {
+  @available(iOS 1.0, tvOS 1.0, watchOS 1.0, *)
+  @available(OSX, deprecated,
+    message: "This initializer is unsafe on macOS, please use the XCTImageAsset.image property")
+  convenience init!(asset: XCTImageAsset) {
+    #if os(iOS) || os(tvOS)
+    let bundle = Bundle(for: BundleToken.self)
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    #elseif os(OSX)
+    self.init(named: NSImage.Name(asset.name))
+    #elseif os(watchOS)
+    self.init(named: asset.name)
+    #endif
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/XCAssets/swift4-context-all-forceNamespaces.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift4-context-all-forceNamespaces.swift
@@ -17,91 +17,7 @@ internal typealias AssetDataTypeAlias = NSDataAsset
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-internal struct ColorAsset {
-  internal fileprivate(set) var name: String
-
-  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
-  internal var color: AssetColorTypeAlias {
-    return AssetColorTypeAlias(asset: self)
-  }
-}
-
-internal extension AssetColorTypeAlias {
-  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
-  convenience init!(asset: ColorAsset) {
-    let bundle = Bundle(for: BundleToken.self)
-    #if os(iOS) || os(tvOS)
-    self.init(named: asset.name, in: bundle, compatibleWith: nil)
-    #elseif os(OSX)
-    self.init(named: NSColor.Name(asset.name), bundle: bundle)
-    #elseif os(watchOS)
-    self.init(named: asset.name)
-    #endif
-  }
-}
-
-internal struct DataAsset {
-  internal fileprivate(set) var name: String
-
-  #if os(iOS) || os(tvOS) || os(OSX)
-  @available(iOS 9.0, tvOS 9.0, OSX 10.11, *)
-  internal var data: AssetDataTypeAlias {
-    return AssetDataTypeAlias(asset: self)
-  }
-  #endif
-}
-
-#if os(iOS) || os(tvOS) || os(OSX)
-internal extension AssetDataTypeAlias {
-  @available(iOS 9.0, tvOS 9.0, OSX 10.11, *)
-  convenience init!(asset: DataAsset) {
-    let bundle = Bundle(for: BundleToken.self)
-    #if os(iOS) || os(tvOS)
-    self.init(name: asset.name, bundle: bundle)
-    #elseif os(OSX)
-    self.init(name: NSDataAsset.Name(asset.name), bundle: bundle)
-    #endif
-  }
-}
-#endif
-
-@available(*, deprecated, renamed: "ImageAsset")
-internal typealias AssetType = ImageAsset
-
-internal struct ImageAsset {
-  internal fileprivate(set) var name: String
-
-  internal var image: Image {
-    let bundle = Bundle(for: BundleToken.self)
-    #if os(iOS) || os(tvOS)
-    let image = Image(named: name, in: bundle, compatibleWith: nil)
-    #elseif os(OSX)
-    let image = bundle.image(forResource: NSImage.Name(name))
-    #elseif os(watchOS)
-    let image = Image(named: name)
-    #endif
-    guard let result = image else { fatalError("Unable to load image named \(name).") }
-    return result
-  }
-}
-
-internal extension Image {
-  @available(iOS 1.0, tvOS 1.0, watchOS 1.0, *)
-  @available(OSX, deprecated,
-    message: "This initializer is unsafe on macOS, please use the ImageAsset.image property")
-  convenience init!(asset: ImageAsset) {
-    #if os(iOS) || os(tvOS)
-    let bundle = Bundle(for: BundleToken.self)
-    self.init(named: asset.name, in: bundle, compatibleWith: nil)
-    #elseif os(OSX)
-    self.init(named: NSImage.Name(asset.name))
-    #elseif os(watchOS)
-    self.init(named: asset.name)
-    #endif
-  }
-}
-
-// MARK: Assets
+// MARK: - Asset Catalogs
 
 // swiftlint:disable identifier_name line_length nesting type_body_length type_name
 internal enum Asset {
@@ -187,5 +103,91 @@ internal enum Asset {
   }
 }
 // swiftlint:enable identifier_name line_length nesting type_body_length type_name
+
+// MARK: - Implementation Details
+
+internal struct ColorAsset {
+  internal fileprivate(set) var name: String
+
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
+  internal var color: AssetColorTypeAlias {
+    return AssetColorTypeAlias(asset: self)
+  }
+}
+
+internal extension AssetColorTypeAlias {
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
+  convenience init!(asset: ColorAsset) {
+    let bundle = Bundle(for: BundleToken.self)
+    #if os(iOS) || os(tvOS)
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    #elseif os(OSX)
+    self.init(named: NSColor.Name(asset.name), bundle: bundle)
+    #elseif os(watchOS)
+    self.init(named: asset.name)
+    #endif
+  }
+}
+
+internal struct DataAsset {
+  internal fileprivate(set) var name: String
+
+  #if os(iOS) || os(tvOS) || os(OSX)
+  @available(iOS 9.0, tvOS 9.0, OSX 10.11, *)
+  internal var data: AssetDataTypeAlias {
+    return AssetDataTypeAlias(asset: self)
+  }
+  #endif
+}
+
+#if os(iOS) || os(tvOS) || os(OSX)
+internal extension AssetDataTypeAlias {
+  @available(iOS 9.0, tvOS 9.0, OSX 10.11, *)
+  convenience init!(asset: DataAsset) {
+    let bundle = Bundle(for: BundleToken.self)
+    #if os(iOS) || os(tvOS)
+    self.init(name: asset.name, bundle: bundle)
+    #elseif os(OSX)
+    self.init(name: NSDataAsset.Name(asset.name), bundle: bundle)
+    #endif
+  }
+}
+#endif
+
+@available(*, deprecated, renamed: "ImageAsset")
+internal typealias AssetType = ImageAsset
+
+internal struct ImageAsset {
+  internal fileprivate(set) var name: String
+
+  internal var image: Image {
+    let bundle = Bundle(for: BundleToken.self)
+    #if os(iOS) || os(tvOS)
+    let image = Image(named: name, in: bundle, compatibleWith: nil)
+    #elseif os(OSX)
+    let image = bundle.image(forResource: NSImage.Name(name))
+    #elseif os(watchOS)
+    let image = Image(named: name)
+    #endif
+    guard let result = image else { fatalError("Unable to load image named \(name).") }
+    return result
+  }
+}
+
+internal extension Image {
+  @available(iOS 1.0, tvOS 1.0, watchOS 1.0, *)
+  @available(OSX, deprecated,
+    message: "This initializer is unsafe on macOS, please use the ImageAsset.image property")
+  convenience init!(asset: ImageAsset) {
+    #if os(iOS) || os(tvOS)
+    let bundle = Bundle(for: BundleToken.self)
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    #elseif os(OSX)
+    self.init(named: NSImage.Name(asset.name))
+    #elseif os(watchOS)
+    self.init(named: asset.name)
+    #endif
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/XCAssets/swift4-context-all-no-all-values.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift4-context-all-no-all-values.swift
@@ -17,6 +17,48 @@ internal typealias AssetDataTypeAlias = NSDataAsset
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Asset Catalogs
+
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
+internal enum Asset {
+  internal enum Colors {
+    internal enum _24Vision {
+      internal static let background = ColorAsset(name: "24Vision/Background")
+      internal static let primary = ColorAsset(name: "24Vision/Primary")
+    }
+    internal static let orange = ImageAsset(name: "Orange")
+    internal enum Vengo {
+      internal static let primary = ColorAsset(name: "Vengo/Primary")
+      internal static let tint = ColorAsset(name: "Vengo/Tint")
+    }
+  }
+  internal enum Data {
+    internal static let data = DataAsset(name: "Data")
+    internal enum Json {
+      internal static let data = DataAsset(name: "Json/Data")
+    }
+    internal static let readme = DataAsset(name: "README")
+  }
+  internal enum Images {
+    internal enum Exotic {
+      internal static let banana = ImageAsset(name: "Exotic/Banana")
+      internal static let mango = ImageAsset(name: "Exotic/Mango")
+    }
+    internal enum Round {
+      internal static let apricot = ImageAsset(name: "Round/Apricot")
+      internal static let apple = ImageAsset(name: "Round/Apple")
+      internal enum Double {
+        internal static let cherry = ImageAsset(name: "Round/Double/Cherry")
+      }
+      internal static let tomato = ImageAsset(name: "Round/Tomato")
+    }
+    internal static let `private` = ImageAsset(name: "private")
+  }
+}
+// swiftlint:enable identifier_name line_length nesting type_body_length type_name
+
+// MARK: - Implementation Details
+
 internal struct ColorAsset {
   internal fileprivate(set) var name: String
 
@@ -100,45 +142,5 @@ internal extension Image {
     #endif
   }
 }
-
-// MARK: Assets
-
-// swiftlint:disable identifier_name line_length nesting type_body_length type_name
-internal enum Asset {
-  internal enum Colors {
-    internal enum _24Vision {
-      internal static let background = ColorAsset(name: "24Vision/Background")
-      internal static let primary = ColorAsset(name: "24Vision/Primary")
-    }
-    internal static let orange = ImageAsset(name: "Orange")
-    internal enum Vengo {
-      internal static let primary = ColorAsset(name: "Vengo/Primary")
-      internal static let tint = ColorAsset(name: "Vengo/Tint")
-    }
-  }
-  internal enum Data {
-    internal static let data = DataAsset(name: "Data")
-    internal enum Json {
-      internal static let data = DataAsset(name: "Json/Data")
-    }
-    internal static let readme = DataAsset(name: "README")
-  }
-  internal enum Images {
-    internal enum Exotic {
-      internal static let banana = ImageAsset(name: "Exotic/Banana")
-      internal static let mango = ImageAsset(name: "Exotic/Mango")
-    }
-    internal enum Round {
-      internal static let apricot = ImageAsset(name: "Round/Apricot")
-      internal static let apple = ImageAsset(name: "Round/Apple")
-      internal enum Double {
-        internal static let cherry = ImageAsset(name: "Round/Double/Cherry")
-      }
-      internal static let tomato = ImageAsset(name: "Round/Tomato")
-    }
-    internal static let `private` = ImageAsset(name: "private")
-  }
-}
-// swiftlint:enable identifier_name line_length nesting type_body_length type_name
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/XCAssets/swift4-context-all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift4-context-all-publicAccess.swift
@@ -17,91 +17,7 @@ public typealias AssetDataTypeAlias = NSDataAsset
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-public struct ColorAsset {
-  public fileprivate(set) var name: String
-
-  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
-  public var color: AssetColorTypeAlias {
-    return AssetColorTypeAlias(asset: self)
-  }
-}
-
-public extension AssetColorTypeAlias {
-  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
-  convenience init!(asset: ColorAsset) {
-    let bundle = Bundle(for: BundleToken.self)
-    #if os(iOS) || os(tvOS)
-    self.init(named: asset.name, in: bundle, compatibleWith: nil)
-    #elseif os(OSX)
-    self.init(named: NSColor.Name(asset.name), bundle: bundle)
-    #elseif os(watchOS)
-    self.init(named: asset.name)
-    #endif
-  }
-}
-
-public struct DataAsset {
-  public fileprivate(set) var name: String
-
-  #if os(iOS) || os(tvOS) || os(OSX)
-  @available(iOS 9.0, tvOS 9.0, OSX 10.11, *)
-  public var data: AssetDataTypeAlias {
-    return AssetDataTypeAlias(asset: self)
-  }
-  #endif
-}
-
-#if os(iOS) || os(tvOS) || os(OSX)
-public extension AssetDataTypeAlias {
-  @available(iOS 9.0, tvOS 9.0, OSX 10.11, *)
-  convenience init!(asset: DataAsset) {
-    let bundle = Bundle(for: BundleToken.self)
-    #if os(iOS) || os(tvOS)
-    self.init(name: asset.name, bundle: bundle)
-    #elseif os(OSX)
-    self.init(name: NSDataAsset.Name(asset.name), bundle: bundle)
-    #endif
-  }
-}
-#endif
-
-@available(*, deprecated, renamed: "ImageAsset")
-public typealias AssetType = ImageAsset
-
-public struct ImageAsset {
-  public fileprivate(set) var name: String
-
-  public var image: Image {
-    let bundle = Bundle(for: BundleToken.self)
-    #if os(iOS) || os(tvOS)
-    let image = Image(named: name, in: bundle, compatibleWith: nil)
-    #elseif os(OSX)
-    let image = bundle.image(forResource: NSImage.Name(name))
-    #elseif os(watchOS)
-    let image = Image(named: name)
-    #endif
-    guard let result = image else { fatalError("Unable to load image named \(name).") }
-    return result
-  }
-}
-
-public extension Image {
-  @available(iOS 1.0, tvOS 1.0, watchOS 1.0, *)
-  @available(OSX, deprecated,
-    message: "This initializer is unsafe on macOS, please use the ImageAsset.image property")
-  convenience init!(asset: ImageAsset) {
-    #if os(iOS) || os(tvOS)
-    let bundle = Bundle(for: BundleToken.self)
-    self.init(named: asset.name, in: bundle, compatibleWith: nil)
-    #elseif os(OSX)
-    self.init(named: NSImage.Name(asset.name))
-    #elseif os(watchOS)
-    self.init(named: asset.name)
-    #endif
-  }
-}
-
-// MARK: Assets
+// MARK: - Asset Catalogs
 
 // swiftlint:disable identifier_name line_length nesting type_body_length type_name
 public enum Asset {
@@ -185,5 +101,91 @@ public enum Asset {
   }
 }
 // swiftlint:enable identifier_name line_length nesting type_body_length type_name
+
+// MARK: - Implementation Details
+
+public struct ColorAsset {
+  public fileprivate(set) var name: String
+
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
+  public var color: AssetColorTypeAlias {
+    return AssetColorTypeAlias(asset: self)
+  }
+}
+
+public extension AssetColorTypeAlias {
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
+  convenience init!(asset: ColorAsset) {
+    let bundle = Bundle(for: BundleToken.self)
+    #if os(iOS) || os(tvOS)
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    #elseif os(OSX)
+    self.init(named: NSColor.Name(asset.name), bundle: bundle)
+    #elseif os(watchOS)
+    self.init(named: asset.name)
+    #endif
+  }
+}
+
+public struct DataAsset {
+  public fileprivate(set) var name: String
+
+  #if os(iOS) || os(tvOS) || os(OSX)
+  @available(iOS 9.0, tvOS 9.0, OSX 10.11, *)
+  public var data: AssetDataTypeAlias {
+    return AssetDataTypeAlias(asset: self)
+  }
+  #endif
+}
+
+#if os(iOS) || os(tvOS) || os(OSX)
+public extension AssetDataTypeAlias {
+  @available(iOS 9.0, tvOS 9.0, OSX 10.11, *)
+  convenience init!(asset: DataAsset) {
+    let bundle = Bundle(for: BundleToken.self)
+    #if os(iOS) || os(tvOS)
+    self.init(name: asset.name, bundle: bundle)
+    #elseif os(OSX)
+    self.init(name: NSDataAsset.Name(asset.name), bundle: bundle)
+    #endif
+  }
+}
+#endif
+
+@available(*, deprecated, renamed: "ImageAsset")
+public typealias AssetType = ImageAsset
+
+public struct ImageAsset {
+  public fileprivate(set) var name: String
+
+  public var image: Image {
+    let bundle = Bundle(for: BundleToken.self)
+    #if os(iOS) || os(tvOS)
+    let image = Image(named: name, in: bundle, compatibleWith: nil)
+    #elseif os(OSX)
+    let image = bundle.image(forResource: NSImage.Name(name))
+    #elseif os(watchOS)
+    let image = Image(named: name)
+    #endif
+    guard let result = image else { fatalError("Unable to load image named \(name).") }
+    return result
+  }
+}
+
+public extension Image {
+  @available(iOS 1.0, tvOS 1.0, watchOS 1.0, *)
+  @available(OSX, deprecated,
+    message: "This initializer is unsafe on macOS, please use the ImageAsset.image property")
+  convenience init!(asset: ImageAsset) {
+    #if os(iOS) || os(tvOS)
+    let bundle = Bundle(for: BundleToken.self)
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    #elseif os(OSX)
+    self.init(named: NSImage.Name(asset.name))
+    #elseif os(watchOS)
+    self.init(named: asset.name)
+    #endif
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Fixtures/Generated/XCAssets/swift4-context-all.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift4-context-all.swift
@@ -17,91 +17,7 @@ internal typealias AssetDataTypeAlias = NSDataAsset
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-internal struct ColorAsset {
-  internal fileprivate(set) var name: String
-
-  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
-  internal var color: AssetColorTypeAlias {
-    return AssetColorTypeAlias(asset: self)
-  }
-}
-
-internal extension AssetColorTypeAlias {
-  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
-  convenience init!(asset: ColorAsset) {
-    let bundle = Bundle(for: BundleToken.self)
-    #if os(iOS) || os(tvOS)
-    self.init(named: asset.name, in: bundle, compatibleWith: nil)
-    #elseif os(OSX)
-    self.init(named: NSColor.Name(asset.name), bundle: bundle)
-    #elseif os(watchOS)
-    self.init(named: asset.name)
-    #endif
-  }
-}
-
-internal struct DataAsset {
-  internal fileprivate(set) var name: String
-
-  #if os(iOS) || os(tvOS) || os(OSX)
-  @available(iOS 9.0, tvOS 9.0, OSX 10.11, *)
-  internal var data: AssetDataTypeAlias {
-    return AssetDataTypeAlias(asset: self)
-  }
-  #endif
-}
-
-#if os(iOS) || os(tvOS) || os(OSX)
-internal extension AssetDataTypeAlias {
-  @available(iOS 9.0, tvOS 9.0, OSX 10.11, *)
-  convenience init!(asset: DataAsset) {
-    let bundle = Bundle(for: BundleToken.self)
-    #if os(iOS) || os(tvOS)
-    self.init(name: asset.name, bundle: bundle)
-    #elseif os(OSX)
-    self.init(name: NSDataAsset.Name(asset.name), bundle: bundle)
-    #endif
-  }
-}
-#endif
-
-@available(*, deprecated, renamed: "ImageAsset")
-internal typealias AssetType = ImageAsset
-
-internal struct ImageAsset {
-  internal fileprivate(set) var name: String
-
-  internal var image: Image {
-    let bundle = Bundle(for: BundleToken.self)
-    #if os(iOS) || os(tvOS)
-    let image = Image(named: name, in: bundle, compatibleWith: nil)
-    #elseif os(OSX)
-    let image = bundle.image(forResource: NSImage.Name(name))
-    #elseif os(watchOS)
-    let image = Image(named: name)
-    #endif
-    guard let result = image else { fatalError("Unable to load image named \(name).") }
-    return result
-  }
-}
-
-internal extension Image {
-  @available(iOS 1.0, tvOS 1.0, watchOS 1.0, *)
-  @available(OSX, deprecated,
-    message: "This initializer is unsafe on macOS, please use the ImageAsset.image property")
-  convenience init!(asset: ImageAsset) {
-    #if os(iOS) || os(tvOS)
-    let bundle = Bundle(for: BundleToken.self)
-    self.init(named: asset.name, in: bundle, compatibleWith: nil)
-    #elseif os(OSX)
-    self.init(named: NSImage.Name(asset.name))
-    #elseif os(watchOS)
-    self.init(named: asset.name)
-    #endif
-  }
-}
-
-// MARK: Assets
+// MARK: - Asset Catalogs
 
 // swiftlint:disable identifier_name line_length nesting type_body_length type_name
 internal enum Asset {
@@ -185,5 +101,91 @@ internal enum Asset {
   }
 }
 // swiftlint:enable identifier_name line_length nesting type_body_length type_name
+
+// MARK: - Implementation Details
+
+internal struct ColorAsset {
+  internal fileprivate(set) var name: String
+
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
+  internal var color: AssetColorTypeAlias {
+    return AssetColorTypeAlias(asset: self)
+  }
+}
+
+internal extension AssetColorTypeAlias {
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
+  convenience init!(asset: ColorAsset) {
+    let bundle = Bundle(for: BundleToken.self)
+    #if os(iOS) || os(tvOS)
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    #elseif os(OSX)
+    self.init(named: NSColor.Name(asset.name), bundle: bundle)
+    #elseif os(watchOS)
+    self.init(named: asset.name)
+    #endif
+  }
+}
+
+internal struct DataAsset {
+  internal fileprivate(set) var name: String
+
+  #if os(iOS) || os(tvOS) || os(OSX)
+  @available(iOS 9.0, tvOS 9.0, OSX 10.11, *)
+  internal var data: AssetDataTypeAlias {
+    return AssetDataTypeAlias(asset: self)
+  }
+  #endif
+}
+
+#if os(iOS) || os(tvOS) || os(OSX)
+internal extension AssetDataTypeAlias {
+  @available(iOS 9.0, tvOS 9.0, OSX 10.11, *)
+  convenience init!(asset: DataAsset) {
+    let bundle = Bundle(for: BundleToken.self)
+    #if os(iOS) || os(tvOS)
+    self.init(name: asset.name, bundle: bundle)
+    #elseif os(OSX)
+    self.init(name: NSDataAsset.Name(asset.name), bundle: bundle)
+    #endif
+  }
+}
+#endif
+
+@available(*, deprecated, renamed: "ImageAsset")
+internal typealias AssetType = ImageAsset
+
+internal struct ImageAsset {
+  internal fileprivate(set) var name: String
+
+  internal var image: Image {
+    let bundle = Bundle(for: BundleToken.self)
+    #if os(iOS) || os(tvOS)
+    let image = Image(named: name, in: bundle, compatibleWith: nil)
+    #elseif os(OSX)
+    let image = bundle.image(forResource: NSImage.Name(name))
+    #elseif os(watchOS)
+    let image = Image(named: name)
+    #endif
+    guard let result = image else { fatalError("Unable to load image named \(name).") }
+    return result
+  }
+}
+
+internal extension Image {
+  @available(iOS 1.0, tvOS 1.0, watchOS 1.0, *)
+  @available(OSX, deprecated,
+    message: "This initializer is unsafe on macOS, please use the ImageAsset.image property")
+  convenience init!(asset: ImageAsset) {
+    #if os(iOS) || os(tvOS)
+    let bundle = Bundle(for: BundleToken.self)
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    #elseif os(OSX)
+    self.init(named: NSImage.Name(asset.name))
+    #elseif os(watchOS)
+    self.init(named: asset.name)
+    #endif
+  }
+}
 
 private final class BundleToken {}

--- a/templates/colors/literals-swift3.stencil
+++ b/templates/colors/literals-swift3.stencil
@@ -15,6 +15,8 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Colors
+
 // swiftlint:disable identifier_name line_length type_body_length
 {{accessModifier}} extension {{enumName}} {
 {% macro h2f hex %}{{hex|hexToInt|int255toFloat}}{% endmacro %}

--- a/templates/colors/literals-swift4.stencil
+++ b/templates/colors/literals-swift4.stencil
@@ -15,6 +15,8 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Colors
+
 // swiftlint:disable identifier_name line_length type_body_length
 {{accessModifier}} extension {{enumName}} {
 {% macro h2f hex %}{{hex|hexToInt|int255toFloat}}{% endmacro %}

--- a/templates/colors/swift3.stencil
+++ b/templates/colors/swift3.stencil
@@ -15,18 +15,7 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-// swiftlint:disable operator_usage_whitespace
-{{accessModifier}} extension {{colorAlias}} {
-  convenience init(rgbaValue: UInt32) {
-    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
-    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
-    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
-    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
-
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
-  }
-}
-// swiftlint:enable operator_usage_whitespace
+// MARK: - Colors
 
 // swiftlint:disable identifier_name line_length type_body_length
 {% set enumName %}{{param.enumName|default:"ColorName"}}{% endset %}
@@ -53,6 +42,21 @@
   {% endif %}
 }
 // swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+// swiftlint:disable operator_usage_whitespace
+{{accessModifier}} extension {{colorAlias}} {
+  convenience init(rgbaValue: UInt32) {
+    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
+    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
+    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
+    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
+
+    self.init(red: red, green: green, blue: blue, alpha: alpha)
+  }
+}
+// swiftlint:enable operator_usage_whitespace
 
 {{accessModifier}} extension {{colorAlias}} {
   convenience init(named color: {{enumName}}) {

--- a/templates/colors/swift4.stencil
+++ b/templates/colors/swift4.stencil
@@ -15,18 +15,7 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-// swiftlint:disable operator_usage_whitespace
-{{accessModifier}} extension {{colorAlias}} {
-  convenience init(rgbaValue: UInt32) {
-    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
-    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
-    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
-    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
-
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
-  }
-}
-// swiftlint:enable operator_usage_whitespace
+// MARK: - Colors
 
 // swiftlint:disable identifier_name line_length type_body_length
 {% set enumName %}{{param.enumName|default:"ColorName"}}{% endset %}
@@ -53,6 +42,21 @@
   {% endif %}
 }
 // swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+// swiftlint:disable operator_usage_whitespace
+{{accessModifier}} extension {{colorAlias}} {
+  convenience init(rgbaValue: UInt32) {
+    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
+    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
+    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
+    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
+
+    self.init(red: red, green: green, blue: blue, alpha: alpha)
+  }
+}
+// swiftlint:enable operator_usage_whitespace
 
 {{accessModifier}} extension {{colorAlias}} {
   convenience init(named color: {{enumName}}) {

--- a/templates/fonts/swift3.stencil
+++ b/templates/fonts/swift3.stencil
@@ -14,6 +14,34 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Fonts
+
+// swiftlint:disable identifier_name line_length type_body_length
+{% macro transformPath path %}{% filter removeNewlines %}
+  {% if param.preservePath %}
+    {{path}}
+  {% else %}
+    {{path|basename}}
+  {% endif %}
+{% endfilter %}{% endmacro %}
+{{accessModifier}} enum {{param.enumName|default:"FontFamily"}} {
+  {% for family in families %}
+  {{accessModifier}} enum {{family.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% for font in family.fonts %}
+    {{accessModifier}} static let {{font.style|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = FontConvertible(name: "{{font.name}}", family: "{{family.name}}", path: "{% call transformPath font.path %}")
+    {% endfor %}
+    {{accessModifier}} static let all: [FontConvertible] = [{% for font in family.fonts %}{{font.style|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% if not forloop.last %}, {% endif %}{% endfor %}]
+  }
+  {% endfor %}
+  {{accessModifier}} static let allCustomFonts: [FontConvertible] = [{% for family in families %}{{family.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}.all{% if not forloop.last %}, {% endif %}{% endfor %}].flatMap { $0 }
+  {{accessModifier}} static func registerAllCustomFonts() {
+    allCustomFonts.forEach { $0.register() }
+  }
+}
+// swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
 {{accessModifier}} struct FontConvertible {
   {{accessModifier}} let name: String
   {{accessModifier}} let family: String
@@ -50,30 +78,6 @@
     self.init(name: font.name, size: size)
   }
 }
-
-// swiftlint:disable identifier_name line_length type_body_length
-{% macro transformPath path %}{% filter removeNewlines %}
-  {% if param.preservePath %}
-    {{path}}
-  {% else %}
-    {{path|basename}}
-  {% endif %}
-{% endfilter %}{% endmacro %}
-{{accessModifier}} enum {{param.enumName|default:"FontFamily"}} {
-  {% for family in families %}
-  {{accessModifier}} enum {{family.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% for font in family.fonts %}
-    {{accessModifier}} static let {{font.style|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = FontConvertible(name: "{{font.name}}", family: "{{family.name}}", path: "{% call transformPath font.path %}")
-    {% endfor %}
-    {{accessModifier}} static let all: [FontConvertible] = [{% for font in family.fonts %}{{font.style|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% if not forloop.last %}, {% endif %}{% endfor %}]
-  }
-  {% endfor %}
-  {{accessModifier}} static let allCustomFonts: [FontConvertible] = [{% for family in families %}{{family.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}.all{% if not forloop.last %}, {% endif %}{% endfor %}].flatMap { $0 }
-  {{accessModifier}} static func registerAllCustomFonts() {
-    allCustomFonts.forEach { $0.register() }
-  }
-}
-// swiftlint:enable identifier_name line_length type_body_length
 
 private final class BundleToken {}
 {% else %}

--- a/templates/fonts/swift4.stencil
+++ b/templates/fonts/swift4.stencil
@@ -14,6 +14,34 @@
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
+// MARK: - Fonts
+
+// swiftlint:disable identifier_name line_length type_body_length
+{% macro transformPath path %}{% filter removeNewlines %}
+  {% if param.preservePath %}
+    {{path}}
+  {% else %}
+    {{path|basename}}
+  {% endif %}
+{% endfilter %}{% endmacro %}
+{{accessModifier}} enum {{param.enumName|default:"FontFamily"}} {
+  {% for family in families %}
+  {{accessModifier}} enum {{family.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% for font in family.fonts %}
+    {{accessModifier}} static let {{font.style|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = FontConvertible(name: "{{font.name}}", family: "{{family.name}}", path: "{% call transformPath font.path %}")
+    {% endfor %}
+    {{accessModifier}} static let all: [FontConvertible] = [{% for font in family.fonts %}{{font.style|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% if not forloop.last %}, {% endif %}{% endfor %}]
+  }
+  {% endfor %}
+  {{accessModifier}} static let allCustomFonts: [FontConvertible] = [{% for family in families %}{{family.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}.all{% if not forloop.last %}, {% endif %}{% endfor %}].flatMap { $0 }
+  {{accessModifier}} static func registerAllCustomFonts() {
+    allCustomFonts.forEach { $0.register() }
+  }
+}
+// swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
 {{accessModifier}} struct FontConvertible {
   {{accessModifier}} let name: String
   {{accessModifier}} let family: String
@@ -50,30 +78,6 @@
     self.init(name: font.name, size: size)
   }
 }
-
-// swiftlint:disable identifier_name line_length type_body_length
-{% macro transformPath path %}{% filter removeNewlines %}
-  {% if param.preservePath %}
-    {{path}}
-  {% else %}
-    {{path|basename}}
-  {% endif %}
-{% endfilter %}{% endmacro %}
-{{accessModifier}} enum {{param.enumName|default:"FontFamily"}} {
-  {% for family in families %}
-  {{accessModifier}} enum {{family.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% for font in family.fonts %}
-    {{accessModifier}} static let {{font.style|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = FontConvertible(name: "{{font.name}}", family: "{{family.name}}", path: "{% call transformPath font.path %}")
-    {% endfor %}
-    {{accessModifier}} static let all: [FontConvertible] = [{% for font in family.fonts %}{{font.style|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% if not forloop.last %}, {% endif %}{% endfor %}]
-  }
-  {% endfor %}
-  {{accessModifier}} static let allCustomFonts: [FontConvertible] = [{% for family in families %}{{family.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}.all{% if not forloop.last %}, {% endif %}{% endfor %}].flatMap { $0 }
-  {{accessModifier}} static func registerAllCustomFonts() {
-    allCustomFonts.forEach { $0.register() }
-  }
-}
-// swiftlint:enable identifier_name line_length type_body_length
 
 private final class BundleToken {}
 {% else %}

--- a/templates/ib/swift3.stencil
+++ b/templates/ib/swift3.stencil
@@ -15,49 +15,8 @@ import {{module}}
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-{# This first part of the code is static, same every time whatever Storyboard you have #}
-{{accessModifier}} protocol StoryboardType {
-  static var storyboardName: String { get }
-}
+// MARK: - Storyboards
 
-{{accessModifier}} extension StoryboardType {
-  static var storyboard: {{prefix}}Storyboard {
-    return {{prefix}}Storyboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
-  }
-}
-
-{{accessModifier}} struct SceneType<T{% if not isAppKit %}: UIViewController{% endif %}> {
-  {{accessModifier}} let storyboard: StoryboardType.Type
-  {{accessModifier}} let identifier: String
-
-  {{accessModifier}} func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiate{{controller}}(withIdentifier: identifier) as? T else {
-      fatalError("{{controller}} '\(identifier)' is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-{{accessModifier}} struct InitialSceneType<T{% if not isAppKit %}: UIViewController{% endif %}> {
-  {{accessModifier}} let storyboard: StoryboardType.Type
-
-  {{accessModifier}} func instantiate() -> T {
-    guard let controller = storyboard.storyboard.instantiateInitial{{controller}}() as? T else {
-      fatalError("{{controller}} is not of the expected class \(T.self).")
-    }
-    return controller
-  }
-}
-
-{{accessModifier}} protocol SegueType: RawRepresentable { }
-
-{{accessModifier}} extension {% if isAppKit %}NSSeguePerforming{% else %}UIViewController{% endif %} {
-  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
-    performSegue{% if isAppKit %}?{% endif %}(withIdentifier: segue.rawValue, sender: sender)
-  }
-}
-
-{# This is where the generation begins, this code depends on what you have in your Storyboards #}
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 {% set sceneEnumName %}{{param.sceneEnumName|default:"StoryboardScene"}}{% endset %}
 {% macro className scene %}{% filter removeNewlines %}
@@ -99,6 +58,49 @@ import {{module}}
   {% endfor %}
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
+{{accessModifier}} protocol StoryboardType {
+  static var storyboardName: String { get }
+}
+
+{{accessModifier}} extension StoryboardType {
+  static var storyboard: {{prefix}}Storyboard {
+    return {{prefix}}Storyboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
+  }
+}
+
+{{accessModifier}} struct SceneType<T{% if not isAppKit %}: UIViewController{% endif %}> {
+  {{accessModifier}} let storyboard: StoryboardType.Type
+  {{accessModifier}} let identifier: String
+
+  {{accessModifier}} func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiate{{controller}}(withIdentifier: identifier) as? T else {
+      fatalError("{{controller}} '\(identifier)' is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+{{accessModifier}} struct InitialSceneType<T{% if not isAppKit %}: UIViewController{% endif %}> {
+  {{accessModifier}} let storyboard: StoryboardType.Type
+
+  {{accessModifier}} func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateInitial{{controller}}() as? T else {
+      fatalError("{{controller}} is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+{{accessModifier}} protocol SegueType: RawRepresentable { }
+
+{{accessModifier}} extension {% if isAppKit %}NSSeguePerforming{% else %}UIViewController{% endif %} {
+  func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
+    performSegue{% if isAppKit %}?{% endif %}(withIdentifier: segue.rawValue, sender: sender)
+  }
+}
 
 private final class BundleToken {}
 {% elif storyboards %}

--- a/templates/ib/swift4.stencil
+++ b/templates/ib/swift4.stencil
@@ -15,7 +15,52 @@ import {{module}}
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
 
-{# This first part of the code is static, same every time whatever Storyboard you have #}
+// MARK: - Storyboards
+
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+{% set sceneEnumName %}{{param.sceneEnumName|default:"StoryboardScene"}}{% endset %}
+{% macro className scene %}{% filter removeNewlines %}
+  {% if scene.module %}
+    {% if not param.ignoreTargetModule or scene.module != env.PRODUCT_MODULE_NAME and scene.module != param.module %}
+      {{scene.module}}.
+    {% endif %}
+  {% endif %}
+  {{scene.type}}
+{% endfilter %}{% endmacro %}
+{{accessModifier}} enum {{sceneEnumName}} {
+  {% for storyboard in storyboards %}
+  {% set storyboardName %}{{storyboard.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}{% endset %}
+  {{accessModifier}} enum {{storyboardName}}: StoryboardType {
+    {{accessModifier}} static let storyboardName = "{{storyboard.name}}"
+    {% if storyboard.initialScene %}
+
+    {% set sceneClass %}{% call className storyboard.initialScene %}{% endset %}
+    {{accessModifier}} static let initialScene = InitialSceneType<{{sceneClass}}>(storyboard: {{storyboardName}}.self)
+    {% endif %}
+    {% for scene in storyboard.scenes %}
+
+    {% set sceneID %}{{scene.identifier|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset %}
+    {% set sceneClass %}{% call className scene %}{% endset %}
+    {{accessModifier}} static let {{sceneID}} = SceneType<{{sceneClass}}>(storyboard: {{storyboardName}}.self, identifier: "{{scene.identifier}}")
+    {% endfor %}
+  }
+  {% endfor %}
+}
+
+{{accessModifier}} enum {{param.segueEnumName|default:"StoryboardSegue"}} {
+  {% for storyboard in storyboards where storyboard.segues %}
+  {{accessModifier}} enum {{storyboard.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}: String, SegueType {
+    {% for segue in storyboard.segues %}
+    {% set segueID %}{{segue.identifier|swiftIdentifier:"pretty"|lowerFirstWord}}{% endset %}
+    case {{segueID|escapeReservedKeywords}}{% if segueID != segue.identifier %} = "{{segue.identifier}}"{% endif %}
+    {% endfor %}
+  }
+  {% endfor %}
+}
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
 {{accessModifier}} protocol StoryboardType {
   static var storyboardName: String { get }
 }
@@ -59,49 +104,6 @@ import {{module}}
     performSegue{% if isAppKit %}?{% endif %}(withIdentifier: identifier, sender: sender)
   }
 }
-
-{# This is where the generation begins, this code depends on what you have in your Storyboards #}
-// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
-{% set sceneEnumName %}{{param.sceneEnumName|default:"StoryboardScene"}}{% endset %}
-{% macro className scene %}{% filter removeNewlines %}
-  {% if scene.module %}
-    {% if not param.ignoreTargetModule or scene.module != env.PRODUCT_MODULE_NAME and scene.module != param.module %}
-      {{scene.module}}.
-    {% endif %}
-  {% endif %}
-  {{scene.type}}
-{% endfilter %}{% endmacro %}
-{{accessModifier}} enum {{sceneEnumName}} {
-  {% for storyboard in storyboards %}
-  {% set storyboardName %}{{storyboard.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}{% endset %}
-  {{accessModifier}} enum {{storyboardName}}: StoryboardType {
-    {{accessModifier}} static let storyboardName = "{{storyboard.name}}"
-    {% if storyboard.initialScene %}
-
-    {% set sceneClass %}{% call className storyboard.initialScene %}{% endset %}
-    {{accessModifier}} static let initialScene = InitialSceneType<{{sceneClass}}>(storyboard: {{storyboardName}}.self)
-    {% endif %}
-    {% for scene in storyboard.scenes %}
-
-    {% set sceneID %}{{scene.identifier|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset %}
-    {% set sceneClass %}{% call className scene %}{% endset %}
-    {{accessModifier}} static let {{sceneID}} = SceneType<{{sceneClass}}>(storyboard: {{storyboardName}}.self, identifier: "{{scene.identifier}}")
-    {% endfor %}
-  }
-  {% endfor %}
-}
-
-{{accessModifier}} enum {{param.segueEnumName|default:"StoryboardSegue"}} {
-  {% for storyboard in storyboards where storyboard.segues %}
-  {{accessModifier}} enum {{storyboard.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}: String, SegueType {
-    {% for segue in storyboard.segues %}
-    {% set segueID %}{{segue.identifier|swiftIdentifier:"pretty"|lowerFirstWord}}{% endset %}
-    case {{segueID|escapeReservedKeywords}}{% if segueID != segue.identifier %} = "{{segue.identifier}}"{% endif %}
-    {% endfor %}
-  }
-  {% endfor %}
-}
-// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}
 {% elif storyboards %}

--- a/templates/strings/flat-swift3.stencil
+++ b/templates/strings/flat-swift3.stencil
@@ -7,6 +7,9 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
+
+// MARK: - Strings
+
 {% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
   {% for type in types %}
     _ p{{forloop.counter}}: {{type}}{% if not forloop.last %}, {% endif %}
@@ -34,7 +37,6 @@ import Foundation
   {% call recursiveBlock table child %}
   {% endfor %}
 {% endmacro %}
-
 // swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 {{accessModifier}} enum {{enumName}} {
@@ -49,6 +51,8 @@ import Foundation
   {% endif %}
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
 
 extension {{enumName}} {
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/templates/strings/flat-swift4.stencil
+++ b/templates/strings/flat-swift4.stencil
@@ -7,6 +7,9 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
+
+// MARK: - Strings
+
 {% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
   {% for type in types %}
     _ p{{forloop.counter}}: {{type}}{% if not forloop.last %}, {% endif %}
@@ -34,7 +37,6 @@ import Foundation
   {% call recursiveBlock table child %}
   {% endfor %}
 {% endmacro %}
-
 // swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 {{accessModifier}} enum {{enumName}} {
@@ -49,6 +51,8 @@ import Foundation
   {% endif %}
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
 
 extension {{enumName}} {
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/templates/strings/structured-swift3.stencil
+++ b/templates/strings/structured-swift3.stencil
@@ -7,6 +7,9 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
+
+// MARK: - Strings
+
 {% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
   {% for type in types %}
     _ p{{forloop.counter}}: {{type}}{% if not forloop.last %}, {% endif %}
@@ -37,7 +40,6 @@ import Foundation
   }
   {% endfor %}
 {% endmacro %}
-
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
@@ -45,7 +47,7 @@ import Foundation
   {% if tables.count > 1 %}
   {% for table in tables %}
   {{accessModifier}} enum {{table.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-  	{% filter indent:2 %}{% call recursiveBlock table.name table.levels %}{% endfilter %}
+    {% filter indent:2 %}{% call recursiveBlock table.name table.levels %}{% endfilter %}
   }
   {% endfor %}
   {% else %}
@@ -54,6 +56,8 @@ import Foundation
 }
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:enable nesting type_body_length type_name
+
+// MARK: - Implementation Details
 
 extension {{enumName}} {
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/templates/strings/structured-swift4.stencil
+++ b/templates/strings/structured-swift4.stencil
@@ -7,6 +7,9 @@ import Foundation
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
+
+// MARK: - Strings
+
 {% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
   {% for type in types %}
     _ p{{forloop.counter}}: {{type}}{% if not forloop.last %}, {% endif %}
@@ -37,7 +40,6 @@ import Foundation
   }
   {% endfor %}
 {% endmacro %}
-
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
@@ -45,7 +47,7 @@ import Foundation
   {% if tables.count > 1 %}
   {% for table in tables %}
   {{accessModifier}} enum {{table.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-  	{% filter indent:2 %}{% call recursiveBlock table.name table.levels %}{% endfilter %}
+    {% filter indent:2 %}{% call recursiveBlock table.name table.levels %}{% endfilter %}
   }
   {% endfor %}
   {% else %}
@@ -54,6 +56,8 @@ import Foundation
 }
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:enable nesting type_body_length type_name
+
+// MARK: - Implementation Details
 
 extension {{enumName}} {
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {

--- a/templates/xcassets/swift3.stencil
+++ b/templates/xcassets/swift3.stencil
@@ -2,6 +2,10 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
 {% if catalogs %}
+{% set enumName %}{{param.enumName|default:"Asset"}}{% endset %}
+{% set colorType %}{{param.colorTypeName|default:"ColorAsset"}}{% endset %}
+{% set dataType %}{{param.dataTypeName|default:"DataAsset"}}{% endset %}
+{% set imageType %}{{param.imageTypeName|default:"ImageAsset"}}{% endset %}
 {% set colorAlias %}{{param.colorAliasName|default:"AssetColorTypeAlias"}}{% endset %}
 {% set dataAlias %}{{param.dataAliasName|default:"AssetDataTypeAlias"}}{% endset %}
 {% set imageAlias %}{{param.imageAliasName|default:"Image"}}{% endset %}
@@ -22,96 +26,8 @@
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
-{% set enumName %}{{param.enumName|default:"Asset"}}{% endset %}
 
-{% set colorType %}{{param.colorTypeName|default:"ColorAsset"}}{% endset %}
-{{accessModifier}} struct {{colorType}} {
-  {{accessModifier}} fileprivate(set) var name: String
-
-  #if swift(>=3.2)
-  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
-  {{accessModifier}} var color: {{colorAlias}} {
-    return {{colorAlias}}(asset: self)
-  }
-  #endif
-}
-
-{{accessModifier}} extension {{colorAlias}} {
-  #if swift(>=3.2)
-  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
-  convenience init!(asset: {{colorType}}) {
-    let bundle = Bundle(for: BundleToken.self)
-    #if os(iOS) || os(tvOS)
-    self.init(named: asset.name, in: bundle, compatibleWith: nil)
-    #elseif os(OSX)
-    self.init(named: asset.name, bundle: bundle)
-    #elseif os(watchOS)
-    self.init(named: asset.name)
-    #endif
-  }
-  #endif
-}
-
-{% set dataType %}{{param.dataTypeName|default:"DataAsset"}}{% endset %}
-{{accessModifier}} struct {{dataType}} {
-  {{accessModifier}} fileprivate(set) var name: String
-
-  #if os(iOS) || os(tvOS) || os(OSX)
-  #if swift(>=3.2)
-  @available(iOS 9.0, tvOS 9.0, OSX 10.11, *)
-  {{accessModifier}} var data: {{dataAlias}} {
-    return {{dataAlias}}(asset: self)
-  }
-  #endif
-  #endif
-}
-
-#if os(iOS) || os(tvOS) || os(OSX)
-{{accessModifier}} extension {{dataAlias}} {
-  #if swift(>=3.2)
-  @available(iOS 9.0, tvOS 9.0, OSX 10.11, *)
-  convenience init!(asset: {{dataType}}) {
-    let bundle = Bundle(for: BundleToken.self)
-    self.init(name: asset.name, bundle: bundle)
-  }
-  #endif
-}
-#endif
-
-{% set imageType %}{{param.imageTypeName|default:"ImageAsset"}}{% endset %}
-@available(*, deprecated, renamed: "{{imageType}}")
-{{accessModifier}} typealias {{enumName}}Type = {{imageType}}
-
-{{accessModifier}} struct {{imageType}} {
-  {{accessModifier}} fileprivate(set) var name: String
-
-  {{accessModifier}} var image: {{imageAlias}} {
-    let bundle = Bundle(for: BundleToken.self)
-    #if os(iOS) || os(tvOS)
-    let image = {{imageAlias}}(named: name, in: bundle, compatibleWith: nil)
-    #elseif os(OSX)
-    let image = bundle.image(forResource: name)
-    #elseif os(watchOS)
-    let image = {{imageAlias}}(named: name)
-    #endif
-    guard let result = image else { fatalError("Unable to load image named \(name).") }
-    return result
-  }
-}
-
-{{accessModifier}} extension {{imageAlias}} {
-  @available(iOS 1.0, tvOS 1.0, watchOS 1.0, *)
-  @available(OSX, deprecated,
-    message: "This initializer is unsafe on macOS, please use the {{imageType}}.image property")
-  convenience init!(asset: {{imageType}}) {
-    #if os(iOS) || os(tvOS)
-    let bundle = Bundle(for: BundleToken.self)
-    self.init(named: asset.name, in: bundle, compatibleWith: nil)
-    #elseif os(OSX) || os(watchOS)
-    self.init(named: asset.name)
-    #endif
-  }
-}
+// MARK: - Asset Catalogs
 
 {% macro enumBlock assets %}
   {% call casesBlock assets %}
@@ -166,8 +82,6 @@
   {% endif %}
   {% endfor %}
 {% endmacro %}
-// MARK: Assets
-
 // swiftlint:disable identifier_name line_length nesting type_body_length type_name
 {{accessModifier}} enum {{enumName}} {
   {% if catalogs.count > 1 %}
@@ -181,6 +95,94 @@
   {% endif %}
 }
 // swiftlint:enable identifier_name line_length nesting type_body_length type_name
+
+// MARK: - Implementation Details
+
+{{accessModifier}} struct {{colorType}} {
+  {{accessModifier}} fileprivate(set) var name: String
+
+  #if swift(>=3.2)
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
+  {{accessModifier}} var color: {{colorAlias}} {
+    return {{colorAlias}}(asset: self)
+  }
+  #endif
+}
+
+{{accessModifier}} extension {{colorAlias}} {
+  #if swift(>=3.2)
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
+  convenience init!(asset: {{colorType}}) {
+    let bundle = Bundle(for: BundleToken.self)
+    #if os(iOS) || os(tvOS)
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    #elseif os(OSX)
+    self.init(named: asset.name, bundle: bundle)
+    #elseif os(watchOS)
+    self.init(named: asset.name)
+    #endif
+  }
+  #endif
+}
+
+{{accessModifier}} struct {{dataType}} {
+  {{accessModifier}} fileprivate(set) var name: String
+
+  #if os(iOS) || os(tvOS) || os(OSX)
+  #if swift(>=3.2)
+  @available(iOS 9.0, tvOS 9.0, OSX 10.11, *)
+  {{accessModifier}} var data: {{dataAlias}} {
+    return {{dataAlias}}(asset: self)
+  }
+  #endif
+  #endif
+}
+
+#if os(iOS) || os(tvOS) || os(OSX)
+{{accessModifier}} extension {{dataAlias}} {
+  #if swift(>=3.2)
+  @available(iOS 9.0, tvOS 9.0, OSX 10.11, *)
+  convenience init!(asset: {{dataType}}) {
+    let bundle = Bundle(for: BundleToken.self)
+    self.init(name: asset.name, bundle: bundle)
+  }
+  #endif
+}
+#endif
+
+@available(*, deprecated, renamed: "{{imageType}}")
+{{accessModifier}} typealias {{enumName}}Type = {{imageType}}
+
+{{accessModifier}} struct {{imageType}} {
+  {{accessModifier}} fileprivate(set) var name: String
+
+  {{accessModifier}} var image: {{imageAlias}} {
+    let bundle = Bundle(for: BundleToken.self)
+    #if os(iOS) || os(tvOS)
+    let image = {{imageAlias}}(named: name, in: bundle, compatibleWith: nil)
+    #elseif os(OSX)
+    let image = bundle.image(forResource: name)
+    #elseif os(watchOS)
+    let image = {{imageAlias}}(named: name)
+    #endif
+    guard let result = image else { fatalError("Unable to load image named \(name).") }
+    return result
+  }
+}
+
+{{accessModifier}} extension {{imageAlias}} {
+  @available(iOS 1.0, tvOS 1.0, watchOS 1.0, *)
+  @available(OSX, deprecated,
+    message: "This initializer is unsafe on macOS, please use the {{imageType}}.image property")
+  convenience init!(asset: {{imageType}}) {
+    #if os(iOS) || os(tvOS)
+    let bundle = Bundle(for: BundleToken.self)
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    #elseif os(OSX) || os(watchOS)
+    self.init(named: asset.name)
+    #endif
+  }
+}
 
 private final class BundleToken {}
 {% else %}

--- a/templates/xcassets/swift4.stencil
+++ b/templates/xcassets/swift4.stencil
@@ -2,6 +2,10 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
 {% if catalogs %}
+{% set enumName %}{{param.enumName|default:"Asset"}}{% endset %}
+{% set colorType %}{{param.colorTypeName|default:"ColorAsset"}}{% endset %}
+{% set dataType %}{{param.dataTypeName|default:"DataAsset"}}{% endset %}
+{% set imageType %}{{param.imageTypeName|default:"ImageAsset"}}{% endset %}
 {% set colorAlias %}{{param.colorAliasName|default:"AssetColorTypeAlias"}}{% endset %}
 {% set dataAlias %}{{param.dataAliasName|default:"AssetDataTypeAlias"}}{% endset %}
 {% set imageAlias %}{{param.imageAliasName|default:"Image"}}{% endset %}
@@ -22,94 +26,8 @@
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
-{% set enumName %}{{param.enumName|default:"Asset"}}{% endset %}
 
-{% set colorType %}{{param.colorTypeName|default:"ColorAsset"}}{% endset %}
-{{accessModifier}} struct {{colorType}} {
-  {{accessModifier}} fileprivate(set) var name: String
-
-  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
-  {{accessModifier}} var color: {{colorAlias}} {
-    return {{colorAlias}}(asset: self)
-  }
-}
-
-{{accessModifier}} extension {{colorAlias}} {
-  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
-  convenience init!(asset: {{colorType}}) {
-    let bundle = Bundle(for: BundleToken.self)
-    #if os(iOS) || os(tvOS)
-    self.init(named: asset.name, in: bundle, compatibleWith: nil)
-    #elseif os(OSX)
-    self.init(named: NSColor.Name(asset.name), bundle: bundle)
-    #elseif os(watchOS)
-    self.init(named: asset.name)
-    #endif
-  }
-}
-
-{% set dataType %}{{param.dataTypeName|default:"DataAsset"}}{% endset %}
-{{accessModifier}} struct {{dataType}} {
-  {{accessModifier}} fileprivate(set) var name: String
-
-  #if os(iOS) || os(tvOS) || os(OSX)
-  @available(iOS 9.0, tvOS 9.0, OSX 10.11, *)
-  {{accessModifier}} var data: {{dataAlias}} {
-    return {{dataAlias}}(asset: self)
-  }
-  #endif
-}
-
-#if os(iOS) || os(tvOS) || os(OSX)
-{{accessModifier}} extension {{dataAlias}} {
-  @available(iOS 9.0, tvOS 9.0, OSX 10.11, *)
-  convenience init!(asset: {{dataType}}) {
-    let bundle = Bundle(for: BundleToken.self)
-    #if os(iOS) || os(tvOS)
-    self.init(name: asset.name, bundle: bundle)
-    #elseif os(OSX)
-    self.init(name: NSDataAsset.Name(asset.name), bundle: bundle)
-    #endif
-  }
-}
-#endif
-
-{% set imageType %}{{param.imageTypeName|default:"ImageAsset"}}{% endset %}
-@available(*, deprecated, renamed: "{{imageType}}")
-{{accessModifier}} typealias {{enumName}}Type = {{imageType}}
-
-{{accessModifier}} struct {{imageType}} {
-  {{accessModifier}} fileprivate(set) var name: String
-
-  {{accessModifier}} var image: {{imageAlias}} {
-    let bundle = Bundle(for: BundleToken.self)
-    #if os(iOS) || os(tvOS)
-    let image = {{imageAlias}}(named: name, in: bundle, compatibleWith: nil)
-    #elseif os(OSX)
-    let image = bundle.image(forResource: NSImage.Name(name))
-    #elseif os(watchOS)
-    let image = {{imageAlias}}(named: name)
-    #endif
-    guard let result = image else { fatalError("Unable to load image named \(name).") }
-    return result
-  }
-}
-
-{{accessModifier}} extension {{imageAlias}} {
-  @available(iOS 1.0, tvOS 1.0, watchOS 1.0, *)
-  @available(OSX, deprecated,
-    message: "This initializer is unsafe on macOS, please use the {{imageType}}.image property")
-  convenience init!(asset: {{imageType}}) {
-    #if os(iOS) || os(tvOS)
-    let bundle = Bundle(for: BundleToken.self)
-    self.init(named: asset.name, in: bundle, compatibleWith: nil)
-    #elseif os(OSX)
-    self.init(named: NSImage.Name(asset.name))
-    #elseif os(watchOS)
-    self.init(named: asset.name)
-    #endif
-  }
-}
+// MARK: - Asset Catalogs
 
 {% macro enumBlock assets %}
   {% call casesBlock assets %}
@@ -164,8 +82,6 @@
   {% endif %}
   {% endfor %}
 {% endmacro %}
-// MARK: Assets
-
 // swiftlint:disable identifier_name line_length nesting type_body_length type_name
 {{accessModifier}} enum {{enumName}} {
   {% if catalogs.count > 1 %}
@@ -179,6 +95,92 @@
   {% endif %}
 }
 // swiftlint:enable identifier_name line_length nesting type_body_length type_name
+
+// MARK: - Implementation Details
+
+{{accessModifier}} struct {{colorType}} {
+  {{accessModifier}} fileprivate(set) var name: String
+
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
+  {{accessModifier}} var color: {{colorAlias}} {
+    return {{colorAlias}}(asset: self)
+  }
+}
+
+{{accessModifier}} extension {{colorAlias}} {
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
+  convenience init!(asset: {{colorType}}) {
+    let bundle = Bundle(for: BundleToken.self)
+    #if os(iOS) || os(tvOS)
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    #elseif os(OSX)
+    self.init(named: NSColor.Name(asset.name), bundle: bundle)
+    #elseif os(watchOS)
+    self.init(named: asset.name)
+    #endif
+  }
+}
+
+{{accessModifier}} struct {{dataType}} {
+  {{accessModifier}} fileprivate(set) var name: String
+
+  #if os(iOS) || os(tvOS) || os(OSX)
+  @available(iOS 9.0, tvOS 9.0, OSX 10.11, *)
+  {{accessModifier}} var data: {{dataAlias}} {
+    return {{dataAlias}}(asset: self)
+  }
+  #endif
+}
+
+#if os(iOS) || os(tvOS) || os(OSX)
+{{accessModifier}} extension {{dataAlias}} {
+  @available(iOS 9.0, tvOS 9.0, OSX 10.11, *)
+  convenience init!(asset: {{dataType}}) {
+    let bundle = Bundle(for: BundleToken.self)
+    #if os(iOS) || os(tvOS)
+    self.init(name: asset.name, bundle: bundle)
+    #elseif os(OSX)
+    self.init(name: NSDataAsset.Name(asset.name), bundle: bundle)
+    #endif
+  }
+}
+#endif
+
+@available(*, deprecated, renamed: "{{imageType}}")
+{{accessModifier}} typealias {{enumName}}Type = {{imageType}}
+
+{{accessModifier}} struct {{imageType}} {
+  {{accessModifier}} fileprivate(set) var name: String
+
+  {{accessModifier}} var image: {{imageAlias}} {
+    let bundle = Bundle(for: BundleToken.self)
+    #if os(iOS) || os(tvOS)
+    let image = {{imageAlias}}(named: name, in: bundle, compatibleWith: nil)
+    #elseif os(OSX)
+    let image = bundle.image(forResource: NSImage.Name(name))
+    #elseif os(watchOS)
+    let image = {{imageAlias}}(named: name)
+    #endif
+    guard let result = image else { fatalError("Unable to load image named \(name).") }
+    return result
+  }
+}
+
+{{accessModifier}} extension {{imageAlias}} {
+  @available(iOS 1.0, tvOS 1.0, watchOS 1.0, *)
+  @available(OSX, deprecated,
+    message: "This initializer is unsafe on macOS, please use the {{imageType}}.image property")
+  convenience init!(asset: {{imageType}}) {
+    #if os(iOS) || os(tvOS)
+    let bundle = Bundle(for: BundleToken.self)
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    #elseif os(OSX)
+    self.init(named: NSImage.Name(asset.name))
+    #elseif os(watchOS)
+    self.init(named: asset.name)
+    #endif
+  }
+}
 
 private final class BundleToken {}
 {% else %}


### PR DESCRIPTION
Fixes #479.

Moves all generated constants to the top, and all other content (implementation details) to the bottom. Also separate the to by a `// MARK: - ...` for easier navigation.