### PR TITLE
Fix (completely) broken swiftlint for output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,9 @@
   [#424](https://github.com/SwiftGen/SwiftGen/pull/424)
 * Use `swiftlint:disable all` in generated files to avoid interference with SwiftLint rules custom to the host project.  
   [Frederick Pietschmann](https://github.com/fredpi)
+  [David Jennes](https://github.com/djbe)
   [#409](https://github.com/SwiftGen/SwiftGen/issues/409)
+  [#506](https://github.com/SwiftGen/SwiftGen/issues/506)
 * XCAssets: Added support for `NSDataAssets`.  
   [Oliver Jones](https://github.com/orj)
   [#444](https://github.com/SwiftGen/SwiftGen/issues/444)

--- a/Scripts/SwiftLint.sh
+++ b/Scripts/SwiftLint.sh
@@ -26,8 +26,23 @@ if [ -z "$selected_path" ]; then
 	exit 1
 fi
 
+# temporary work directory
+scratch=`mktemp -d -t SwiftGen`
+function finish {
+  rm -rf "$scratch"
+}
+trap finish EXIT
+
+# actually run swiftlint
 if [ "$key" = "templates_generated" ]; then
-	find "${PROJECT_DIR}/${selected_path}" -name "*.swift" -exec ${PROJECT_DIR}/Scripts/swiftlint_no_disable_all.sh {} \;
+	# copy the generated output to a temp dir and strip the "swiftlint:disable:all"
+	for f in `find "${PROJECT_DIR}/${selected_path}" -name '*.swift'`; do
+		temp_file="${scratch}${f#"$PROJECT_DIR"}"
+		mkdir -p $(dirname "$temp_file")
+		sed s@"swiftlint:disable all"@" --"@ "$f" > "$temp_file"
+	done
+
+	"$SWIFTLINT" lint --strict --config "$CONFIG" --path "$scratch" | sed s@"$scratch"@"${PROJECT_DIR}"@
 else
 	"$SWIFTLINT" lint --strict --config "$CONFIG" --path "${PROJECT_DIR}/${selected_path}"
 fi

--- a/Scripts/swiftlint_no_disable_all.sh
+++ b/Scripts/swiftlint_no_disable_all.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-cat $1 | sed s@"swiftlint:disable all"@" --"@ | swiftlint --use-stdin --strict | sed s@"<nopath>"@"$1"@


### PR DESCRIPTION
Seems no one noticed that since #409, the linting of output on CI has been broken (not on device though, if you have `swiftlint` installed globally).

Also, the linting performance is abysmal, this PR improves things. It goes from `22.44s` down to `9.80s`.