### PR TITLE
Strings: fix parser for key ending with `.`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ _None_
   [Olivier Halligon](https://github.com/AliSoftware)
   [#533](https://github.com/SwiftGen/SwiftGen/pull/533)
   [#516](https://github.com/SwiftGen/SwiftGen/issues/516)
+* Strings: Ensure the parser correctly handles keys ending with a `.`.  
+  [David Jennes](https://github.com/djbe)
+  [#531](https://github.com/SwiftGen/SwiftGen/pull/531)
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ _None_
   [Olivier Halligon](https://github.com/AliSoftware)
   [#533](https://github.com/SwiftGen/SwiftGen/pull/533)
   [#516](https://github.com/SwiftGen/SwiftGen/issues/516)
-* Strings: Ensure the parser correctly handles keys ending with a `.`.  
+* Strings: Ensure the parser correctly handles keys ending with a `.` and empty key components.  
   [David Jennes](https://github.com/djbe)
   [#531](https://github.com/SwiftGen/SwiftGen/pull/531)
 

--- a/Sources/SwiftGenKit/Parsers/Strings/StringsEntry.swift
+++ b/Sources/SwiftGenKit/Parsers/Strings/StringsEntry.swift
@@ -18,7 +18,7 @@ extension Strings {
       self.key = key
       self.translation = translation
       self.types = types
-      keyStructure = Entry.explode(key: key)
+      keyStructure = Entry.split(key: key)
     }
 
     init(key: String, translation: String, types: PlaceholderType...) {
@@ -34,7 +34,7 @@ extension Strings {
 
     private static let separatorSet = CharacterSet(charactersIn: ".")
 
-    private static func explode(key: String) -> [String] {
+    private static func split(key: String) -> [String] {
       return key
         .components(separatedBy: Entry.separatorSet)
         .filter { !$0.isEmpty }

--- a/Sources/SwiftGenKit/Parsers/Strings/StringsEntry.swift
+++ b/Sources/SwiftGenKit/Parsers/Strings/StringsEntry.swift
@@ -10,16 +10,15 @@ import PathKit
 extension Strings {
   struct Entry {
     let key: String
-    var keyStructure: [String] {
-        return key.components(separatedBy: CharacterSet(charactersIn: "."))
-    }
     let translation: String
     let types: [PlaceholderType]
+    let keyStructure: [String]
 
     init(key: String, translation: String, types: [PlaceholderType]) {
       self.key = key
       self.translation = translation
       self.types = types
+      keyStructure = Entry.explode(key: key)
     }
 
     init(key: String, translation: String, types: PlaceholderType...) {
@@ -29,6 +28,16 @@ extension Strings {
     init(key: String, translation: String) throws {
       let types = try PlaceholderType.placeholders(fromFormat: translation)
       self.init(key: key, translation: translation, types: types)
+    }
+
+    // MARK: - Structured keys
+
+    private static let separatorSet = CharacterSet(charactersIn: ".")
+
+    private static func explode(key: String) -> [String] {
+      return key
+        .components(separatedBy: Entry.separatorSet)
+        .filter { !$0.isEmpty }
     }
   }
 }

--- a/Sources/SwiftGenKit/Stencil/StringsContext.swift
+++ b/Sources/SwiftGenKit/Stencil/StringsContext.swift
@@ -68,7 +68,11 @@ extension Strings.Parser {
     usingMapper mapper: @escaping Mapper) -> [String: Any] {
 
     var structuredStrings: [String: Any] = [:]
+    if let name = keyPath.last {
+      structuredStrings["name"] = name
+    }
 
+    // collect strings for this level
     let strings = entries
       .filter { $0.keyStructure.count == keyPath.count + 1 }
       .sorted { $0.key.lowercased() < $1.key.lowercased() }
@@ -78,32 +82,13 @@ extension Strings.Parser {
       structuredStrings["strings"] = strings
     }
 
-    if let lastKeyPathComponent = keyPath.last {
-      structuredStrings["name"] = lastKeyPathComponent
-    }
-
-    var children: [[String: Any]] = []
-    let nextLevelKeyPaths: [[String]] = entries
-      .filter { $0.keyStructure.count > keyPath.count + 1 }
-      .map { Array($0.keyStructure.prefix(keyPath.count + 1)) }
-
-    let sortedNextLevelKeyPaths = Array(Set(
-      nextLevelKeyPaths.map { keyPath in
-        keyPath.joined(separator: Strings.Entry.separator)
-      }))
-      .sorted()
-      .map { $0.components(separatedBy: Strings.Entry.separator) }
-
-    for nextLevelKeyPath in sortedNextLevelKeyPaths {
-      let entriesInKeyPath = entries.filter {
-        Array($0.keyStructure.prefix(nextLevelKeyPath.count)) == nextLevelKeyPath
+    // collect children for this level
+    let childEntries = entries.filter { $0.keyStructure.count > keyPath.count + 1 }
+    let children = Dictionary(grouping: childEntries) { $0.keyStructure[keyPath.count] }
+      .sorted { $0.key < $1.key }
+      .map { name, entries in
+        structure(entries: entries, atKeyPath: keyPath + [name], usingMapper: mapper)
       }
-      children.append(
-          structure(entries: entriesInKeyPath,
-                    atKeyPath: nextLevelKeyPath,
-                    usingMapper: mapper)
-      )
-    }
 
     if !children.isEmpty {
       structuredStrings["children"] = children

--- a/Sources/SwiftGenKit/Stencil/StringsContext.swift
+++ b/Sources/SwiftGenKit/Stencil/StringsContext.swift
@@ -82,7 +82,8 @@ extension Strings.Parser {
       structuredStrings["strings"] = strings
     }
 
-    // collect children for this level
+    // collect children for this level, group them by name for the next level, sort them
+    // and then structure those grouped entries
     let childEntries = entries.filter { $0.keyStructure.count > keyPath.count + 1 }
     let children = Dictionary(grouping: childEntries) { $0.keyStructure[keyPath.count] }
       .sorted { $0.key < $1.key }

--- a/Sources/SwiftGenKit/Stencil/StringsContext.swift
+++ b/Sources/SwiftGenKit/Stencil/StringsContext.swift
@@ -31,10 +31,8 @@ private extension String {
 extension Strings.Parser {
   public func stencilContext() -> [String: Any] {
     let entryToStringMapper = { (entry: Strings.Entry, keyPath: [String]) -> [String: Any] in
-      let levelName = entry.keyStructure.last ?? ""
-
       var result: [String: Any] = [
-        "name": levelName,
+        "name": entry.keyStructure.last ?? "",
         "key": entry.key.newlineEscaped,
         "translation": entry.translation.newlineEscaped
       ]
@@ -91,10 +89,10 @@ extension Strings.Parser {
 
     let sortedNextLevelKeyPaths = Array(Set(
       nextLevelKeyPaths.map { keyPath in
-        keyPath.joined(separator: ".")
+        keyPath.joined(separator: Strings.Entry.separator)
       }))
       .sorted()
-      .map { $0.components(separatedBy: ".") }
+      .map { $0.components(separatedBy: Strings.Entry.separator) }
 
     for nextLevelKeyPath in sortedNextLevelKeyPaths {
       let entriesInKeyPath = entries.filter {

--- a/Tests/Fixtures/Generated/Strings/flat-swift3-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift3-context-multiple.swift
@@ -53,6 +53,10 @@ internal enum L10n {
     internal static let singleline = L10n.tr("LocMultiline", "SINGLELINE")
     /// another single line
     internal static let singleline2 = L10n.tr("LocMultiline", "SINGLELINE2")
+    /// Ceci n'est pas une pipe.
+    internal static let endingWith = L10n.tr("LocMultiline", "ending.with.")
+    /// Veni, vidi, vici
+    internal static let someDotsAndEmptyComponents = L10n.tr("LocMultiline", "..some..dots.and..empty..components..")
   }
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length

--- a/Tests/Fixtures/Generated/Strings/flat-swift4-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Strings/flat-swift4-context-multiple.swift
@@ -53,6 +53,10 @@ internal enum L10n {
     internal static let singleline = L10n.tr("LocMultiline", "SINGLELINE")
     /// another single line
     internal static let singleline2 = L10n.tr("LocMultiline", "SINGLELINE2")
+    /// Ceci n'est pas une pipe.
+    internal static let endingWith = L10n.tr("LocMultiline", "ending.with.")
+    /// Veni, vidi, vici
+    internal static let someDotsAndEmptyComponents = L10n.tr("LocMultiline", "..some..dots.and..empty..components..")
   }
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length

--- a/Tests/Fixtures/Generated/Strings/structured-swift3-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift3-context-multiple.swift
@@ -86,6 +86,20 @@ internal enum L10n {
     internal static let singleline = L10n.tr("LocMultiline", "SINGLELINE")
     /// another single line
     internal static let singleline2 = L10n.tr("LocMultiline", "SINGLELINE2")
+    internal enum Ending {
+      /// Ceci n'est pas une pipe.
+      internal static let with = L10n.tr("LocMultiline", "ending.with.")
+    }
+    internal enum Some {
+      internal enum Dots {
+        internal enum And {
+          internal enum Empty {
+            /// Veni, vidi, vici
+            internal static let components = L10n.tr("LocMultiline", "..some..dots.and..empty..components..")
+          }
+        }
+      }
+    }
   }
 }
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length

--- a/Tests/Fixtures/Generated/Strings/structured-swift4-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Strings/structured-swift4-context-multiple.swift
@@ -86,6 +86,20 @@ internal enum L10n {
     internal static let singleline = L10n.tr("LocMultiline", "SINGLELINE")
     /// another single line
     internal static let singleline2 = L10n.tr("LocMultiline", "SINGLELINE2")
+    internal enum Ending {
+      /// Ceci n'est pas une pipe.
+      internal static let with = L10n.tr("LocMultiline", "ending.with.")
+    }
+    internal enum Some {
+      internal enum Dots {
+        internal enum And {
+          internal enum Empty {
+            /// Veni, vidi, vici
+            internal static let components = L10n.tr("LocMultiline", "..some..dots.and..empty..components..")
+          }
+        }
+      }
+    }
   }
 }
 // swiftlint:enable explicit_type_interface function_parameter_count identifier_name line_length

--- a/Tests/Fixtures/Resources/Strings/LocMultiline.strings
+++ b/Tests/Fixtures/Resources/Strings/LocMultiline.strings
@@ -7,3 +7,6 @@ multi\
 "SINGLELINE2"     = "another single line";
 "multiLine\
 Key" = "test";
+
+"ending.with." = "Ceci n'est pas une pipe.";
+"..some..dots.and..empty..components.." = "Veni, vidi, vici";

--- a/Tests/Fixtures/StencilContexts/Strings/multiline.yaml
+++ b/Tests/Fixtures/StencilContexts/Strings/multiline.yaml
@@ -1,5 +1,22 @@
 tables:
 - levels:
+    children:
+    - name: "ending"
+      strings:
+      - key: "ending.with."
+        name: "with"
+        translation: "Ceci n'est pas une pipe."
+    - children:
+      - children:
+        - children:
+          - name: "empty"
+            strings:
+            - key: "..some..dots.and..empty..components.."
+              name: "components"
+              translation: "Veni, vidi, vici"
+          name: "and"
+        name: "dots"
+      name: "some"
     strings:
     - key: "MULTILINE"
       name: "MULTILINE"

--- a/Tests/Fixtures/StencilContexts/Strings/multiple.yaml
+++ b/Tests/Fixtures/StencilContexts/Strings/multiple.yaml
@@ -82,6 +82,23 @@ tables:
       - "Int"
   name: "Localizable"
 - levels:
+    children:
+    - name: "ending"
+      strings:
+      - key: "ending.with."
+        name: "with"
+        translation: "Ceci n'est pas une pipe."
+    - children:
+      - children:
+        - children:
+          - name: "empty"
+            strings:
+            - key: "..some..dots.and..empty..components.."
+              name: "components"
+              translation: "Veni, vidi, vici"
+          name: "and"
+        name: "dots"
+      name: "some"
     strings:
     - key: "MULTILINE"
       name: "MULTILINE"


### PR DESCRIPTION
Fixes #528.

This ensures that keys ending with a `.` don't produce a last, empty level name. It adds the `.` to the previous level. For example:
- key: `"hello.world."` --> level name: `"world."` --> swift identifier: `world`
- key: `"hello.world..."` --> level name: `"world..."` --> swift identifier: `world`

Our `swiftIdentifier:"pretty"` filter ends up stripping the `_` characters at the end, but if a user uses a custom template with `swiftIdentifier:"normal"`, they'd end up with `world_` and `world___`.

Note that https://github.com/SwiftGen/StencilSwiftKit/pull/105 fixes a crash in the filter itself when transforming empty strings.