### PR TITLE
Symbolic link workaround

### DIFF
--- a/Sources/SwiftGen/Path+AppSupport.swift
+++ b/Sources/SwiftGen/Path+AppSupport.swift
@@ -36,4 +36,15 @@ let templatesRelativePath: String = {
 private final class BundleToken {}
 
 let appSupportTemplatesPath = Path.applicationSupport + "SwiftGen/templates"
-let bundledTemplatesPath = Path(ProcessInfo.processInfo.arguments[0]).parent() + templatesRelativePath
+let binaryPath: Path = {
+  var binaryPath = Path(ProcessInfo.processInfo.arguments[0])
+  do {
+    while binaryPath.isSymlink {
+      binaryPath = try binaryPath.symlinkDestination()
+    }
+  } catch {
+    print("Warning: could not resolve symlink of \(binaryPath) with error \(error)")
+  }
+  return binaryPath
+}()
+let bundledTemplatesPath = binaryPath.parent() + templatesRelativePath


### PR DESCRIPTION
* [x] I've started my branch from the `develop` branch (gitflow)
* [ ] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself  
      _(or added `#trivial` to the PR title if I think it doesn't warrant a mention in the CHANGELOG)_
  * [ ] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
  * [ ] Add a period and 2 spaces at the end of your short entry description
  * [ ] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

Seems like there is an issue if we call swiftgen using a symbolic link.
The issue does not come from swiftgen implementation but seems to be an Apple bug which does not return the same `arguments[0]` depending on where you call the symbolic link from. 
[This sample](https://github.com/Liquidsoul/apple-radars/tree/master/symlink-arg0) shows the issue.
In my opinion, the value should always be the symbolic link path, meaning that bundled templates resolution would not work. So, in order to solve this, swiftgen needs to go to the concrete swiftgen path.
