### PR TITLE
Strings: fix format parser to handle `% d` and `%#x`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@
   [David Jennes](https://github.com/djbe)
   [#435](https://github.com/SwiftGen/SwiftGen/issues/435)
   [#485](https://github.com/SwiftGen/SwiftGen/pull/485)
+* Strings: the parser now correctly handles formats such as `% d` and `%#x`.  
+  [David Jennes](https://github.com/djbe)
+  [#502](https://github.com/SwiftGen/SwiftGen/pull/502)
 
 ### Breaking Changes
 

--- a/Sources/SwiftGenKit/Parsers/Strings/PlaceholderType.swift
+++ b/Sources/SwiftGenKit/Parsers/Strings/PlaceholderType.swift
@@ -49,7 +49,7 @@ extension Strings.PlaceholderType {
     // like in "%3$" to make positional specifiers
     let position = "([1-9]\\d*\\$)?"
     // precision like in "%1.2f"
-    let precision = "[-+]?\\d?(?:\\.\\d)?"
+    let precision = "[-+# 0]?\\d?(?:\\.\\d)?"
 
     do {
       return try NSRegularExpression(

--- a/Tests/SwiftGenKitTests/StringParserTests.swift
+++ b/Tests/SwiftGenKitTests/StringParserTests.swift
@@ -50,6 +50,18 @@ class StringParserTests: XCTestCase {
     XCTAssertEqual(placeholders, [.unknown, .int, .object, .float, .char])
   }
 
+  func testParseFlags() throws {
+    let formats = ["%-9d", "%+9d", "% 9d", "%#9d", "%09d"]
+    for format in formats {
+      let placeholders = try Strings.PlaceholderType.placeholders(fromFormat: format)
+      XCTAssertEqual(placeholders, [.int], "Failed to parse format \"\(format)\"")
+    }
+
+    let invalidFormat = "%_9d %_9f %_9@ %!9@"
+    let placeholders = try Strings.PlaceholderType.placeholders(fromFormat: invalidFormat)
+    XCTAssertEqual(placeholders, [])
+  }
+
   func testParseDuplicateFormatPlaceholders() throws {
     let placeholders = try Strings.PlaceholderType.placeholders(fromFormat: "Text: %1$@; %1$@.")
     XCTAssertEqual(placeholders, [.object])


### PR DESCRIPTION
Fixes #501.

We were missing some cases such as (see docs https://en.wikipedia.org/wiki/Printf_format_string#Flags_field):
- `% d` --> pad with spaces
- `%#x` --> "alternate form" (no idea)
- `%0d` --> pad with zeroes

What's still missing:

Apparently this is possible:
```c
printf("%*d", 5, 10)
printf("%.*s", 3, "abcdef)
```

So both the width and precision fields can accept dynamic values (`int`). After some testing we've noticed that the `String(format:)` initialiser has quite a few bugs with these dynamic fields, so we're not adding them for now.