### PR TITLE
Colors: fix `publicAccess` modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-* Colors: Fix an issue where the `public` access modifier was not being added correctly in the `literals` templates when the `publicAccess` parameter was specified.  
+* Colors: Fix an issue where the `public` access modifier was not being added correctly in the `literals-swift3` and `literals-swift4` templates when the `publicAccess` parameter was specified. Also remove some uneccessary `public` access modifiers from the `swift3` and `swift4` templates.  
   [Isaac Halvorson](https://github.com/hisaac)
   [#549](https://github.com/SwiftGen/SwiftGen/pull/549)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ _None_
 
 ### Bug Fixes
 
-_None_
+* Colors: Fix an issue where the `public` access modifier was not being added correctly in the `literals` templates when the `publicAccess` parameter was specified.  
+  [Isaac Halvorson](https://github.com/hisaac)
+  [#546](https://github.com/SwiftGen/SwiftGen/pull/546)
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ _None_
 
 * Colors: Fix an issue where the `public` access modifier was not being added correctly in the `literals` templates when the `publicAccess` parameter was specified.  
   [Isaac Halvorson](https://github.com/hisaac)
-  [#546](https://github.com/SwiftGen/SwiftGen/pull/546)
+  [#549](https://github.com/SwiftGen/SwiftGen/pull/549)
 
 ### Internal Changes
 

--- a/Tests/Fixtures/Generated/Colors/literals-swift3-context-defaults-customname.swift
+++ b/Tests/Fixtures/Generated/Colors/literals-swift3-context-defaults-customname.swift
@@ -16,12 +16,12 @@
 // swiftlint:disable identifier_name line_length type_body_length
 internal extension UIColor {
   /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)
-  static let articleBody = #colorLiteral(red: 0.2, green: 0.5882353, blue: 0.4, alpha: 1.0)
+  internal static let articleBody = #colorLiteral(red: 0.2, green: 0.5882353, blue: 0.4, alpha: 1.0)
   /// 0xff66ccff (r: 255, g: 102, b: 204, a: 255)
-  static let articleFootnote = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
+  internal static let articleFootnote = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
   /// 0x33fe66ff (r: 51, g: 254, b: 102, a: 255)
-  static let articleTitle = #colorLiteral(red: 0.2, green: 0.99607843, blue: 0.4, alpha: 1.0)
+  internal static let articleTitle = #colorLiteral(red: 0.2, green: 0.99607843, blue: 0.4, alpha: 1.0)
   /// 0xffffffcc (r: 255, g: 255, b: 255, a: 204)
-  static let `private` = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
+  internal static let `private` = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
 }
 // swiftlint:enable identifier_name line_length type_body_length

--- a/Tests/Fixtures/Generated/Colors/literals-swift3-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Colors/literals-swift3-context-defaults-publicAccess.swift
@@ -17,12 +17,12 @@
 // swiftlint:disable identifier_name line_length type_body_length
 public extension ColorName {
   /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)
-  static let articleBody = #colorLiteral(red: 0.2, green: 0.5882353, blue: 0.4, alpha: 1.0)
+  public static let articleBody = #colorLiteral(red: 0.2, green: 0.5882353, blue: 0.4, alpha: 1.0)
   /// 0xff66ccff (r: 255, g: 102, b: 204, a: 255)
-  static let articleFootnote = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
+  public static let articleFootnote = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
   /// 0x33fe66ff (r: 51, g: 254, b: 102, a: 255)
-  static let articleTitle = #colorLiteral(red: 0.2, green: 0.99607843, blue: 0.4, alpha: 1.0)
+  public static let articleTitle = #colorLiteral(red: 0.2, green: 0.99607843, blue: 0.4, alpha: 1.0)
   /// 0xffffffcc (r: 255, g: 255, b: 255, a: 204)
-  static let `private` = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
+  public static let `private` = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
 }
 // swiftlint:enable identifier_name line_length type_body_length

--- a/Tests/Fixtures/Generated/Colors/literals-swift3-context-defaults.swift
+++ b/Tests/Fixtures/Generated/Colors/literals-swift3-context-defaults.swift
@@ -17,12 +17,12 @@
 // swiftlint:disable identifier_name line_length type_body_length
 internal extension ColorName {
   /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)
-  static let articleBody = #colorLiteral(red: 0.2, green: 0.5882353, blue: 0.4, alpha: 1.0)
+  internal static let articleBody = #colorLiteral(red: 0.2, green: 0.5882353, blue: 0.4, alpha: 1.0)
   /// 0xff66ccff (r: 255, g: 102, b: 204, a: 255)
-  static let articleFootnote = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
+  internal static let articleFootnote = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
   /// 0x33fe66ff (r: 51, g: 254, b: 102, a: 255)
-  static let articleTitle = #colorLiteral(red: 0.2, green: 0.99607843, blue: 0.4, alpha: 1.0)
+  internal static let articleTitle = #colorLiteral(red: 0.2, green: 0.99607843, blue: 0.4, alpha: 1.0)
   /// 0xffffffcc (r: 255, g: 255, b: 255, a: 204)
-  static let `private` = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
+  internal static let `private` = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
 }
 // swiftlint:enable identifier_name line_length type_body_length

--- a/Tests/Fixtures/Generated/Colors/literals-swift3-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Colors/literals-swift3-context-multiple.swift
@@ -16,31 +16,31 @@
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal extension ColorName {
-  enum Colors {
+  internal enum Colors {
     /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)
-    static let articleBody = #colorLiteral(red: 0.2, green: 0.5882353, blue: 0.4, alpha: 1.0)
+    internal static let articleBody = #colorLiteral(red: 0.2, green: 0.5882353, blue: 0.4, alpha: 1.0)
     /// 0xff66ccff (r: 255, g: 102, b: 204, a: 255)
-    static let articleFootnote = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
+    internal static let articleFootnote = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
     /// 0x33fe66ff (r: 51, g: 254, b: 102, a: 255)
-    static let articleTitle = #colorLiteral(red: 0.2, green: 0.99607843, blue: 0.4, alpha: 1.0)
+    internal static let articleTitle = #colorLiteral(red: 0.2, green: 0.99607843, blue: 0.4, alpha: 1.0)
     /// 0xffffffcc (r: 255, g: 255, b: 255, a: 204)
-    static let `private` = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
+    internal static let `private` = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
   }
-  enum Extra {
+  internal enum Extra {
     /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)
-    static let articleBody = #colorLiteral(red: 0.2, green: 0.5882353, blue: 0.4, alpha: 1.0)
+    internal static let articleBody = #colorLiteral(red: 0.2, green: 0.5882353, blue: 0.4, alpha: 1.0)
     /// 0xff66ccff (r: 255, g: 102, b: 204, a: 255)
-    static let articleFootnote = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
+    internal static let articleFootnote = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
     /// 0x33fe66ff (r: 51, g: 254, b: 102, a: 255)
-    static let articleTitle = #colorLiteral(red: 0.2, green: 0.99607843, blue: 0.4, alpha: 1.0)
+    internal static let articleTitle = #colorLiteral(red: 0.2, green: 0.99607843, blue: 0.4, alpha: 1.0)
     /// 0xff66ccff (r: 255, g: 102, b: 204, a: 255)
-    static let cyanColor = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
+    internal static let cyanColor = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
     /// 0xffffffcc (r: 255, g: 255, b: 255, a: 204)
-    static let namedValue = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
+    internal static let namedValue = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
     /// 0xffffffcc (r: 255, g: 255, b: 255, a: 204)
-    static let nestedNamedValue = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
+    internal static let nestedNamedValue = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
     /// 0xffffffcc (r: 255, g: 255, b: 255, a: 204)
-    static let `private` = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
+    internal static let `private` = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length

--- a/Tests/Fixtures/Generated/Colors/literals-swift4-context-defaults-customname.swift
+++ b/Tests/Fixtures/Generated/Colors/literals-swift4-context-defaults-customname.swift
@@ -16,12 +16,12 @@
 // swiftlint:disable identifier_name line_length type_body_length
 internal extension UIColor {
   /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)
-  static let articleBody = #colorLiteral(red: 0.2, green: 0.5882353, blue: 0.4, alpha: 1.0)
+  internal static let articleBody = #colorLiteral(red: 0.2, green: 0.5882353, blue: 0.4, alpha: 1.0)
   /// 0xff66ccff (r: 255, g: 102, b: 204, a: 255)
-  static let articleFootnote = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
+  internal static let articleFootnote = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
   /// 0x33fe66ff (r: 51, g: 254, b: 102, a: 255)
-  static let articleTitle = #colorLiteral(red: 0.2, green: 0.99607843, blue: 0.4, alpha: 1.0)
+  internal static let articleTitle = #colorLiteral(red: 0.2, green: 0.99607843, blue: 0.4, alpha: 1.0)
   /// 0xffffffcc (r: 255, g: 255, b: 255, a: 204)
-  static let `private` = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
+  internal static let `private` = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
 }
 // swiftlint:enable identifier_name line_length type_body_length

--- a/Tests/Fixtures/Generated/Colors/literals-swift4-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Colors/literals-swift4-context-defaults-publicAccess.swift
@@ -17,12 +17,12 @@
 // swiftlint:disable identifier_name line_length type_body_length
 public extension ColorName {
   /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)
-  static let articleBody = #colorLiteral(red: 0.2, green: 0.5882353, blue: 0.4, alpha: 1.0)
+  public static let articleBody = #colorLiteral(red: 0.2, green: 0.5882353, blue: 0.4, alpha: 1.0)
   /// 0xff66ccff (r: 255, g: 102, b: 204, a: 255)
-  static let articleFootnote = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
+  public static let articleFootnote = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
   /// 0x33fe66ff (r: 51, g: 254, b: 102, a: 255)
-  static let articleTitle = #colorLiteral(red: 0.2, green: 0.99607843, blue: 0.4, alpha: 1.0)
+  public static let articleTitle = #colorLiteral(red: 0.2, green: 0.99607843, blue: 0.4, alpha: 1.0)
   /// 0xffffffcc (r: 255, g: 255, b: 255, a: 204)
-  static let `private` = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
+  public static let `private` = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
 }
 // swiftlint:enable identifier_name line_length type_body_length

--- a/Tests/Fixtures/Generated/Colors/literals-swift4-context-defaults.swift
+++ b/Tests/Fixtures/Generated/Colors/literals-swift4-context-defaults.swift
@@ -17,12 +17,12 @@
 // swiftlint:disable identifier_name line_length type_body_length
 internal extension ColorName {
   /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)
-  static let articleBody = #colorLiteral(red: 0.2, green: 0.5882353, blue: 0.4, alpha: 1.0)
+  internal static let articleBody = #colorLiteral(red: 0.2, green: 0.5882353, blue: 0.4, alpha: 1.0)
   /// 0xff66ccff (r: 255, g: 102, b: 204, a: 255)
-  static let articleFootnote = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
+  internal static let articleFootnote = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
   /// 0x33fe66ff (r: 51, g: 254, b: 102, a: 255)
-  static let articleTitle = #colorLiteral(red: 0.2, green: 0.99607843, blue: 0.4, alpha: 1.0)
+  internal static let articleTitle = #colorLiteral(red: 0.2, green: 0.99607843, blue: 0.4, alpha: 1.0)
   /// 0xffffffcc (r: 255, g: 255, b: 255, a: 204)
-  static let `private` = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
+  internal static let `private` = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
 }
 // swiftlint:enable identifier_name line_length type_body_length

--- a/Tests/Fixtures/Generated/Colors/literals-swift4-context-multiple.swift
+++ b/Tests/Fixtures/Generated/Colors/literals-swift4-context-multiple.swift
@@ -16,31 +16,31 @@
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal extension ColorName {
-  enum Colors {
+  internal enum Colors {
     /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)
-    static let articleBody = #colorLiteral(red: 0.2, green: 0.5882353, blue: 0.4, alpha: 1.0)
+    internal static let articleBody = #colorLiteral(red: 0.2, green: 0.5882353, blue: 0.4, alpha: 1.0)
     /// 0xff66ccff (r: 255, g: 102, b: 204, a: 255)
-    static let articleFootnote = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
+    internal static let articleFootnote = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
     /// 0x33fe66ff (r: 51, g: 254, b: 102, a: 255)
-    static let articleTitle = #colorLiteral(red: 0.2, green: 0.99607843, blue: 0.4, alpha: 1.0)
+    internal static let articleTitle = #colorLiteral(red: 0.2, green: 0.99607843, blue: 0.4, alpha: 1.0)
     /// 0xffffffcc (r: 255, g: 255, b: 255, a: 204)
-    static let `private` = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
+    internal static let `private` = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
   }
-  enum Extra {
+  internal enum Extra {
     /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)
-    static let articleBody = #colorLiteral(red: 0.2, green: 0.5882353, blue: 0.4, alpha: 1.0)
+    internal static let articleBody = #colorLiteral(red: 0.2, green: 0.5882353, blue: 0.4, alpha: 1.0)
     /// 0xff66ccff (r: 255, g: 102, b: 204, a: 255)
-    static let articleFootnote = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
+    internal static let articleFootnote = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
     /// 0x33fe66ff (r: 51, g: 254, b: 102, a: 255)
-    static let articleTitle = #colorLiteral(red: 0.2, green: 0.99607843, blue: 0.4, alpha: 1.0)
+    internal static let articleTitle = #colorLiteral(red: 0.2, green: 0.99607843, blue: 0.4, alpha: 1.0)
     /// 0xff66ccff (r: 255, g: 102, b: 204, a: 255)
-    static let cyanColor = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
+    internal static let cyanColor = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
     /// 0xffffffcc (r: 255, g: 255, b: 255, a: 204)
-    static let namedValue = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
+    internal static let namedValue = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
     /// 0xffffffcc (r: 255, g: 255, b: 255, a: 204)
-    static let nestedNamedValue = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
+    internal static let nestedNamedValue = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
     /// 0xffffffcc (r: 255, g: 255, b: 255, a: 204)
-    static let `private` = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
+    internal static let `private` = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length

--- a/Tests/Fixtures/Generated/Colors/swift3-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Colors/swift3-context-defaults-publicAccess.swift
@@ -49,7 +49,7 @@ internal extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-public extension Color {
+internal extension Color {
   convenience init(named color: ColorName) {
     self.init(rgbaValue: color.rgbaValue)
   }

--- a/Tests/Fixtures/Generated/Colors/swift3-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Colors/swift3-context-defaults-publicAccess.swift
@@ -37,7 +37,7 @@ public struct ColorName {
 // MARK: - Implementation Details
 
 // swiftlint:disable operator_usage_whitespace
-public extension Color {
+internal extension Color {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
     let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
@@ -49,7 +49,7 @@ public extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-public extension Color {
+internal extension Color {
   convenience init(named color: ColorName) {
     self.init(rgbaValue: color.rgbaValue)
   }

--- a/Tests/Fixtures/Generated/Colors/swift3-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Colors/swift3-context-defaults-publicAccess.swift
@@ -49,7 +49,7 @@ internal extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-internal extension Color {
+public extension Color {
   convenience init(named color: ColorName) {
     self.init(rgbaValue: color.rgbaValue)
   }

--- a/Tests/Fixtures/Generated/Colors/swift4-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Colors/swift4-context-defaults-publicAccess.swift
@@ -49,7 +49,7 @@ internal extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-public extension Color {
+internal extension Color {
   convenience init(named color: ColorName) {
     self.init(rgbaValue: color.rgbaValue)
   }

--- a/Tests/Fixtures/Generated/Colors/swift4-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Colors/swift4-context-defaults-publicAccess.swift
@@ -37,7 +37,7 @@ public struct ColorName {
 // MARK: - Implementation Details
 
 // swiftlint:disable operator_usage_whitespace
-public extension Color {
+internal extension Color {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
     let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
@@ -49,7 +49,7 @@ public extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-public extension Color {
+internal extension Color {
   convenience init(named color: ColorName) {
     self.init(rgbaValue: color.rgbaValue)
   }

--- a/Tests/Fixtures/Generated/Colors/swift4-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Colors/swift4-context-defaults-publicAccess.swift
@@ -49,7 +49,7 @@ internal extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-internal extension Color {
+public extension Color {
   convenience init(named color: ColorName) {
     self.init(rgbaValue: color.rgbaValue)
   }

--- a/templates/colors/literals-swift3.stencil
+++ b/templates/colors/literals-swift3.stencil
@@ -23,12 +23,12 @@
 {% macro enumBlock colors %}
   {% for color in colors %}
   /// 0x{{color.red}}{{color.green}}{{color.blue}}{{color.alpha}} (r: {{color.red|hexToInt}}, g: {{color.green|hexToInt}}, b: {{color.blue|hexToInt}}, a: {{color.alpha|hexToInt}})
-  static let {{color.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = #colorLiteral(red: {% call h2f color.red %}, green: {% call h2f color.green %}, blue: {% call h2f color.blue %}, alpha: {% call h2f color.alpha %})
+  {{accessModifier}} static let {{color.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = #colorLiteral(red: {% call h2f color.red %}, green: {% call h2f color.green %}, blue: {% call h2f color.blue %}, alpha: {% call h2f color.alpha %})
   {% endfor %}
 {% endmacro %}
   {% if palettes.count > 1 %}
   {% for palette in palettes %}
-  enum {{palette.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+  {{accessModifier}} enum {{palette.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
     {% filter indent:2 %}{% call enumBlock palette.colors %}{% endfilter %}
   }
   {% endfor %}

--- a/templates/colors/literals-swift4.stencil
+++ b/templates/colors/literals-swift4.stencil
@@ -23,12 +23,12 @@
 {% macro enumBlock colors %}
   {% for color in colors %}
   /// 0x{{color.red}}{{color.green}}{{color.blue}}{{color.alpha}} (r: {{color.red|hexToInt}}, g: {{color.green|hexToInt}}, b: {{color.blue|hexToInt}}, a: {{color.alpha|hexToInt}})
-  static let {{color.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = #colorLiteral(red: {% call h2f color.red %}, green: {% call h2f color.green %}, blue: {% call h2f color.blue %}, alpha: {% call h2f color.alpha %})
+  {{accessModifier}} static let {{color.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = #colorLiteral(red: {% call h2f color.red %}, green: {% call h2f color.green %}, blue: {% call h2f color.blue %}, alpha: {% call h2f color.alpha %})
   {% endfor %}
 {% endmacro %}
   {% if palettes.count > 1 %}
   {% for palette in palettes %}
-  enum {{palette.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+  {{accessModifier}} enum {{palette.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
     {% filter indent:2 %}{% call enumBlock palette.colors %}{% endfilter %}
   }
   {% endfor %}

--- a/templates/colors/swift3.stencil
+++ b/templates/colors/swift3.stencil
@@ -58,7 +58,7 @@ internal extension {{colorAlias}} {
 }
 // swiftlint:enable operator_usage_whitespace
 
-{{accessModifier}} extension {{colorAlias}} {
+internal extension {{colorAlias}} {
   convenience init(named color: {{enumName}}) {
     self.init(rgbaValue: color.rgbaValue)
   }

--- a/templates/colors/swift3.stencil
+++ b/templates/colors/swift3.stencil
@@ -58,7 +58,7 @@ internal extension {{colorAlias}} {
 }
 // swiftlint:enable operator_usage_whitespace
 
-internal extension {{colorAlias}} {
+{{accessModifier}} extension {{colorAlias}} {
   convenience init(named color: {{enumName}}) {
     self.init(rgbaValue: color.rgbaValue)
   }

--- a/templates/colors/swift3.stencil
+++ b/templates/colors/swift3.stencil
@@ -46,7 +46,7 @@
 // MARK: - Implementation Details
 
 // swiftlint:disable operator_usage_whitespace
-{{accessModifier}} extension {{colorAlias}} {
+internal extension {{colorAlias}} {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
     let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
@@ -58,7 +58,7 @@
 }
 // swiftlint:enable operator_usage_whitespace
 
-{{accessModifier}} extension {{colorAlias}} {
+internal extension {{colorAlias}} {
   convenience init(named color: {{enumName}}) {
     self.init(rgbaValue: color.rgbaValue)
   }

--- a/templates/colors/swift4.stencil
+++ b/templates/colors/swift4.stencil
@@ -58,7 +58,7 @@ internal extension {{colorAlias}} {
 }
 // swiftlint:enable operator_usage_whitespace
 
-{{accessModifier}} extension {{colorAlias}} {
+internal extension {{colorAlias}} {
   convenience init(named color: {{enumName}}) {
     self.init(rgbaValue: color.rgbaValue)
   }

--- a/templates/colors/swift4.stencil
+++ b/templates/colors/swift4.stencil
@@ -58,7 +58,7 @@ internal extension {{colorAlias}} {
 }
 // swiftlint:enable operator_usage_whitespace
 
-internal extension {{colorAlias}} {
+{{accessModifier}} extension {{colorAlias}} {
   convenience init(named color: {{enumName}}) {
     self.init(rgbaValue: color.rgbaValue)
   }

--- a/templates/colors/swift4.stencil
+++ b/templates/colors/swift4.stencil
@@ -46,7 +46,7 @@
 // MARK: - Implementation Details
 
 // swiftlint:disable operator_usage_whitespace
-{{accessModifier}} extension {{colorAlias}} {
+internal extension {{colorAlias}} {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
     let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
@@ -58,7 +58,7 @@
 }
 // swiftlint:enable operator_usage_whitespace
 
-{{accessModifier}} extension {{colorAlias}} {
+internal extension {{colorAlias}} {
   convenience init(named color: {{enumName}}) {
     self.init(rgbaValue: color.rgbaValue)
   }


### PR DESCRIPTION
* [x] I've started my branch from the `develop` branch (gitflow)
* [x] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself  
      _(or added `#trivial` to the PR title if I think it doesn't warrant a mention in the CHANGELOG)_
  * [x] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
  * [x] Add a period and 2 spaces at the end of your short entry description
  * [x] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

Fixes #548.

This PR fixes two issues:

1. The `public` access modifier was not being added correctly when using `publicAccess: true` on the `literals-swift3` and `literals-swift4` templates.
2. Removed superfluous access modifiers from the `swift3` and `swift4` templates (based off of a comment from @djbe here: https://github.com/SwiftGen/SwiftGen/issues/548#issuecomment-427953553).

This includes updates to the stencil template files to correct the issues, and updates to the test data to match the changes.

All tests are currently passing.