### PR TITLE
Better config linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Read the [SwiftGen 6.0 Migration Guide](https://github.com/SwiftGen/SwiftGen/blo
 * The `swiftgen.yml` config file now accepts multiple outputs for each command, allowing you to generate multiple outputs from the same files and content. This also means that the `output` parameter is now deprecated, in favour of the `outputs` parameter, and it may be removed in a future version of SwiftGen. Similarly, the `paths` parameter has been renamed to `inputs` for consistency. You can always use `swiftgen config lint` to validate your configuration file.  
   [David Jennes](https://github.com/djbe) 
   [#424](https://github.com/SwiftGen/SwiftGen/pull/424)
+  [#510](https://github.com/SwiftGen/SwiftGen/pull/510)
 * Use `swiftlint:disable all` in generated files to avoid interference with SwiftLint rules custom to the host project.  
   [Frederick Pietschmann](https://github.com/fredpi)
   [David Jennes](https://github.com/djbe)

--- a/Sources/SwiftGen/Commander/ConfigCommands.swift
+++ b/Sources/SwiftGen/Commander/ConfigCommands.swift
@@ -94,7 +94,7 @@ let configRunCommand = command(
           guard let parserCmd = allParserCommands.first(where: { $0.name == cmd }) else {
             throw Config.Error.missingEntry(key: cmd)
           }
-          entry.makeRelativeTo(inputDir: config.inputDir, outputDir: config.outputDir)
+          entry.makingRelativeTo(inputDir: config.inputDir, outputDir: config.outputDir)
           if verbose {
             for item in entry.commandLine(forCommand: cmd) {
               logMessage(.info, " $ \(item)")

--- a/Sources/SwiftGen/Config/Config.swift
+++ b/Sources/SwiftGen/Config/Config.swift
@@ -86,7 +86,7 @@ extension Config {
 
   private func lint(cmd: String, entry: ConfigEntry, logger: (LogLevel, String) -> Void = logMessage) {
     var entry = entry
-    entry.makeRelativeTo(inputDir: inputDir, outputDir: outputDir)
+    entry.makingRelativeTo(inputDir: inputDir, outputDir: outputDir)
 
     for inputPath in entry.inputs {
       if !inputPath.exists {

--- a/Sources/SwiftGen/Config/Config.swift
+++ b/Sources/SwiftGen/Config/Config.swift
@@ -55,29 +55,82 @@ extension Config {
 // MARK: - Linting
 
 extension Config {
+  // Deprecated
+  private static let deprecatedCommands = [
+    "storyboards": "ib"
+  ]
+
   func lint(logger: (LogLevel, String) -> Void = logMessage) {
-    logger(.info, "> Common parent directory used for all input paths:  \(self.inputDir ?? "<none>")")
+    logger(.info, "> Common parent directory used for all input paths:  \(inputDir ?? "<none>")")
+    if let inputDir = inputDir, !inputDir.exists {
+      logger(.error, "input_dir: Input directory \(inputDir) does not exist")
+    }
+
     logger(.info, "> Common parent directory used for all output paths: \(self.outputDir ?? "<none>")")
-    for (cmd, entries) in self.commands {
+    if let outputDir = outputDir, !outputDir.exists {
+      logger(.error, "output_dir: Output directory \(outputDir) does not exist")
+    }
+
+    for (cmd, entries) in commands {
+      if let replacement = Config.deprecatedCommands[cmd] {
+        logger(.warning, "`\(cmd)` action has been deprecated, please use `\(replacement)` instead.")
+      }
+
       let entriesCount = "\(entries.count) " + (entries.count > 1 ? "entries" : "entry")
       logger(.info, "> \(entriesCount) for command \(cmd):")
-      for var entry in entries {
-        entry.makeRelativeTo(inputDir: self.inputDir, outputDir: self.outputDir)
-        for inputPath in entry.inputs where inputPath.isAbsolute {
-          logger(.warning, "\(cmd).paths: \(inputPath) is an absolute path.")
-        }
-        for entryOutput in entry.outputs {
-          if case TemplateRef.path(let templateRef) = entryOutput.template, templateRef.isAbsolute {
-            logger(.warning, "\(cmd).templatePath: \(templateRef) is an absolute path.")
-          }
-          if entryOutput.output.isAbsolute {
-            logger(.warning, "\(cmd).output: \(entryOutput.output) is an absolute path.")
-          }
-        }
-        for item in entry.commandLine(forCommand: cmd) {
-          logMessage(.info, " $ \(item)")
-        }
+      for entry in entries {
+        lint(cmd: cmd, entry: entry, logger: logger)
       }
+    }
+  }
+
+  private func lint(cmd: String, entry: ConfigEntry, logger: (LogLevel, String) -> Void = logMessage) {
+    var entry = entry
+    entry.makeRelativeTo(inputDir: inputDir, outputDir: outputDir)
+
+    for inputPath in entry.inputs {
+      if !inputPath.exists {
+        logger(.error, "\(cmd).inputs: \(inputPath) does not exist")
+      }
+      if inputPath.isAbsolute {
+        logger(.warning, """
+          \(cmd).inputs: \(inputPath) is an absolute path. Prefer relative paths for portability \
+          when sharing your project.
+          """)
+      }
+    }
+
+    for entryOutput in entry.outputs {
+      do {
+        let actualCmd = Config.deprecatedCommands[cmd] ?? cmd
+        _ = try entryOutput.template.resolvePath(forSubcommand: actualCmd)
+      } catch let error {
+        logger(.error, "\(cmd).outputs: \(error)")
+      }
+      if case TemplateRef.path(let templateRef) = entryOutput.template, templateRef.isAbsolute {
+        logger(.warning, """
+          \(cmd).outputs.templatePath: \(templateRef) is an absolute path. Prefer relative paths \
+          for portability when sharing your project.
+          """)
+      }
+
+      let outputParent = entryOutput.output.parent()
+      if !outputParent.exists {
+        logger(.error, """
+          \(cmd).outputs.output: \(outputParent) does not exist. Intermediate folders up to the \
+          output file must already exist to avoid misconfigurations, and won't be created for you.
+          """)
+      }
+      if entryOutput.output.isAbsolute {
+        logger(.warning, """
+          \(cmd).outputs.output: \(entryOutput.output) is an absolute path. Prefer relative paths \
+          for portability when sharing your project.
+          """)
+      }
+    }
+
+    for item in entry.commandLine(forCommand: cmd) {
+      logMessage(.info, " $ \(item)")
     }
   }
 }

--- a/Sources/SwiftGen/Config/ConfigEntry.swift
+++ b/Sources/SwiftGen/Config/ConfigEntry.swift
@@ -31,13 +31,13 @@ struct ConfigEntry {
   var inputs: [Path]
   var outputs: [ConfigEntryOutput]
 
-  mutating func makeRelativeTo(inputDir: Path?, outputDir: Path?) {
+  mutating func makingRelativeTo(inputDir: Path?, outputDir: Path?) {
     if let inputDir = inputDir {
       self.inputs = self.inputs.map { $0.isRelative ? inputDir + $0 : $0 }
     }
     self.outputs = self.outputs.map {
       var output = $0
-      output.makeRelativeTo(outputDir: outputDir)
+      output.makingRelativeTo(outputDir: outputDir)
       return output
     }
   }

--- a/Sources/SwiftGen/Config/ConfigOutput.swift
+++ b/Sources/SwiftGen/Config/ConfigOutput.swift
@@ -23,7 +23,7 @@ struct ConfigEntryOutput {
   var parameters: [String: Any]
   var template: TemplateRef
 
-  mutating func makeRelativeTo(outputDir: Path?) {
+  mutating func makingRelativeTo(outputDir: Path?) {
     if let outputDir = outputDir, self.output.isRelative {
       self.output = outputDir + self.output
     }

--- a/Sources/SwiftGen/Path+AppSupport.swift
+++ b/Sources/SwiftGen/Path+AppSupport.swift
@@ -26,12 +26,14 @@ extension Path {
 let templatesRelativePath: String = {
   if let path = Bundle.main.object(forInfoDictionaryKey: "TemplatePath") as? String, !path.isEmpty {
     return path
-  } else if let path = Bundle.main.path(forResource: "templates", ofType: nil) {
+  } else if let path = Bundle(for: BundleToken.self).path(forResource: "templates", ofType: nil) {
     return path
   } else {
     return "../templates"
   }
 }()
+
+private final class BundleToken {}
 
 let appSupportTemplatesPath = Path.applicationSupport + "SwiftGen/templates"
 let bundledTemplatesPath = Path(ProcessInfo.processInfo.arguments[0]).parent() + templatesRelativePath

--- a/SwiftGen.xcodeproj/project.pbxproj
+++ b/SwiftGen.xcodeproj/project.pbxproj
@@ -98,6 +98,8 @@
 		DDCCACDC209551240017FB43 /* Segue.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCCACD8209551230017FB43 /* Segue.swift */; };
 		DDCCACDD209551240017FB43 /* Scene.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCCACD9209551230017FB43 /* Scene.swift */; };
 		DDD2D709210F293E00D678E0 /* YAML.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDD2D708210F293E00D678E0 /* YAML.swift */; };
+		DDDD4C6A215D21A800FC5DE1 /* config-deprecated-commands.yml in Resources */ = {isa = PBXBuildFile; fileRef = DDDD4C68215D215600FC5DE1 /* config-deprecated-commands.yml */; };
+		DDDD4C6B215D447700FC5DE1 /* templates in Resources */ = {isa = PBXBuildFile; fileRef = DDC09D011E1D199A005C6EE6 /* templates */; };
 		DDDE51131FAF6AD4004203BE /* StringsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDE506D1FAF6AD4004203BE /* StringsTests.swift */; };
 		DDDE51141FAF6AD4004203BE /* FontsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDE506E1FAF6AD4004203BE /* FontsTests.swift */; };
 		DDDE51941FAF6AD4004203BE /* XCAssetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDDE50F51FAF6AD4004203BE /* XCAssetsTests.swift */; };
@@ -359,6 +361,7 @@
 		DDCCACD8209551230017FB43 /* Segue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Segue.swift; sourceTree = "<group>"; };
 		DDCCACD9209551230017FB43 /* Scene.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Scene.swift; sourceTree = "<group>"; };
 		DDD2D708210F293E00D678E0 /* YAML.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YAML.swift; sourceTree = "<group>"; };
+		DDDD4C68215D215600FC5DE1 /* config-deprecated-commands.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "config-deprecated-commands.yml"; sourceTree = "<group>"; };
 		DDDE504B1FAF687A004203BE /* Templates UnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Templates UnitTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DDDE506D1FAF6AD4004203BE /* StringsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringsTests.swift; sourceTree = "<group>"; };
 		DDDE506E1FAF6AD4004203BE /* FontsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FontsTests.swift; sourceTree = "<group>"; };
@@ -489,21 +492,22 @@
 		093405061F81537400187787 /* Configs */ = {
 			isa = PBXGroup;
 			children = (
+				37DC60301F98D1DA00B7B31C /* config-absolute-paths-direct.yml */,
+				37DC603A1F98E74600B7B31C /* config-absolute-paths-prefix.yml */,
+				37DC602D1F98D1D900B7B31C /* config-both-templates.yml */,
+				DDDD4C68215D215600FC5DE1 /* config-deprecated-commands.yml */,
 				DD40284E209FBF300045FC76 /* config-deprecated-mixed-with-new.yml */,
 				DD40284F209FBF300045FC76 /* config-deprecated-output.yml */,
 				DD40284D209FBF300045FC76 /* config-deprecated-paths.yml */,
-				093405071F81539100187787 /* config-with-params.yml */,
-				093405111F87AA6500187787 /* config-with-multi-entries.yml */,
-				DD402849209E56B50045FC76 /* config-with-multi-outputs.yml */,
-				37DC60301F98D1DA00B7B31C /* config-absolute-paths-direct.yml */,
-				37DC603A1F98E74600B7B31C /* config-absolute-paths-prefix.yml */,
-				37DC60311F98D1DA00B7B31C /* config-missing-paths.yml */,
-				37DC602B1F98D1D900B7B31C /* config-missing-template.yml */,
-				37DC602D1F98D1D900B7B31C /* config-both-templates.yml */,
-				37DC602C1F98D1D900B7B31C /* config-missing-output.yml */,
+				37DC602F1F98D1DA00B7B31C /* config-invalid-output.yml */,
 				37DC602A1F98D1D900B7B31C /* config-invalid-structure.yml */,
 				37DC602E1F98D1D900B7B31C /* config-invalid-template.yml */,
-				37DC602F1F98D1DA00B7B31C /* config-invalid-output.yml */,
+				37DC60311F98D1DA00B7B31C /* config-missing-paths.yml */,
+				37DC602B1F98D1D900B7B31C /* config-missing-template.yml */,
+				37DC602C1F98D1D900B7B31C /* config-missing-output.yml */,
+				093405111F87AA6500187787 /* config-with-multi-entries.yml */,
+				DD402849209E56B50045FC76 /* config-with-multi-outputs.yml */,
+				093405071F81539100187787 /* config-with-params.yml */,
 			);
 			name = Configs;
 			path = ../Fixtures/Configs;
@@ -983,6 +987,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DD402851209FBF300045FC76 /* config-deprecated-mixed-with-new.yml in Resources */,
+				DDDD4C6A215D21A800FC5DE1 /* config-deprecated-commands.yml in Resources */,
 				DD402852209FBF300045FC76 /* config-deprecated-output.yml in Resources */,
 				37DC60331F98D7DD00B7B31C /* config-both-templates.yml in Resources */,
 				37DC60381F98D7DD00B7B31C /* config-missing-paths.yml in Resources */,
@@ -997,6 +1002,7 @@
 				37DC60321F98D7DD00B7B31C /* config-absolute-paths-direct.yml in Resources */,
 				DD402850209FBF300045FC76 /* config-deprecated-paths.yml in Resources */,
 				37DC60371F98D7DD00B7B31C /* config-missing-output.yml in Resources */,
+				DDDD4C6B215D447700FC5DE1 /* templates in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1301,7 +1307,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [[ ! $CI && ! $NO_CODE_LINT ]]; then\n  \"$SRCROOT/Scripts/SwiftLint.sh\" \"templates_tests\"\nfi";
+			shellScript = "if [[ ! $CI && ! $NO_CODE_LINT ]]; then\n  \"$SRCROOT/Scripts/SwiftLint.sh\" \"templates_tests\"\nfi\n";
 		};
 		DD9F4769206ADCD4006B0DCA /* ⚠️ SwiftLint (generated output) */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1315,7 +1321,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [[ ! $CI && ! $NO_CODE_LINT ]]; then\n  \"$SRCROOT/Scripts/SwiftLint.sh\" \"templates_generated\"\nfi";
+			shellScript = "if [[ ! $CI && ! $NO_CODE_LINT ]]; then\n  \"$SRCROOT/Scripts/SwiftLint.sh\" \"templates_generated\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Tests/Fixtures/Configs/config-deprecated-commands.yml
+++ b/Tests/Fixtures/Configs/config-deprecated-commands.yml
@@ -1,0 +1,6 @@
+output_dir: Common/Generated
+storyboards:
+  paths: Sources2/Folder
+  outputs:
+    templateName: scenes-swift4
+    output: test-scenes.swift

--- a/Tests/Fixtures/Configs/config-with-multi-entries.yml
+++ b/Tests/Fixtures/Configs/config-with-multi-entries.yml
@@ -14,7 +14,7 @@ xcassets:
       output: assets-colors.swift
   - inputs: XCAssets/Images.xcassets
     outputs:
-      templateName: swift3
+      templateName: custom-swift3
       output: assets-images.swift
       params: { "enumName": "Pics" }
   - inputs:

--- a/Tests/SwiftGenTests/ConfigLintTests.swift
+++ b/Tests/SwiftGenTests/ConfigLintTests.swift
@@ -10,6 +10,7 @@ import XCTest
 class ConfigLintTests: XCTestCase {
   private func _testLint(fixture: String,
                          expectedLogs: [(LogLevel, String)],
+                         unwantedLevels: Set<LogLevel> = [],
                          assertionMessage: String,
                          file: StaticString = #file,
                          line: UInt = #line) {
@@ -22,6 +23,8 @@ class ConfigLintTests: XCTestCase {
       let logger = { (level: LogLevel, msg: String) -> Void in
         if let idx = missingLogs.index(where: { $0 == level && $1 == msg }) {
           missingLogs.remove(at: idx)
+        } else if unwantedLevels.contains(level) {
+          XCTFail("Unexpected log: \(msg)")
         }
       }
 
@@ -46,13 +49,22 @@ class ConfigLintTests: XCTestCase {
     )
   }
 
-  func testLint_AbsolutePathDirect() {
+  func testAbsolutePathDirect() {
     let commands = ["strings", "fonts", "ib", "colors", "xcassets"]
     let logs = commands.flatMap { (cmd: String) -> [(LogLevel, String)] in
       [
-        (.warning, "\(cmd).paths: /\(cmd)/paths is an absolute path."),
-        (.warning, "\(cmd).templatePath: /\(cmd)/templates.stencil is an absolute path."),
-        (.warning, "\(cmd).output: /\(cmd)/out.swift is an absolute path.")
+        (.warning, """
+          \(cmd).inputs: /\(cmd)/paths is an absolute path. Prefer relative paths for portability \
+          when sharing your project.
+          """),
+        (.warning, """
+          \(cmd).outputs.templatePath: /\(cmd)/templates.stencil is an absolute path. Prefer \
+          relative paths for portability when sharing your project.
+          """),
+        (.warning, """
+          \(cmd).outputs.output: /\(cmd)/out.swift is an absolute path. Prefer relative paths for \
+          portability when sharing your project.
+          """)
       ]
     }
 
@@ -63,13 +75,22 @@ class ConfigLintTests: XCTestCase {
     )
   }
 
-  func testLintAbsolutePathPrefix() {
+  func testAbsolutePathPrefix() {
     let commands = ["strings", "fonts", "ib", "colors", "xcassets"]
     let logs = commands.flatMap { (cmd: String) -> [(LogLevel, String)] in
       [
-        (.warning, "\(cmd).paths: /input/\(cmd)/paths is an absolute path."),
-        (.warning, "\(cmd).templatePath: /templates/\(cmd)/templates.stencil is an absolute path."),
-        (.warning, "\(cmd).output: /output/\(cmd)/out.swift is an absolute path.")
+        (.warning, """
+          \(cmd).inputs: /input/\(cmd)/paths is an absolute path. Prefer relative paths for \
+          portability when sharing your project.
+          """),
+        (.warning, """
+          \(cmd).outputs.templatePath: /templates/\(cmd)/templates.stencil is an absolute path. \
+          Prefer relative paths for portability when sharing your project.
+          """),
+        (.warning, """
+          \(cmd).outputs.output: /output/\(cmd)/out.swift is an absolute path. Prefer relative \
+          paths for portability when sharing your project.
+          """)
       ]
     }
 
@@ -80,7 +101,7 @@ class ConfigLintTests: XCTestCase {
     )
   }
 
-  func testLintMissingSources() {
+  func testMissingSources() {
     _testLint(
       fixture: "config-missing-paths",
       expectedLogs: [(.error, "Missing entry for key strings.inputs.")],
@@ -88,7 +109,7 @@ class ConfigLintTests: XCTestCase {
     )
   }
 
-  func testLintMissingTemplateNameAndPath() {
+  func testMissingTemplateNameAndPath() {
     let errorMsg = """
       You must specify a template by name (templateName) or path (templatePath).
 
@@ -101,7 +122,7 @@ class ConfigLintTests: XCTestCase {
     )
   }
 
-  func testLintBothTemplateNameAndPath() {
+  func testBothTemplateNameAndPath() {
     let errorMsg = """
       You need to choose EITHER a named template OR a template path. \
       Found name 'template' and path 'template.swift'
@@ -113,7 +134,7 @@ class ConfigLintTests: XCTestCase {
     )
   }
 
-  func testLintMissingOutput() {
+  func testMissingOutput() {
     _testLint(
       fixture: "config-missing-output",
       expectedLogs: [(.error, "Missing entry for key strings.outputs.output.")],
@@ -121,7 +142,7 @@ class ConfigLintTests: XCTestCase {
     )
   }
 
-  func testLintInvalidStructure() {
+  func testInvalidStructure() {
     _testLint(
       fixture: "config-invalid-structure",
       expectedLogs: [(.error, """
@@ -131,7 +152,7 @@ class ConfigLintTests: XCTestCase {
     )
   }
 
-  func testLintInvalidTemplateValue() {
+  func testInvalidTemplateValue() {
     _testLint(
       fixture: "config-invalid-template",
       expectedLogs: [(.error, "Wrong type for key strings.outputs.templateName: expected String, got Array<Any>.")],
@@ -139,7 +160,7 @@ class ConfigLintTests: XCTestCase {
     )
   }
 
-  func testLintInvalidOutput() {
+  func testInvalidOutput() {
     _testLint(
       fixture: "config-invalid-output",
       expectedLogs: [(.error, "Wrong type for key strings.outputs.output: expected String, got Array<Any>.")],
@@ -147,9 +168,58 @@ class ConfigLintTests: XCTestCase {
     )
   }
 
+  // MARK: - Path validation
+
+  func testInvalidPaths() {
+    _testLint(
+      fixture: "config-with-multi-entries",
+      expectedLogs: [
+        (.error, "input_dir: Input directory Fixtures/ does not exist"),
+        (.error, "output_dir: Output directory Generated/ does not exist"),
+        (.error, "strings.inputs: Fixtures/Strings/Localizable.strings does not exist"),
+        (.error, "strings.outputs: Template not found at path templates/custom-swift3."),
+        (.error, """
+          strings.outputs.output: Generated does not exist. Intermediate folders up to the output \
+          file must already exist to avoid misconfigurations, and won't be created for you.
+          """),
+        (.error, "xcassets.inputs: Fixtures/XCAssets/Colors.xcassets does not exist"),
+        (.error, "xcassets.inputs: Fixtures/XCAssets/Colors.xcassets does not exist"),
+        (.error, "xcassets.inputs: Fixtures/XCAssets/Images.xcassets does not exist"),
+        (.error, "xcassets.inputs: Fixtures/XCAssets/Images.xcassets does not exist"),
+        (.error, """
+          xcassets.outputs: Template named custom-swift3 not found. Use `swiftgen templates` to \
+          list available named templates or use `templatePath` to specify a template by its full \
+          path.
+          """),
+        (.error, """
+          xcassets.outputs.output: Generated does not exist. Intermediate folders up to the output \
+          file must already exist to avoid misconfigurations, and won't be created for you.
+          """),
+        (.error, """
+          xcassets.outputs.output: Generated does not exist. Intermediate folders up to the output \
+          file must already exist to avoid misconfigurations, and won't be created for you.
+          """),
+        (.error, """
+          xcassets.outputs.output: Generated does not exist. Intermediate folders up to the output \
+          file must already exist to avoid misconfigurations, and won't be created for you.
+          """)
+      ],
+      unwantedLevels: [.warning, .error],
+      assertionMessage: "Linter should show errors for invalid paths and templates"
+    )
+  }
+
   // MARK: - Deprecation warnings
 
-  func testLintDeprecatedPaths() {
+  func testDeprecatedCommands() {
+    _testLint(
+      fixture: "config-deprecated-commands",
+      expectedLogs: [(.warning, "`storyboards` action has been deprecated, please use `ib` instead.")],
+      assertionMessage: "Linter should warn about deprecated commands"
+    )
+  }
+
+  func testDeprecatedPaths() {
     _testLint(
       fixture: "config-deprecated-paths",
       expectedLogs: [(.warning, "strings: `paths` is a deprecated in favour of `inputs`.")],
@@ -157,7 +227,7 @@ class ConfigLintTests: XCTestCase {
     )
   }
 
-  func testLintDeprecatedOutput() {
+  func testDeprecatedOutput() {
     _testLint(
       fixture: "config-deprecated-output",
       expectedLogs: [
@@ -169,7 +239,7 @@ class ConfigLintTests: XCTestCase {
     )
   }
 
-  func testLintDeprecateMixedWithNew() {
+  func testDeprecateMixedWithNew() {
     _testLint(
       fixture: "config-deprecated-mixed-with-new",
       expectedLogs: [

--- a/Tests/SwiftGenTests/ConfigReadTests.swift
+++ b/Tests/SwiftGenTests/ConfigReadTests.swift
@@ -8,7 +8,7 @@ import PathKit
 import XCTest
 
 class ConfigReadTests: XCTestCase {
-  func testReadConfigWithParams() throws {
+  func testConfigWithParams() throws {
     guard let path = Bundle(for: type(of: self)).path(forResource: "config-with-params", ofType: "yml") else {
       fatalError("Fixture not found")
     }
@@ -44,7 +44,7 @@ class ConfigReadTests: XCTestCase {
     }
   }
 
-  func testReadConfigWithMultiEntries() throws {
+  func testConfigWithMultiEntries() throws {
     guard let path = Bundle(for: type(of: self)).path(forResource: "config-with-multi-entries", ofType: "yml") else {
       fatalError("Fixture not found")
     }
@@ -86,7 +86,7 @@ class ConfigReadTests: XCTestCase {
       XCTAssertEqual(xcassetsEntries[1].outputs.count, 1)
       XCTAssertEqual(xcassetsEntries[1].outputs[0].output, "assets-images.swift")
       XCTAssertEqualDict(xcassetsEntries[1].outputs[0].parameters, ["enumName": "Pics"])
-      XCTAssertEqual(xcassetsEntries[1].outputs[0].template, .name("swift3"))
+      XCTAssertEqual(xcassetsEntries[1].outputs[0].template, .name("custom-swift3"))
       // > xcassets[2]
       XCTAssertEqual(xcassetsEntries[2].inputs, ["XCAssets/Colors.xcassets", "XCAssets/Images.xcassets"])
       XCTAssertEqual(xcassetsEntries[2].outputs.count, 1)
@@ -98,7 +98,7 @@ class ConfigReadTests: XCTestCase {
     }
   }
 
-  func testReadConfigWithMultiOutputs() throws {
+  func testConfigWithMultiOutputs() throws {
     guard let path = Bundle(for: type(of: self)).path(forResource: "config-with-multi-outputs", ofType: "yml") else {
       fatalError("Fixture not found")
     }
@@ -134,7 +134,7 @@ class ConfigReadTests: XCTestCase {
 
   // MARK: - Invalid configs
 
-  func testReadInvalidConfigThrows() {
+  func testInvalidConfigThrows() {
     let badConfigs = [
       "config-missing-paths": "Missing entry for key strings.inputs.",
       "config-missing-template": """
@@ -178,7 +178,7 @@ class ConfigReadTests: XCTestCase {
 
   // MARK: - Deprecations
 
-  func testReadDeprecatedOutput() throws {
+  func testDeprecatedOutput() throws {
     guard let path = Bundle(for: type(of: self)).path(forResource: "config-deprecated-output", ofType: "yml") else {
       fatalError("Fixture not found")
     }
@@ -202,7 +202,7 @@ class ConfigReadTests: XCTestCase {
     }
   }
 
-  func testReadDeprecatedPaths() throws {
+  func testDeprecatedPaths() throws {
     guard let path = Bundle(for: type(of: self)).path(forResource: "config-deprecated-paths", ofType: "yml") else {
       fatalError("Fixture not found")
     }
@@ -220,7 +220,7 @@ class ConfigReadTests: XCTestCase {
     }
   }
 
-  func testReadDeprecatedUseNewerProperties() throws {
+  func testDeprecatedUseNewerProperties() throws {
     let bundle = Bundle(for: type(of: self))
     guard let path = bundle.path(forResource: "config-deprecated-mixed-with-new", ofType: "yml") else {
       fatalError("Fixture not found")


### PR DESCRIPTION
Check if:
- `input_dir` & `output_dir` exist
- command is deprecated
- command `inputs` item exists
- command `outputs.output` parent exists
- command `outputs` template can be resolved
