### PR TITLE
Fix README typo #trivial

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ let bar = PlistFiles.Stuff.key1
 ## Strings
 
 ```yaml
-fonts:
+strings:
   inputs: /path/to/Localizable.strings
   outputs:
     templateName: structured-swift4


### PR DESCRIPTION
* [x] I've started my branch from the `develop` branch (gitflow)
* [x] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself  
      _(or added `#trivial` to the PR title if I think it doesn't warrant a mention in the CHANGELOG)_
  * [x] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
  * [x] Add a period and 2 spaces at the end of your short entry description
  * [x] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

### Fix README typo

I found a typo in `README.md`

- LINE 601: fonts -> strings
- Before
```yaml
fonts:
  inputs: /path/to/Localizable.strings
  ...
```
- After 
```yaml
strings:
  inputs: /path/to/Localizable.strings
  ...
```