### PR TITLE
Strings: Use `tr` without params for strings without params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
 * Strings: the parser now correctly handles formats such as `% d` and `%#x`.  
   [David Jennes](https://github.com/djbe)
   [#502](https://github.com/SwiftGen/SwiftGen/pull/502)
+* Strings: ensure strings without arguments are not processed using `String(format:)`.  
+  [David Jennes](https://github.com/djbe)
+  [#503](https://github.com/SwiftGen/SwiftGen/pull/503)
 
 ### Breaking Changes
 

--- a/Scripts/SwiftLint.sh
+++ b/Scripts/SwiftLint.sh
@@ -39,7 +39,7 @@ if [ "$key" = "templates_generated" ]; then
 	for f in `find "${PROJECT_DIR}/${selected_path}" -name '*.swift'`; do
 		temp_file="${scratch}${f#"$PROJECT_DIR"}"
 		mkdir -p $(dirname "$temp_file")
-		sed s@"swiftlint:disable all"@" --"@ "$f" > "$temp_file"
+		sed "s/swiftlint:disable all/ --/" "$f" > "$temp_file"
 	done
 
 	"$SWIFTLINT" lint --strict --config "$CONFIG" --path "$scratch" | sed s@"$scratch"@"${PROJECT_DIR}"@

--- a/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable-customname.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable-customname.swift
@@ -46,6 +46,10 @@ internal enum XCTLoc {
 // MARK: - Implementation Details
 
 extension XCTLoc {
+  fileprivate static func tr(_ table: String, _ key: String) -> String {
+    return NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
+  }
+
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
     let format = NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)

--- a/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable-no-comments.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable-no-comments.swift
@@ -35,6 +35,10 @@ internal enum L10n {
 // MARK: - Implementation Details
 
 extension L10n {
+  fileprivate static func tr(_ table: String, _ key: String) -> String {
+    return NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
+  }
+
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
     let format = NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)

--- a/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable-publicAccess.swift
@@ -46,6 +46,10 @@ public enum L10n {
 // MARK: - Implementation Details
 
 extension L10n {
+  fileprivate static func tr(_ table: String, _ key: String) -> String {
+    return NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
+  }
+
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
     let format = NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)

--- a/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift3-context-localizable.swift
@@ -46,6 +46,10 @@ internal enum L10n {
 // MARK: - Implementation Details
 
 extension L10n {
+  fileprivate static func tr(_ table: String, _ key: String) -> String {
+    return NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
+  }
+
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
     let format = NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)

--- a/Tests/Fixtures/Generated/Strings/flat-swift3-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift3-context-multiple.swift
@@ -60,6 +60,10 @@ internal enum L10n {
 // MARK: - Implementation Details
 
 extension L10n {
+  fileprivate static func tr(_ table: String, _ key: String) -> String {
+    return NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
+  }
+
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
     let format = NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)

--- a/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable-customname.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable-customname.swift
@@ -46,6 +46,10 @@ internal enum XCTLoc {
 // MARK: - Implementation Details
 
 extension XCTLoc {
+  private static func tr(_ table: String, _ key: String) -> String {
+    return NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
+  }
+
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
     let format = NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)

--- a/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable-no-comments.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable-no-comments.swift
@@ -35,6 +35,10 @@ internal enum L10n {
 // MARK: - Implementation Details
 
 extension L10n {
+  private static func tr(_ table: String, _ key: String) -> String {
+    return NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
+  }
+
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
     let format = NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)

--- a/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable-publicAccess.swift
@@ -46,6 +46,10 @@ public enum L10n {
 // MARK: - Implementation Details
 
 extension L10n {
+  private static func tr(_ table: String, _ key: String) -> String {
+    return NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
+  }
+
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
     let format = NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)

--- a/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift4-context-localizable.swift
@@ -46,6 +46,10 @@ internal enum L10n {
 // MARK: - Implementation Details
 
 extension L10n {
+  private static func tr(_ table: String, _ key: String) -> String {
+    return NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
+  }
+
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
     let format = NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)

--- a/Tests/Fixtures/Generated/Strings/flat-swift4-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift4-context-multiple.swift
@@ -60,6 +60,10 @@ internal enum L10n {
 // MARK: - Implementation Details
 
 extension L10n {
+  private static func tr(_ table: String, _ key: String) -> String {
+    return NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
+  }
+
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
     let format = NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)

--- a/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable-customname.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable-customname.swift
@@ -83,6 +83,10 @@ internal enum XCTLoc {
 // MARK: - Implementation Details
 
 extension XCTLoc {
+  fileprivate static func tr(_ table: String, _ key: String) -> String {
+    return NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
+  }
+
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
     let format = NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)

--- a/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable-no-comments.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable-no-comments.swift
@@ -72,6 +72,10 @@ internal enum L10n {
 // MARK: - Implementation Details
 
 extension L10n {
+  fileprivate static func tr(_ table: String, _ key: String) -> String {
+    return NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
+  }
+
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
     let format = NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)

--- a/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable-publicAccess.swift
@@ -83,6 +83,10 @@ public enum L10n {
 // MARK: - Implementation Details
 
 extension L10n {
+  fileprivate static func tr(_ table: String, _ key: String) -> String {
+    return NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
+  }
+
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
     let format = NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)

--- a/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift3-context-localizable.swift
@@ -83,6 +83,10 @@ internal enum L10n {
 // MARK: - Implementation Details
 
 extension L10n {
+  fileprivate static func tr(_ table: String, _ key: String) -> String {
+    return NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
+  }
+
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
     let format = NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)

--- a/Tests/Fixtures/Generated/Strings/structured-swift3-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift3-context-multiple.swift
@@ -94,6 +94,10 @@ internal enum L10n {
 // MARK: - Implementation Details
 
 extension L10n {
+  fileprivate static func tr(_ table: String, _ key: String) -> String {
+    return NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
+  }
+
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
     let format = NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)

--- a/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable-customname.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable-customname.swift
@@ -83,6 +83,10 @@ internal enum XCTLoc {
 // MARK: - Implementation Details
 
 extension XCTLoc {
+  private static func tr(_ table: String, _ key: String) -> String {
+    return NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
+  }
+
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
     let format = NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)

--- a/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable-no-comments.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable-no-comments.swift
@@ -72,6 +72,10 @@ internal enum L10n {
 // MARK: - Implementation Details
 
 extension L10n {
+  private static func tr(_ table: String, _ key: String) -> String {
+    return NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
+  }
+
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
     let format = NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)

--- a/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable-publicAccess.swift
@@ -83,6 +83,10 @@ public enum L10n {
 // MARK: - Implementation Details
 
 extension L10n {
+  private static func tr(_ table: String, _ key: String) -> String {
+    return NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
+  }
+
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
     let format = NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)

--- a/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift4-context-localizable.swift
@@ -83,6 +83,10 @@ internal enum L10n {
 // MARK: - Implementation Details
 
 extension L10n {
+  private static func tr(_ table: String, _ key: String) -> String {
+    return NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
+  }
+
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
     let format = NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)

--- a/Tests/Fixtures/Generated/Strings/structured-swift4-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift4-context-multiple.swift
@@ -94,6 +94,10 @@ internal enum L10n {
 // MARK: - Implementation Details
 
 extension L10n {
+  private static func tr(_ table: String, _ key: String) -> String {
+    return NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
+  }
+
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
     let format = NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)

--- a/templates/strings/flat-swift3.stencil
+++ b/templates/strings/flat-swift3.stencil
@@ -55,6 +55,10 @@ import Foundation
 // MARK: - Implementation Details
 
 extension {{enumName}} {
+  fileprivate static func tr(_ table: String, _ key: String) -> String {
+    return NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
+  }
+
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
     let format = NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)

--- a/templates/strings/flat-swift4.stencil
+++ b/templates/strings/flat-swift4.stencil
@@ -55,6 +55,10 @@ import Foundation
 // MARK: - Implementation Details
 
 extension {{enumName}} {
+  private static func tr(_ table: String, _ key: String) -> String {
+    return NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
+  }
+
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
     let format = NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)

--- a/templates/strings/structured-swift3.stencil
+++ b/templates/strings/structured-swift3.stencil
@@ -60,6 +60,10 @@ import Foundation
 // MARK: - Implementation Details
 
 extension {{enumName}} {
+  fileprivate static func tr(_ table: String, _ key: String) -> String {
+    return NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
+  }
+
   fileprivate static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
     let format = NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)

--- a/templates/strings/structured-swift4.stencil
+++ b/templates/strings/structured-swift4.stencil
@@ -60,6 +60,10 @@ import Foundation
 // MARK: - Implementation Details
 
 extension {{enumName}} {
+  private static func tr(_ table: String, _ key: String) -> String {
+    return NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
+  }
+
   private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
     let format = NSLocalizedString(key, tableName: table, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)


### PR DESCRIPTION
Refs #501.

Adds a `tr` function that doesn't accept any parameters, and directly returns the result of `NSLocalizedString`.