### PR TITLE
Clarify template name/path errors

### DIFF
--- a/Sources/SwiftGen/TemplateRef.swift
+++ b/Sources/SwiftGen/TemplateRef.swift
@@ -71,13 +71,13 @@ extension TemplateRef.Error: CustomStringConvertible {
     case .namedTemplateNotFound(let name):
       return """
         Template named \(name) not found. Use `swiftgen templates` to list available named templates \
-        or use --templatePath to specify a template by its full path.
+        or use `templatePath` to specify a template by its full path.
         """
     case .templatePathNotFound(let path):
       return "Template not found at path \(path.description)."
     case .noTemplateProvided:
       return """
-        You must specify a template name (-t) or path (-p).
+        You must specify a template by name (templateName) or path (templatePath).
 
         To list all the available named templates, use 'swiftgen templates list'.
         """

--- a/Tests/SwiftGenTests/ConfigLintTests.swift
+++ b/Tests/SwiftGenTests/ConfigLintTests.swift
@@ -90,7 +90,7 @@ class ConfigLintTests: XCTestCase {
 
   func testLintMissingTemplateNameAndPath() {
     let errorMsg = """
-      You must specify a template name (-t) or path (-p).
+      You must specify a template by name (templateName) or path (templatePath).
 
       To list all the available named templates, use 'swiftgen templates list'.
       """

--- a/Tests/SwiftGenTests/ConfigReadTests.swift
+++ b/Tests/SwiftGenTests/ConfigReadTests.swift
@@ -138,7 +138,7 @@ class ConfigReadTests: XCTestCase {
     let badConfigs = [
       "config-missing-paths": "Missing entry for key strings.inputs.",
       "config-missing-template": """
-        You must specify a template name (-t) or path (-p).
+        You must specify a template by name (templateName) or path (templatePath).
 
         To list all the available named templates, use 'swiftgen templates list'.
         """,


### PR DESCRIPTION
This is to better match our focus on configuration users, so that they don't suddenly get some weird errors about CLI flags.

The errors themselves are still usable for CLI users, because the configuration field names match the CLI options.