### PR TITLE
Core Data: optional scalar attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ _None_
   [David Jennes](https://github.com/djbe)
   [Igor Palaguta](https://github.com/Igor-Palaguta)
   [#455](https://github.com/SwiftGen/SwiftGen/pull/455)
+  [#567](https://github.com/SwiftGen/SwiftGen/pull/567)
   [#45](https://github.com/SwiftGen/SwiftGen/issues/45)
   [#185](https://github.com/SwiftGen/SwiftGen/issues/185)
   [#191](https://github.com/SwiftGen/SwiftGen/pull/191)

--- a/Tests/Fixtures/Generated/CoreData/swift3-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift3-context-defaults-publicAccess.swift
@@ -149,8 +149,8 @@ public class MainEntity: NSManagedObject {
   @NSManaged public var transient: String?
   @NSManaged public var uri: URL?
   @NSManaged public var uuid: UUID?
-  @NSManaged public var manyToMany: Set<SecondaryEntity>
-  @NSManaged public var oneToMany: NSOrderedSet
+  @NSManaged public var manyToMany: Set<SecondaryEntity>?
+  @NSManaged public var oneToMany: NSOrderedSet?
   @NSManaged public var oneToOne: SecondaryEntity?
   @NSManaged public var fetchedProperty: [NewEntity]
   // swiftlint:enable discouraged_optional_boolean
@@ -310,7 +310,7 @@ public class SecondaryEntity: NSManagedObject {
 
   // swiftlint:disable discouraged_optional_boolean
   @NSManaged public var name: String
-  @NSManaged public var manyToMany: Set<MainEntity>
+  @NSManaged public var manyToMany: Set<MainEntity>?
   @NSManaged public var oneToMany: MainEntity?
   @NSManaged public var oneToOne: MainEntity?
   // swiftlint:enable discouraged_optional_boolean

--- a/Tests/Fixtures/Generated/CoreData/swift3-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift3-context-defaults-publicAccess.swift
@@ -26,8 +26,8 @@ public class AbstractEntity: NSManagedObject {
     return NSFetchRequest<AbstractEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
-  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:disable discouraged_optional_boolean
+  // swiftlint:enable discouraged_optional_boolean
 }
 
 // MARK: - ChildEntity
@@ -46,8 +46,8 @@ public class ChildEntity: MainEntity {
     return NSFetchRequest<ChildEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
-  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:disable discouraged_optional_boolean
+  // swiftlint:enable discouraged_optional_boolean
 }
 
 // MARK: - MainEntity
@@ -66,7 +66,7 @@ public class MainEntity: NSManagedObject {
     return NSFetchRequest<MainEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:disable discouraged_optional_boolean
   @NSManaged public var attributedString: NSAttributedString?
   @NSManaged public var binaryData: Data?
   @NSManaged public var boolean: Bool
@@ -153,7 +153,7 @@ public class MainEntity: NSManagedObject {
   @NSManaged public var oneToMany: NSOrderedSet
   @NSManaged public var oneToOne: SecondaryEntity?
   @NSManaged public var fetchedProperty: [NewEntity]
-  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:enable discouraged_optional_boolean
 }
 
 // MARK: Relationship ManyToMany
@@ -287,9 +287,9 @@ public class NewEntity: AbstractEntity {
     return NSFetchRequest<NewEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:disable discouraged_optional_boolean
   @NSManaged public var identifier: UUID?
-  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:enable discouraged_optional_boolean
 }
 
 // MARK: - SecondaryEntity
@@ -308,12 +308,12 @@ public class SecondaryEntity: NSManagedObject {
     return NSFetchRequest<SecondaryEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:disable discouraged_optional_boolean
   @NSManaged public var name: String!
   @NSManaged public var manyToMany: Set<MainEntity>
   @NSManaged public var oneToMany: MainEntity?
   @NSManaged public var oneToOne: MainEntity?
-  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:enable discouraged_optional_boolean
 }
 
 // MARK: Relationship ManyToMany

--- a/Tests/Fixtures/Generated/CoreData/swift3-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift3-context-defaults-publicAccess.swift
@@ -144,7 +144,7 @@ public class MainEntity: NSManagedObject {
     }
   }
   @NSManaged public var optionalString: String?
-  @NSManaged public var string: String!
+  @NSManaged public var string: String
   @NSManaged public var transformable: AnyObject?
   @NSManaged public var transient: String?
   @NSManaged public var uri: URL?
@@ -309,7 +309,7 @@ public class SecondaryEntity: NSManagedObject {
   }
 
   // swiftlint:disable discouraged_optional_boolean
-  @NSManaged public var name: String!
+  @NSManaged public var name: String
   @NSManaged public var manyToMany: Set<MainEntity>
   @NSManaged public var oneToMany: MainEntity?
   @NSManaged public var oneToOne: MainEntity?

--- a/Tests/Fixtures/Generated/CoreData/swift3-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift3-context-defaults-publicAccess.swift
@@ -72,11 +72,56 @@ public class MainEntity: NSManagedObject {
   @NSManaged public var boolean: Bool
   @NSManaged public var date: Date?
   @NSManaged public var decimal: NSDecimalNumber?
-  @NSManaged public var double: Double
+  public var double: Double? {
+    get {
+      let key = "double"
+      willAccessValue(forKey: key)
+      defer { didAccessValue(forKey: key) }
+
+      return primitiveValue(forKey: key) as? Double
+    }
+    set {
+      let key = "double"
+      willChangeValue(forKey: key)
+      defer { didChangeValue(forKey: key) }
+
+      setPrimitiveValue(newValue, forKey: key)
+    }
+  }
   @NSManaged public var float: Float
-  @NSManaged public var int16: Int16
+  public var int16: Int16? {
+    get {
+      let key = "int16"
+      willAccessValue(forKey: key)
+      defer { didAccessValue(forKey: key) }
+
+      return primitiveValue(forKey: key) as? Int16
+    }
+    set {
+      let key = "int16"
+      willChangeValue(forKey: key)
+      defer { didChangeValue(forKey: key) }
+
+      setPrimitiveValue(newValue, forKey: key)
+    }
+  }
   @NSManaged public var int32: Int32
-  @NSManaged public var int64: Int64
+  public var int64: Int64? {
+    get {
+      let key = "int64"
+      willAccessValue(forKey: key)
+      defer { didAccessValue(forKey: key) }
+
+      return primitiveValue(forKey: key) as? Int64
+    }
+    set {
+      let key = "int64"
+      willChangeValue(forKey: key)
+      defer { didChangeValue(forKey: key) }
+
+      setPrimitiveValue(newValue, forKey: key)
+    }
+  }
   @NSManaged public var nonOptional: String!
   @NSManaged public var string: String?
   @NSManaged public var transformable: AnyObject?

--- a/Tests/Fixtures/Generated/CoreData/swift3-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift3-context-defaults-publicAccess.swift
@@ -26,8 +26,8 @@ public class AbstractEntity: NSManagedObject {
     return NSFetchRequest<AbstractEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional
-  // swiftlint:enable implicitly_unwrapped_optional
+  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
 }
 
 // MARK: - ChildEntity
@@ -46,8 +46,8 @@ public class ChildEntity: MainEntity {
     return NSFetchRequest<ChildEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional
-  // swiftlint:enable implicitly_unwrapped_optional
+  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
 }
 
 // MARK: - MainEntity
@@ -66,64 +66,85 @@ public class MainEntity: NSManagedObject {
     return NSFetchRequest<MainEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional
+  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
   @NSManaged public var attributedString: NSAttributedString?
   @NSManaged public var binaryData: Data?
   @NSManaged public var boolean: Bool
   @NSManaged public var date: Date?
   @NSManaged public var decimal: NSDecimalNumber?
-  public var double: Double? {
+  @NSManaged public var double: Double
+  @NSManaged public var float: Float
+  @NSManaged public var int16: Int16
+  @NSManaged public var int32: Int32
+  @NSManaged public var int64: Int64
+  public var optionalBoolean: Bool? {
     get {
-      let key = "double"
+      let key = "optionalBoolean"
+      willAccessValue(forKey: key)
+      defer { didAccessValue(forKey: key) }
+
+      return primitiveValue(forKey: key) as? Bool
+    }
+    set {
+      let key = "optionalBoolean"
+      willChangeValue(forKey: key)
+      defer { didChangeValue(forKey: key) }
+
+      setPrimitiveValue(newValue, forKey: key)
+    }
+  }
+  public var optionalDouble: Double? {
+    get {
+      let key = "optionalDouble"
       willAccessValue(forKey: key)
       defer { didAccessValue(forKey: key) }
 
       return primitiveValue(forKey: key) as? Double
     }
     set {
-      let key = "double"
+      let key = "optionalDouble"
       willChangeValue(forKey: key)
       defer { didChangeValue(forKey: key) }
 
       setPrimitiveValue(newValue, forKey: key)
     }
   }
-  @NSManaged public var float: Float
-  public var int16: Int16? {
+  @NSManaged public var optionalFloat: Float
+  public var optionalInt16: Int16? {
     get {
-      let key = "int16"
+      let key = "optionalInt16"
       willAccessValue(forKey: key)
       defer { didAccessValue(forKey: key) }
 
       return primitiveValue(forKey: key) as? Int16
     }
     set {
-      let key = "int16"
+      let key = "optionalInt16"
       willChangeValue(forKey: key)
       defer { didChangeValue(forKey: key) }
 
       setPrimitiveValue(newValue, forKey: key)
     }
   }
-  @NSManaged public var int32: Int32
-  public var int64: Int64? {
+  @NSManaged public var optionalInt32: Int32
+  public var optionalInt64: Int64? {
     get {
-      let key = "int64"
+      let key = "optionalInt64"
       willAccessValue(forKey: key)
       defer { didAccessValue(forKey: key) }
 
       return primitiveValue(forKey: key) as? Int64
     }
     set {
-      let key = "int64"
+      let key = "optionalInt64"
       willChangeValue(forKey: key)
       defer { didChangeValue(forKey: key) }
 
       setPrimitiveValue(newValue, forKey: key)
     }
   }
-  @NSManaged public var nonOptional: String!
-  @NSManaged public var string: String?
+  @NSManaged public var optionalString: String?
+  @NSManaged public var string: String!
   @NSManaged public var transformable: AnyObject?
   @NSManaged public var transient: String?
   @NSManaged public var uri: URL?
@@ -132,7 +153,7 @@ public class MainEntity: NSManagedObject {
   @NSManaged public var oneToMany: NSOrderedSet
   @NSManaged public var oneToOne: SecondaryEntity?
   @NSManaged public var fetchedProperty: [NewEntity]
-  // swiftlint:enable implicitly_unwrapped_optional
+  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
 }
 
 // MARK: Relationship ManyToMany
@@ -266,9 +287,9 @@ public class NewEntity: AbstractEntity {
     return NSFetchRequest<NewEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional
+  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
   @NSManaged public var identifier: UUID?
-  // swiftlint:enable implicitly_unwrapped_optional
+  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
 }
 
 // MARK: - SecondaryEntity
@@ -287,12 +308,12 @@ public class SecondaryEntity: NSManagedObject {
     return NSFetchRequest<SecondaryEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional
+  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
   @NSManaged public var name: String!
   @NSManaged public var manyToMany: Set<MainEntity>
   @NSManaged public var oneToMany: MainEntity?
   @NSManaged public var oneToOne: MainEntity?
-  // swiftlint:enable implicitly_unwrapped_optional
+  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
 }
 
 // MARK: Relationship ManyToMany

--- a/Tests/Fixtures/Generated/CoreData/swift3-context-defaults.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift3-context-defaults.swift
@@ -26,8 +26,8 @@ internal class AbstractEntity: NSManagedObject {
     return NSFetchRequest<AbstractEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional
-  // swiftlint:enable implicitly_unwrapped_optional
+  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
 }
 
 // MARK: - ChildEntity
@@ -46,8 +46,8 @@ internal class ChildEntity: MainEntity {
     return NSFetchRequest<ChildEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional
-  // swiftlint:enable implicitly_unwrapped_optional
+  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
 }
 
 // MARK: - MainEntity
@@ -66,64 +66,85 @@ internal class MainEntity: NSManagedObject {
     return NSFetchRequest<MainEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional
+  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
   @NSManaged internal var attributedString: NSAttributedString?
   @NSManaged internal var binaryData: Data?
   @NSManaged internal var boolean: Bool
   @NSManaged internal var date: Date?
   @NSManaged internal var decimal: NSDecimalNumber?
-  internal var double: Double? {
+  @NSManaged internal var double: Double
+  @NSManaged internal var float: Float
+  @NSManaged internal var int16: Int16
+  @NSManaged internal var int32: Int32
+  @NSManaged internal var int64: Int64
+  internal var optionalBoolean: Bool? {
     get {
-      let key = "double"
+      let key = "optionalBoolean"
+      willAccessValue(forKey: key)
+      defer { didAccessValue(forKey: key) }
+
+      return primitiveValue(forKey: key) as? Bool
+    }
+    set {
+      let key = "optionalBoolean"
+      willChangeValue(forKey: key)
+      defer { didChangeValue(forKey: key) }
+
+      setPrimitiveValue(newValue, forKey: key)
+    }
+  }
+  internal var optionalDouble: Double? {
+    get {
+      let key = "optionalDouble"
       willAccessValue(forKey: key)
       defer { didAccessValue(forKey: key) }
 
       return primitiveValue(forKey: key) as? Double
     }
     set {
-      let key = "double"
+      let key = "optionalDouble"
       willChangeValue(forKey: key)
       defer { didChangeValue(forKey: key) }
 
       setPrimitiveValue(newValue, forKey: key)
     }
   }
-  @NSManaged internal var float: Float
-  internal var int16: Int16? {
+  @NSManaged internal var optionalFloat: Float
+  internal var optionalInt16: Int16? {
     get {
-      let key = "int16"
+      let key = "optionalInt16"
       willAccessValue(forKey: key)
       defer { didAccessValue(forKey: key) }
 
       return primitiveValue(forKey: key) as? Int16
     }
     set {
-      let key = "int16"
+      let key = "optionalInt16"
       willChangeValue(forKey: key)
       defer { didChangeValue(forKey: key) }
 
       setPrimitiveValue(newValue, forKey: key)
     }
   }
-  @NSManaged internal var int32: Int32
-  internal var int64: Int64? {
+  @NSManaged internal var optionalInt32: Int32
+  internal var optionalInt64: Int64? {
     get {
-      let key = "int64"
+      let key = "optionalInt64"
       willAccessValue(forKey: key)
       defer { didAccessValue(forKey: key) }
 
       return primitiveValue(forKey: key) as? Int64
     }
     set {
-      let key = "int64"
+      let key = "optionalInt64"
       willChangeValue(forKey: key)
       defer { didChangeValue(forKey: key) }
 
       setPrimitiveValue(newValue, forKey: key)
     }
   }
-  @NSManaged internal var nonOptional: String!
-  @NSManaged internal var string: String?
+  @NSManaged internal var optionalString: String?
+  @NSManaged internal var string: String!
   @NSManaged internal var transformable: AnyObject?
   @NSManaged internal var transient: String?
   @NSManaged internal var uri: URL?
@@ -132,7 +153,7 @@ internal class MainEntity: NSManagedObject {
   @NSManaged internal var oneToMany: NSOrderedSet
   @NSManaged internal var oneToOne: SecondaryEntity?
   @NSManaged internal var fetchedProperty: [NewEntity]
-  // swiftlint:enable implicitly_unwrapped_optional
+  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
 }
 
 // MARK: Relationship ManyToMany
@@ -266,9 +287,9 @@ internal class NewEntity: AbstractEntity {
     return NSFetchRequest<NewEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional
+  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
   @NSManaged internal var identifier: UUID?
-  // swiftlint:enable implicitly_unwrapped_optional
+  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
 }
 
 // MARK: - SecondaryEntity
@@ -287,12 +308,12 @@ internal class SecondaryEntity: NSManagedObject {
     return NSFetchRequest<SecondaryEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional
+  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
   @NSManaged internal var name: String!
   @NSManaged internal var manyToMany: Set<MainEntity>
   @NSManaged internal var oneToMany: MainEntity?
   @NSManaged internal var oneToOne: MainEntity?
-  // swiftlint:enable implicitly_unwrapped_optional
+  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
 }
 
 // MARK: Relationship ManyToMany

--- a/Tests/Fixtures/Generated/CoreData/swift3-context-defaults.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift3-context-defaults.swift
@@ -149,8 +149,8 @@ internal class MainEntity: NSManagedObject {
   @NSManaged internal var transient: String?
   @NSManaged internal var uri: URL?
   @NSManaged internal var uuid: UUID?
-  @NSManaged internal var manyToMany: Set<SecondaryEntity>
-  @NSManaged internal var oneToMany: NSOrderedSet
+  @NSManaged internal var manyToMany: Set<SecondaryEntity>?
+  @NSManaged internal var oneToMany: NSOrderedSet?
   @NSManaged internal var oneToOne: SecondaryEntity?
   @NSManaged internal var fetchedProperty: [NewEntity]
   // swiftlint:enable discouraged_optional_boolean
@@ -310,7 +310,7 @@ internal class SecondaryEntity: NSManagedObject {
 
   // swiftlint:disable discouraged_optional_boolean
   @NSManaged internal var name: String
-  @NSManaged internal var manyToMany: Set<MainEntity>
+  @NSManaged internal var manyToMany: Set<MainEntity>?
   @NSManaged internal var oneToMany: MainEntity?
   @NSManaged internal var oneToOne: MainEntity?
   // swiftlint:enable discouraged_optional_boolean

--- a/Tests/Fixtures/Generated/CoreData/swift3-context-defaults.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift3-context-defaults.swift
@@ -144,7 +144,7 @@ internal class MainEntity: NSManagedObject {
     }
   }
   @NSManaged internal var optionalString: String?
-  @NSManaged internal var string: String!
+  @NSManaged internal var string: String
   @NSManaged internal var transformable: AnyObject?
   @NSManaged internal var transient: String?
   @NSManaged internal var uri: URL?
@@ -309,7 +309,7 @@ internal class SecondaryEntity: NSManagedObject {
   }
 
   // swiftlint:disable discouraged_optional_boolean
-  @NSManaged internal var name: String!
+  @NSManaged internal var name: String
   @NSManaged internal var manyToMany: Set<MainEntity>
   @NSManaged internal var oneToMany: MainEntity?
   @NSManaged internal var oneToOne: MainEntity?

--- a/Tests/Fixtures/Generated/CoreData/swift3-context-defaults.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift3-context-defaults.swift
@@ -72,11 +72,56 @@ internal class MainEntity: NSManagedObject {
   @NSManaged internal var boolean: Bool
   @NSManaged internal var date: Date?
   @NSManaged internal var decimal: NSDecimalNumber?
-  @NSManaged internal var double: Double
+  internal var double: Double? {
+    get {
+      let key = "double"
+      willAccessValue(forKey: key)
+      defer { didAccessValue(forKey: key) }
+
+      return primitiveValue(forKey: key) as? Double
+    }
+    set {
+      let key = "double"
+      willChangeValue(forKey: key)
+      defer { didChangeValue(forKey: key) }
+
+      setPrimitiveValue(newValue, forKey: key)
+    }
+  }
   @NSManaged internal var float: Float
-  @NSManaged internal var int16: Int16
+  internal var int16: Int16? {
+    get {
+      let key = "int16"
+      willAccessValue(forKey: key)
+      defer { didAccessValue(forKey: key) }
+
+      return primitiveValue(forKey: key) as? Int16
+    }
+    set {
+      let key = "int16"
+      willChangeValue(forKey: key)
+      defer { didChangeValue(forKey: key) }
+
+      setPrimitiveValue(newValue, forKey: key)
+    }
+  }
   @NSManaged internal var int32: Int32
-  @NSManaged internal var int64: Int64
+  internal var int64: Int64? {
+    get {
+      let key = "int64"
+      willAccessValue(forKey: key)
+      defer { didAccessValue(forKey: key) }
+
+      return primitiveValue(forKey: key) as? Int64
+    }
+    set {
+      let key = "int64"
+      willChangeValue(forKey: key)
+      defer { didChangeValue(forKey: key) }
+
+      setPrimitiveValue(newValue, forKey: key)
+    }
+  }
   @NSManaged internal var nonOptional: String!
   @NSManaged internal var string: String?
   @NSManaged internal var transformable: AnyObject?

--- a/Tests/Fixtures/Generated/CoreData/swift3-context-defaults.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift3-context-defaults.swift
@@ -26,8 +26,8 @@ internal class AbstractEntity: NSManagedObject {
     return NSFetchRequest<AbstractEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
-  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:disable discouraged_optional_boolean
+  // swiftlint:enable discouraged_optional_boolean
 }
 
 // MARK: - ChildEntity
@@ -46,8 +46,8 @@ internal class ChildEntity: MainEntity {
     return NSFetchRequest<ChildEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
-  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:disable discouraged_optional_boolean
+  // swiftlint:enable discouraged_optional_boolean
 }
 
 // MARK: - MainEntity
@@ -66,7 +66,7 @@ internal class MainEntity: NSManagedObject {
     return NSFetchRequest<MainEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:disable discouraged_optional_boolean
   @NSManaged internal var attributedString: NSAttributedString?
   @NSManaged internal var binaryData: Data?
   @NSManaged internal var boolean: Bool
@@ -153,7 +153,7 @@ internal class MainEntity: NSManagedObject {
   @NSManaged internal var oneToMany: NSOrderedSet
   @NSManaged internal var oneToOne: SecondaryEntity?
   @NSManaged internal var fetchedProperty: [NewEntity]
-  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:enable discouraged_optional_boolean
 }
 
 // MARK: Relationship ManyToMany
@@ -287,9 +287,9 @@ internal class NewEntity: AbstractEntity {
     return NSFetchRequest<NewEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:disable discouraged_optional_boolean
   @NSManaged internal var identifier: UUID?
-  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:enable discouraged_optional_boolean
 }
 
 // MARK: - SecondaryEntity
@@ -308,12 +308,12 @@ internal class SecondaryEntity: NSManagedObject {
     return NSFetchRequest<SecondaryEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:disable discouraged_optional_boolean
   @NSManaged internal var name: String!
   @NSManaged internal var manyToMany: Set<MainEntity>
   @NSManaged internal var oneToMany: MainEntity?
   @NSManaged internal var oneToOne: MainEntity?
-  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:enable discouraged_optional_boolean
 }
 
 // MARK: Relationship ManyToMany

--- a/Tests/Fixtures/Generated/CoreData/swift4-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift4-context-defaults-publicAccess.swift
@@ -149,8 +149,8 @@ public class MainEntity: NSManagedObject {
   @NSManaged public var transient: String?
   @NSManaged public var uri: URL?
   @NSManaged public var uuid: UUID?
-  @NSManaged public var manyToMany: Set<SecondaryEntity>
-  @NSManaged public var oneToMany: NSOrderedSet
+  @NSManaged public var manyToMany: Set<SecondaryEntity>?
+  @NSManaged public var oneToMany: NSOrderedSet?
   @NSManaged public var oneToOne: SecondaryEntity?
   @NSManaged public var fetchedProperty: [NewEntity]
   // swiftlint:enable discouraged_optional_boolean
@@ -310,7 +310,7 @@ public class SecondaryEntity: NSManagedObject {
 
   // swiftlint:disable discouraged_optional_boolean
   @NSManaged public var name: String
-  @NSManaged public var manyToMany: Set<MainEntity>
+  @NSManaged public var manyToMany: Set<MainEntity>?
   @NSManaged public var oneToMany: MainEntity?
   @NSManaged public var oneToOne: MainEntity?
   // swiftlint:enable discouraged_optional_boolean

--- a/Tests/Fixtures/Generated/CoreData/swift4-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift4-context-defaults-publicAccess.swift
@@ -26,8 +26,8 @@ public class AbstractEntity: NSManagedObject {
     return NSFetchRequest<AbstractEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
-  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:disable discouraged_optional_boolean
+  // swiftlint:enable discouraged_optional_boolean
 }
 
 // MARK: - ChildEntity
@@ -46,8 +46,8 @@ public class ChildEntity: MainEntity {
     return NSFetchRequest<ChildEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
-  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:disable discouraged_optional_boolean
+  // swiftlint:enable discouraged_optional_boolean
 }
 
 // MARK: - MainEntity
@@ -66,7 +66,7 @@ public class MainEntity: NSManagedObject {
     return NSFetchRequest<MainEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:disable discouraged_optional_boolean
   @NSManaged public var attributedString: NSAttributedString?
   @NSManaged public var binaryData: Data?
   @NSManaged public var boolean: Bool
@@ -153,7 +153,7 @@ public class MainEntity: NSManagedObject {
   @NSManaged public var oneToMany: NSOrderedSet
   @NSManaged public var oneToOne: SecondaryEntity?
   @NSManaged public var fetchedProperty: [NewEntity]
-  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:enable discouraged_optional_boolean
 }
 
 // MARK: Relationship ManyToMany
@@ -287,9 +287,9 @@ public class NewEntity: AbstractEntity {
     return NSFetchRequest<NewEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:disable discouraged_optional_boolean
   @NSManaged public var identifier: UUID?
-  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:enable discouraged_optional_boolean
 }
 
 // MARK: - SecondaryEntity
@@ -308,12 +308,12 @@ public class SecondaryEntity: NSManagedObject {
     return NSFetchRequest<SecondaryEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:disable discouraged_optional_boolean
   @NSManaged public var name: String!
   @NSManaged public var manyToMany: Set<MainEntity>
   @NSManaged public var oneToMany: MainEntity?
   @NSManaged public var oneToOne: MainEntity?
-  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:enable discouraged_optional_boolean
 }
 
 // MARK: Relationship ManyToMany

--- a/Tests/Fixtures/Generated/CoreData/swift4-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift4-context-defaults-publicAccess.swift
@@ -144,7 +144,7 @@ public class MainEntity: NSManagedObject {
     }
   }
   @NSManaged public var optionalString: String?
-  @NSManaged public var string: String!
+  @NSManaged public var string: String
   @NSManaged public var transformable: AnyObject?
   @NSManaged public var transient: String?
   @NSManaged public var uri: URL?
@@ -309,7 +309,7 @@ public class SecondaryEntity: NSManagedObject {
   }
 
   // swiftlint:disable discouraged_optional_boolean
-  @NSManaged public var name: String!
+  @NSManaged public var name: String
   @NSManaged public var manyToMany: Set<MainEntity>
   @NSManaged public var oneToMany: MainEntity?
   @NSManaged public var oneToOne: MainEntity?

--- a/Tests/Fixtures/Generated/CoreData/swift4-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift4-context-defaults-publicAccess.swift
@@ -72,11 +72,56 @@ public class MainEntity: NSManagedObject {
   @NSManaged public var boolean: Bool
   @NSManaged public var date: Date?
   @NSManaged public var decimal: NSDecimalNumber?
-  @NSManaged public var double: Double
+  public var double: Double? {
+    get {
+      let key = "double"
+      willAccessValue(forKey: key)
+      defer { didAccessValue(forKey: key) }
+
+      return primitiveValue(forKey: key) as? Double
+    }
+    set {
+      let key = "double"
+      willChangeValue(forKey: key)
+      defer { didChangeValue(forKey: key) }
+
+      setPrimitiveValue(newValue, forKey: key)
+    }
+  }
   @NSManaged public var float: Float
-  @NSManaged public var int16: Int16
+  public var int16: Int16? {
+    get {
+      let key = "int16"
+      willAccessValue(forKey: key)
+      defer { didAccessValue(forKey: key) }
+
+      return primitiveValue(forKey: key) as? Int16
+    }
+    set {
+      let key = "int16"
+      willChangeValue(forKey: key)
+      defer { didChangeValue(forKey: key) }
+
+      setPrimitiveValue(newValue, forKey: key)
+    }
+  }
   @NSManaged public var int32: Int32
-  @NSManaged public var int64: Int64
+  public var int64: Int64? {
+    get {
+      let key = "int64"
+      willAccessValue(forKey: key)
+      defer { didAccessValue(forKey: key) }
+
+      return primitiveValue(forKey: key) as? Int64
+    }
+    set {
+      let key = "int64"
+      willChangeValue(forKey: key)
+      defer { didChangeValue(forKey: key) }
+
+      setPrimitiveValue(newValue, forKey: key)
+    }
+  }
   @NSManaged public var nonOptional: String!
   @NSManaged public var string: String?
   @NSManaged public var transformable: AnyObject?

--- a/Tests/Fixtures/Generated/CoreData/swift4-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift4-context-defaults-publicAccess.swift
@@ -26,8 +26,8 @@ public class AbstractEntity: NSManagedObject {
     return NSFetchRequest<AbstractEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional
-  // swiftlint:enable implicitly_unwrapped_optional
+  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
 }
 
 // MARK: - ChildEntity
@@ -46,8 +46,8 @@ public class ChildEntity: MainEntity {
     return NSFetchRequest<ChildEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional
-  // swiftlint:enable implicitly_unwrapped_optional
+  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
 }
 
 // MARK: - MainEntity
@@ -66,64 +66,85 @@ public class MainEntity: NSManagedObject {
     return NSFetchRequest<MainEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional
+  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
   @NSManaged public var attributedString: NSAttributedString?
   @NSManaged public var binaryData: Data?
   @NSManaged public var boolean: Bool
   @NSManaged public var date: Date?
   @NSManaged public var decimal: NSDecimalNumber?
-  public var double: Double? {
+  @NSManaged public var double: Double
+  @NSManaged public var float: Float
+  @NSManaged public var int16: Int16
+  @NSManaged public var int32: Int32
+  @NSManaged public var int64: Int64
+  public var optionalBoolean: Bool? {
     get {
-      let key = "double"
+      let key = "optionalBoolean"
+      willAccessValue(forKey: key)
+      defer { didAccessValue(forKey: key) }
+
+      return primitiveValue(forKey: key) as? Bool
+    }
+    set {
+      let key = "optionalBoolean"
+      willChangeValue(forKey: key)
+      defer { didChangeValue(forKey: key) }
+
+      setPrimitiveValue(newValue, forKey: key)
+    }
+  }
+  public var optionalDouble: Double? {
+    get {
+      let key = "optionalDouble"
       willAccessValue(forKey: key)
       defer { didAccessValue(forKey: key) }
 
       return primitiveValue(forKey: key) as? Double
     }
     set {
-      let key = "double"
+      let key = "optionalDouble"
       willChangeValue(forKey: key)
       defer { didChangeValue(forKey: key) }
 
       setPrimitiveValue(newValue, forKey: key)
     }
   }
-  @NSManaged public var float: Float
-  public var int16: Int16? {
+  @NSManaged public var optionalFloat: Float
+  public var optionalInt16: Int16? {
     get {
-      let key = "int16"
+      let key = "optionalInt16"
       willAccessValue(forKey: key)
       defer { didAccessValue(forKey: key) }
 
       return primitiveValue(forKey: key) as? Int16
     }
     set {
-      let key = "int16"
+      let key = "optionalInt16"
       willChangeValue(forKey: key)
       defer { didChangeValue(forKey: key) }
 
       setPrimitiveValue(newValue, forKey: key)
     }
   }
-  @NSManaged public var int32: Int32
-  public var int64: Int64? {
+  @NSManaged public var optionalInt32: Int32
+  public var optionalInt64: Int64? {
     get {
-      let key = "int64"
+      let key = "optionalInt64"
       willAccessValue(forKey: key)
       defer { didAccessValue(forKey: key) }
 
       return primitiveValue(forKey: key) as? Int64
     }
     set {
-      let key = "int64"
+      let key = "optionalInt64"
       willChangeValue(forKey: key)
       defer { didChangeValue(forKey: key) }
 
       setPrimitiveValue(newValue, forKey: key)
     }
   }
-  @NSManaged public var nonOptional: String!
-  @NSManaged public var string: String?
+  @NSManaged public var optionalString: String?
+  @NSManaged public var string: String!
   @NSManaged public var transformable: AnyObject?
   @NSManaged public var transient: String?
   @NSManaged public var uri: URL?
@@ -132,7 +153,7 @@ public class MainEntity: NSManagedObject {
   @NSManaged public var oneToMany: NSOrderedSet
   @NSManaged public var oneToOne: SecondaryEntity?
   @NSManaged public var fetchedProperty: [NewEntity]
-  // swiftlint:enable implicitly_unwrapped_optional
+  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
 }
 
 // MARK: Relationship ManyToMany
@@ -266,9 +287,9 @@ public class NewEntity: AbstractEntity {
     return NSFetchRequest<NewEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional
+  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
   @NSManaged public var identifier: UUID?
-  // swiftlint:enable implicitly_unwrapped_optional
+  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
 }
 
 // MARK: - SecondaryEntity
@@ -287,12 +308,12 @@ public class SecondaryEntity: NSManagedObject {
     return NSFetchRequest<SecondaryEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional
+  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
   @NSManaged public var name: String!
   @NSManaged public var manyToMany: Set<MainEntity>
   @NSManaged public var oneToMany: MainEntity?
   @NSManaged public var oneToOne: MainEntity?
-  // swiftlint:enable implicitly_unwrapped_optional
+  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
 }
 
 // MARK: Relationship ManyToMany

--- a/Tests/Fixtures/Generated/CoreData/swift4-context-defaults.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift4-context-defaults.swift
@@ -26,8 +26,8 @@ internal class AbstractEntity: NSManagedObject {
     return NSFetchRequest<AbstractEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional
-  // swiftlint:enable implicitly_unwrapped_optional
+  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
 }
 
 // MARK: - ChildEntity
@@ -46,8 +46,8 @@ internal class ChildEntity: MainEntity {
     return NSFetchRequest<ChildEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional
-  // swiftlint:enable implicitly_unwrapped_optional
+  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
 }
 
 // MARK: - MainEntity
@@ -66,64 +66,85 @@ internal class MainEntity: NSManagedObject {
     return NSFetchRequest<MainEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional
+  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
   @NSManaged internal var attributedString: NSAttributedString?
   @NSManaged internal var binaryData: Data?
   @NSManaged internal var boolean: Bool
   @NSManaged internal var date: Date?
   @NSManaged internal var decimal: NSDecimalNumber?
-  internal var double: Double? {
+  @NSManaged internal var double: Double
+  @NSManaged internal var float: Float
+  @NSManaged internal var int16: Int16
+  @NSManaged internal var int32: Int32
+  @NSManaged internal var int64: Int64
+  internal var optionalBoolean: Bool? {
     get {
-      let key = "double"
+      let key = "optionalBoolean"
+      willAccessValue(forKey: key)
+      defer { didAccessValue(forKey: key) }
+
+      return primitiveValue(forKey: key) as? Bool
+    }
+    set {
+      let key = "optionalBoolean"
+      willChangeValue(forKey: key)
+      defer { didChangeValue(forKey: key) }
+
+      setPrimitiveValue(newValue, forKey: key)
+    }
+  }
+  internal var optionalDouble: Double? {
+    get {
+      let key = "optionalDouble"
       willAccessValue(forKey: key)
       defer { didAccessValue(forKey: key) }
 
       return primitiveValue(forKey: key) as? Double
     }
     set {
-      let key = "double"
+      let key = "optionalDouble"
       willChangeValue(forKey: key)
       defer { didChangeValue(forKey: key) }
 
       setPrimitiveValue(newValue, forKey: key)
     }
   }
-  @NSManaged internal var float: Float
-  internal var int16: Int16? {
+  @NSManaged internal var optionalFloat: Float
+  internal var optionalInt16: Int16? {
     get {
-      let key = "int16"
+      let key = "optionalInt16"
       willAccessValue(forKey: key)
       defer { didAccessValue(forKey: key) }
 
       return primitiveValue(forKey: key) as? Int16
     }
     set {
-      let key = "int16"
+      let key = "optionalInt16"
       willChangeValue(forKey: key)
       defer { didChangeValue(forKey: key) }
 
       setPrimitiveValue(newValue, forKey: key)
     }
   }
-  @NSManaged internal var int32: Int32
-  internal var int64: Int64? {
+  @NSManaged internal var optionalInt32: Int32
+  internal var optionalInt64: Int64? {
     get {
-      let key = "int64"
+      let key = "optionalInt64"
       willAccessValue(forKey: key)
       defer { didAccessValue(forKey: key) }
 
       return primitiveValue(forKey: key) as? Int64
     }
     set {
-      let key = "int64"
+      let key = "optionalInt64"
       willChangeValue(forKey: key)
       defer { didChangeValue(forKey: key) }
 
       setPrimitiveValue(newValue, forKey: key)
     }
   }
-  @NSManaged internal var nonOptional: String!
-  @NSManaged internal var string: String?
+  @NSManaged internal var optionalString: String?
+  @NSManaged internal var string: String!
   @NSManaged internal var transformable: AnyObject?
   @NSManaged internal var transient: String?
   @NSManaged internal var uri: URL?
@@ -132,7 +153,7 @@ internal class MainEntity: NSManagedObject {
   @NSManaged internal var oneToMany: NSOrderedSet
   @NSManaged internal var oneToOne: SecondaryEntity?
   @NSManaged internal var fetchedProperty: [NewEntity]
-  // swiftlint:enable implicitly_unwrapped_optional
+  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
 }
 
 // MARK: Relationship ManyToMany
@@ -266,9 +287,9 @@ internal class NewEntity: AbstractEntity {
     return NSFetchRequest<NewEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional
+  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
   @NSManaged internal var identifier: UUID?
-  // swiftlint:enable implicitly_unwrapped_optional
+  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
 }
 
 // MARK: - SecondaryEntity
@@ -287,12 +308,12 @@ internal class SecondaryEntity: NSManagedObject {
     return NSFetchRequest<SecondaryEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional
+  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
   @NSManaged internal var name: String!
   @NSManaged internal var manyToMany: Set<MainEntity>
   @NSManaged internal var oneToMany: MainEntity?
   @NSManaged internal var oneToOne: MainEntity?
-  // swiftlint:enable implicitly_unwrapped_optional
+  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
 }
 
 // MARK: Relationship ManyToMany

--- a/Tests/Fixtures/Generated/CoreData/swift4-context-defaults.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift4-context-defaults.swift
@@ -149,8 +149,8 @@ internal class MainEntity: NSManagedObject {
   @NSManaged internal var transient: String?
   @NSManaged internal var uri: URL?
   @NSManaged internal var uuid: UUID?
-  @NSManaged internal var manyToMany: Set<SecondaryEntity>
-  @NSManaged internal var oneToMany: NSOrderedSet
+  @NSManaged internal var manyToMany: Set<SecondaryEntity>?
+  @NSManaged internal var oneToMany: NSOrderedSet?
   @NSManaged internal var oneToOne: SecondaryEntity?
   @NSManaged internal var fetchedProperty: [NewEntity]
   // swiftlint:enable discouraged_optional_boolean
@@ -310,7 +310,7 @@ internal class SecondaryEntity: NSManagedObject {
 
   // swiftlint:disable discouraged_optional_boolean
   @NSManaged internal var name: String
-  @NSManaged internal var manyToMany: Set<MainEntity>
+  @NSManaged internal var manyToMany: Set<MainEntity>?
   @NSManaged internal var oneToMany: MainEntity?
   @NSManaged internal var oneToOne: MainEntity?
   // swiftlint:enable discouraged_optional_boolean

--- a/Tests/Fixtures/Generated/CoreData/swift4-context-defaults.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift4-context-defaults.swift
@@ -144,7 +144,7 @@ internal class MainEntity: NSManagedObject {
     }
   }
   @NSManaged internal var optionalString: String?
-  @NSManaged internal var string: String!
+  @NSManaged internal var string: String
   @NSManaged internal var transformable: AnyObject?
   @NSManaged internal var transient: String?
   @NSManaged internal var uri: URL?
@@ -309,7 +309,7 @@ internal class SecondaryEntity: NSManagedObject {
   }
 
   // swiftlint:disable discouraged_optional_boolean
-  @NSManaged internal var name: String!
+  @NSManaged internal var name: String
   @NSManaged internal var manyToMany: Set<MainEntity>
   @NSManaged internal var oneToMany: MainEntity?
   @NSManaged internal var oneToOne: MainEntity?

--- a/Tests/Fixtures/Generated/CoreData/swift4-context-defaults.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift4-context-defaults.swift
@@ -72,11 +72,56 @@ internal class MainEntity: NSManagedObject {
   @NSManaged internal var boolean: Bool
   @NSManaged internal var date: Date?
   @NSManaged internal var decimal: NSDecimalNumber?
-  @NSManaged internal var double: Double
+  internal var double: Double? {
+    get {
+      let key = "double"
+      willAccessValue(forKey: key)
+      defer { didAccessValue(forKey: key) }
+
+      return primitiveValue(forKey: key) as? Double
+    }
+    set {
+      let key = "double"
+      willChangeValue(forKey: key)
+      defer { didChangeValue(forKey: key) }
+
+      setPrimitiveValue(newValue, forKey: key)
+    }
+  }
   @NSManaged internal var float: Float
-  @NSManaged internal var int16: Int16
+  internal var int16: Int16? {
+    get {
+      let key = "int16"
+      willAccessValue(forKey: key)
+      defer { didAccessValue(forKey: key) }
+
+      return primitiveValue(forKey: key) as? Int16
+    }
+    set {
+      let key = "int16"
+      willChangeValue(forKey: key)
+      defer { didChangeValue(forKey: key) }
+
+      setPrimitiveValue(newValue, forKey: key)
+    }
+  }
   @NSManaged internal var int32: Int32
-  @NSManaged internal var int64: Int64
+  internal var int64: Int64? {
+    get {
+      let key = "int64"
+      willAccessValue(forKey: key)
+      defer { didAccessValue(forKey: key) }
+
+      return primitiveValue(forKey: key) as? Int64
+    }
+    set {
+      let key = "int64"
+      willChangeValue(forKey: key)
+      defer { didChangeValue(forKey: key) }
+
+      setPrimitiveValue(newValue, forKey: key)
+    }
+  }
   @NSManaged internal var nonOptional: String!
   @NSManaged internal var string: String?
   @NSManaged internal var transformable: AnyObject?

--- a/Tests/Fixtures/Generated/CoreData/swift4-context-defaults.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift4-context-defaults.swift
@@ -26,8 +26,8 @@ internal class AbstractEntity: NSManagedObject {
     return NSFetchRequest<AbstractEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
-  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:disable discouraged_optional_boolean
+  // swiftlint:enable discouraged_optional_boolean
 }
 
 // MARK: - ChildEntity
@@ -46,8 +46,8 @@ internal class ChildEntity: MainEntity {
     return NSFetchRequest<ChildEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
-  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:disable discouraged_optional_boolean
+  // swiftlint:enable discouraged_optional_boolean
 }
 
 // MARK: - MainEntity
@@ -66,7 +66,7 @@ internal class MainEntity: NSManagedObject {
     return NSFetchRequest<MainEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:disable discouraged_optional_boolean
   @NSManaged internal var attributedString: NSAttributedString?
   @NSManaged internal var binaryData: Data?
   @NSManaged internal var boolean: Bool
@@ -153,7 +153,7 @@ internal class MainEntity: NSManagedObject {
   @NSManaged internal var oneToMany: NSOrderedSet
   @NSManaged internal var oneToOne: SecondaryEntity?
   @NSManaged internal var fetchedProperty: [NewEntity]
-  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:enable discouraged_optional_boolean
 }
 
 // MARK: Relationship ManyToMany
@@ -287,9 +287,9 @@ internal class NewEntity: AbstractEntity {
     return NSFetchRequest<NewEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:disable discouraged_optional_boolean
   @NSManaged internal var identifier: UUID?
-  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:enable discouraged_optional_boolean
 }
 
 // MARK: - SecondaryEntity
@@ -308,12 +308,12 @@ internal class SecondaryEntity: NSManagedObject {
     return NSFetchRequest<SecondaryEntity>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:disable discouraged_optional_boolean
   @NSManaged internal var name: String!
   @NSManaged internal var manyToMany: Set<MainEntity>
   @NSManaged internal var oneToMany: MainEntity?
   @NSManaged internal var oneToOne: MainEntity?
-  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:enable discouraged_optional_boolean
 }
 
 // MARK: Relationship ManyToMany

--- a/Tests/Fixtures/Resources/CoreData/Model.xcdatamodeld/Model 2.xcdatamodel/contents
+++ b/Tests/Fixtures/Resources/CoreData/Model.xcdatamodeld/Model 2.xcdatamodel/contents
@@ -15,13 +15,13 @@
                 <entry key="key" value="value"/>
             </userInfo>
         </attribute>
-        <attribute name="boolean" optional="YES" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="boolean" optional="NO" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="decimal" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
         <attribute name="double" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
-        <attribute name="float" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="float" optional="NO" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="int16" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
-        <attribute name="int32" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="int32" optional="NO" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="int64" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="nonOptional" attributeType="String" syncable="YES"/>
         <attribute name="string" optional="YES" attributeType="String" syncable="YES"/>

--- a/Tests/Fixtures/Resources/CoreData/Model.xcdatamodeld/Model 2.xcdatamodel/contents
+++ b/Tests/Fixtures/Resources/CoreData/Model.xcdatamodeld/Model 2.xcdatamodel/contents
@@ -15,16 +15,22 @@
                 <entry key="key" value="value"/>
             </userInfo>
         </attribute>
-        <attribute name="boolean" optional="NO" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="boolean" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="decimal" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
-        <attribute name="double" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
-        <attribute name="float" optional="NO" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
-        <attribute name="int16" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
-        <attribute name="int32" optional="NO" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
-        <attribute name="int64" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
-        <attribute name="nonOptional" attributeType="String" syncable="YES"/>
-        <attribute name="string" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="double" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="float" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="int16" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="int32" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="int64" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="optionalBoolean" optional="YES" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="optionalDouble" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="optionalFloat" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="optionalInt16" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="optionalInt32" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="optionalInt64" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="optionalString" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="string" attributeType="String" syncable="YES"/>
         <attribute name="transformable" optional="YES" attributeType="Transformable" syncable="YES"/>
         <attribute name="transient" optional="YES" transient="YES" attributeType="String" syncable="YES"/>
         <attribute name="uri" optional="YES" attributeType="URI" syncable="YES"/>
@@ -70,7 +76,7 @@
         <element name="AutoClassGen" positionX="-36" positionY="135" width="128" height="45"/>
         <element name="AutoExtensionGen" positionX="-27" positionY="144" width="128" height="45"/>
         <element name="ChildEntity" positionX="-36" positionY="126" width="128" height="45"/>
-        <element name="MainEntity" positionX="-63" positionY="-18" width="128" height="359"/>
+        <element name="MainEntity" positionX="-63" positionY="-18" width="128" height="449"/>
         <element name="NewEntity" positionX="-27" positionY="144" width="128" height="60"/>
         <element name="SecondaryEntity" positionX="-54" positionY="108" width="128" height="105"/>
     </elements>

--- a/Tests/Fixtures/StencilContexts/CoreData/defaults.yaml
+++ b/Tests/Fixtures/StencilContexts/CoreData/defaults.yaml
@@ -81,7 +81,7 @@ models:
         usesScalarValueType: false
       - customClassName: ""
         isIndexed: false
-        isOptional: true
+        isOptional: false
         isTransient: false
         name: "boolean"
         propertyType: "attribute"
@@ -121,7 +121,7 @@ models:
         usesScalarValueType: true
       - customClassName: ""
         isIndexed: false
-        isOptional: true
+        isOptional: false
         isTransient: false
         name: "float"
         propertyType: "attribute"
@@ -141,7 +141,7 @@ models:
         usesScalarValueType: true
       - customClassName: ""
         isIndexed: false
-        isOptional: true
+        isOptional: false
         isTransient: false
         name: "int32"
         propertyType: "attribute"

--- a/Tests/Fixtures/StencilContexts/CoreData/defaults.yaml
+++ b/Tests/Fixtures/StencilContexts/CoreData/defaults.yaml
@@ -111,7 +111,7 @@ models:
         usesScalarValueType: false
       - customClassName: ""
         isIndexed: false
-        isOptional: true
+        isOptional: false
         isTransient: false
         name: "double"
         propertyType: "attribute"
@@ -131,7 +131,7 @@ models:
         usesScalarValueType: true
       - customClassName: ""
         isIndexed: false
-        isOptional: true
+        isOptional: false
         isTransient: false
         name: "int16"
         propertyType: "attribute"
@@ -151,7 +151,7 @@ models:
         usesScalarValueType: true
       - customClassName: ""
         isIndexed: false
-        isOptional: true
+        isOptional: false
         isTransient: false
         name: "int64"
         propertyType: "attribute"
@@ -161,9 +161,69 @@ models:
         usesScalarValueType: true
       - customClassName: ""
         isIndexed: false
+        isOptional: true
+        isTransient: false
+        name: "optionalBoolean"
+        propertyType: "attribute"
+        type: "Boolean"
+        typeName: "Bool"
+        userInfo: {}
+        usesScalarValueType: true
+      - customClassName: ""
+        isIndexed: false
+        isOptional: true
+        isTransient: false
+        name: "optionalDouble"
+        propertyType: "attribute"
+        type: "Double"
+        typeName: "Double"
+        userInfo: {}
+        usesScalarValueType: true
+      - customClassName: ""
+        isIndexed: false
         isOptional: false
         isTransient: false
-        name: "nonOptional"
+        name: "optionalFloat"
+        propertyType: "attribute"
+        type: "Float"
+        typeName: "Float"
+        userInfo: {}
+        usesScalarValueType: true
+      - customClassName: ""
+        isIndexed: false
+        isOptional: true
+        isTransient: false
+        name: "optionalInt16"
+        propertyType: "attribute"
+        type: "Integer 16"
+        typeName: "Int16"
+        userInfo: {}
+        usesScalarValueType: true
+      - customClassName: ""
+        isIndexed: false
+        isOptional: false
+        isTransient: false
+        name: "optionalInt32"
+        propertyType: "attribute"
+        type: "Integer 32"
+        typeName: "Int32"
+        userInfo: {}
+        usesScalarValueType: true
+      - customClassName: ""
+        isIndexed: false
+        isOptional: true
+        isTransient: false
+        name: "optionalInt64"
+        propertyType: "attribute"
+        type: "Integer 64"
+        typeName: "Int64"
+        userInfo: {}
+        usesScalarValueType: true
+      - customClassName: ""
+        isIndexed: false
+        isOptional: true
+        isTransient: false
+        name: "optionalString"
         propertyType: "attribute"
         type: "String"
         typeName: "String"
@@ -171,7 +231,7 @@ models:
         usesScalarValueType: false
       - customClassName: ""
         isIndexed: false
-        isOptional: true
+        isOptional: false
         isTransient: false
         name: "string"
         propertyType: "attribute"

--- a/templates/coredata/swift3.stencil
+++ b/templates/coredata/swift3.stencil
@@ -32,7 +32,7 @@ import Foundation
     return NSFetchRequest<{{ entityClassName }}>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:disable discouraged_optional_boolean
   {% for attribute in entity.attributes %}
   {% if attribute.usesScalarValueType and attribute.isOptional %}
   {{ accessModifier }} var {{ attribute.name }}: {{ attribute.typeName }}? {
@@ -65,7 +65,7 @@ import Foundation
   {% for fetchedProperty in entity.fetchedProperties %}
   @NSManaged {{ accessModifier }} var {{ fetchedProperty.name }}: [{{ fetchedProperty.fetchRequest.entity }}]
   {% endfor %}
-  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:enable discouraged_optional_boolean
 }
 
 {% for relationship in entity.relationships %}

--- a/templates/coredata/swift3.stencil
+++ b/templates/coredata/swift3.stencil
@@ -8,9 +8,9 @@ import Foundation
 // swiftlint:disable file_length
 // swiftlint:disable attributes
 // swiftlint:disable vertical_whitespace_closing_braces
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
 
 // swiftlint:disable identifier_name line_length type_body_length
-{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
 {% for model in models %}
 {% for name, entity in model.entities where entity.shouldGenerateCode %}
 {% set superclass %}{{ model.entities[entity.superEntity].className | default:"NSManagedObject" }}{% endset %}
@@ -34,7 +34,26 @@ import Foundation
 
   // swiftlint:disable implicitly_unwrapped_optional
   {% for attribute in entity.attributes %}
+  {% if attribute.usesScalarValueType and attribute.isOptional %}
+  {{ accessModifier }} var {{ attribute.name }}: {{ attribute.typeName }}? {
+    get {
+      let key = "{{ attribute.name }}"
+      willAccessValue(forKey: key)
+      defer { didAccessValue(forKey: key) }
+
+      return primitiveValue(forKey: key) as? {{ attribute.typeName }}
+    }
+    set {
+      let key = "{{ attribute.name }}"
+      willChangeValue(forKey: key)
+      defer { didChangeValue(forKey: key) }
+
+      setPrimitiveValue(newValue, forKey: key)
+    }
+  }
+  {% else %}
   @NSManaged {{ accessModifier }} var {{ attribute.name }}: {{ attribute.typeName }}{% if attribute.usesScalarValueType == false %}{% if attribute.isOptional %}?{% else %}!{% endif %}{% endif %}
+  {% endif %}
   {% endfor %}
   {% for relationship in entity.relationships %}
   {% if relationship.isToMany %}

--- a/templates/coredata/swift3.stencil
+++ b/templates/coredata/swift3.stencil
@@ -32,7 +32,7 @@ import Foundation
     return NSFetchRequest<{{ entityClassName }}>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional
+  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
   {% for attribute in entity.attributes %}
   {% if attribute.usesScalarValueType and attribute.isOptional %}
   {{ accessModifier }} var {{ attribute.name }}: {{ attribute.typeName }}? {
@@ -65,7 +65,7 @@ import Foundation
   {% for fetchedProperty in entity.fetchedProperties %}
   @NSManaged {{ accessModifier }} var {{ fetchedProperty.name }}: [{{ fetchedProperty.fetchRequest.entity }}]
   {% endfor %}
-  // swiftlint:enable implicitly_unwrapped_optional
+  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
 }
 
 {% for relationship in entity.relationships %}

--- a/templates/coredata/swift3.stencil
+++ b/templates/coredata/swift3.stencil
@@ -52,7 +52,7 @@ import Foundation
     }
   }
   {% else %}
-  @NSManaged {{ accessModifier }} var {{ attribute.name }}: {{ attribute.typeName }}{% if attribute.usesScalarValueType == false %}{% if attribute.isOptional %}?{% else %}!{% endif %}{% endif %}
+  @NSManaged {{ accessModifier }} var {{ attribute.name }}: {{ attribute.typeName }}{% if attribute.isOptional %}?{% endif %}
   {% endif %}
   {% endfor %}
   {% for relationship in entity.relationships %}

--- a/templates/coredata/swift3.stencil
+++ b/templates/coredata/swift3.stencil
@@ -57,7 +57,7 @@ import Foundation
   {% endfor %}
   {% for relationship in entity.relationships %}
   {% if relationship.isToMany %}
-  @NSManaged {{ accessModifier }} var {{ relationship.name }}: {% if relationship.isOrdered %}NSOrderedSet{% else %}Set<{{ model.entities[relationship.destinationEntity].className | default:"NSManagedObject" }}>{% endif %}
+  @NSManaged {{ accessModifier }} var {{ relationship.name }}: {% if relationship.isOrdered %}NSOrderedSet{% else %}Set<{{ model.entities[relationship.destinationEntity].className | default:"NSManagedObject" }}>{% endif %}{% if relationship.isOptional %}?{% endif %}
   {% else %}
   @NSManaged {{ accessModifier }} var {{ relationship.name }}: {{ model.entities[relationship.destinationEntity].className | default:"NSManagedObject" }}{% if relationship.isOptional %}?{% endif %}
   {% endif %}
@@ -68,8 +68,7 @@ import Foundation
   // swiftlint:enable discouraged_optional_boolean
 }
 
-{% for relationship in entity.relationships %}
-{% if relationship.isToMany %}
+{% for relationship in entity.relationships where relationship.isToMany %}
 {% set destinationEntityClassName %}{{ model.entities[relationship.destinationEntity].className | default:"NSManagedObject" }}{% endset %}
 {% set collectionClassName %}{% if relationship.isOrdered %}NSOrderedSet{% else %}Set<{{ destinationEntityClassName }}>{% endif %}{% endset %}
 {% set relationshipName %}{{ relationship.name | upperFirstLetter }}{% endset %}
@@ -109,7 +108,6 @@ extension {{ entityClassName }} {
   @NSManaged public func removeFrom{{ relationshipName }}(_ values: {{ collectionClassName }})
 }
 
-{% endif %}
 {% endfor %}
 {% if model.fetchRequests[entity.name].count > 0 %}
 // MARK: Fetch Requests

--- a/templates/coredata/swift4.stencil
+++ b/templates/coredata/swift4.stencil
@@ -32,7 +32,7 @@ import Foundation
     return NSFetchRequest<{{ entityClassName }}>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:disable discouraged_optional_boolean
   {% for attribute in entity.attributes %}
   {% if attribute.usesScalarValueType and attribute.isOptional %}
   {{ accessModifier }} var {{ attribute.name }}: {{ attribute.typeName }}? {
@@ -65,7 +65,7 @@ import Foundation
   {% for fetchedProperty in entity.fetchedProperties %}
   @NSManaged {{ accessModifier }} var {{ fetchedProperty.name }}: [{{ fetchedProperty.fetchRequest.entity }}]
   {% endfor %}
-  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
+  // swiftlint:enable discouraged_optional_boolean
 }
 
 {% for relationship in entity.relationships %}

--- a/templates/coredata/swift4.stencil
+++ b/templates/coredata/swift4.stencil
@@ -8,9 +8,9 @@ import Foundation
 // swiftlint:disable file_length
 // swiftlint:disable attributes
 // swiftlint:disable vertical_whitespace_closing_braces
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
 
 // swiftlint:disable identifier_name line_length type_body_length
-{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
 {% for model in models %}
 {% for name, entity in model.entities where entity.shouldGenerateCode %}
 {% set superclass %}{{ model.entities[entity.superEntity].className | default:"NSManagedObject" }}{% endset %}
@@ -34,7 +34,26 @@ import Foundation
 
   // swiftlint:disable implicitly_unwrapped_optional
   {% for attribute in entity.attributes %}
+  {% if attribute.usesScalarValueType and attribute.isOptional %}
+  {{ accessModifier }} var {{ attribute.name }}: {{ attribute.typeName }}? {
+    get {
+      let key = "{{ attribute.name }}"
+      willAccessValue(forKey: key)
+      defer { didAccessValue(forKey: key) }
+
+      return primitiveValue(forKey: key) as? {{ attribute.typeName }}
+    }
+    set {
+      let key = "{{ attribute.name }}"
+      willChangeValue(forKey: key)
+      defer { didChangeValue(forKey: key) }
+
+      setPrimitiveValue(newValue, forKey: key)
+    }
+  }
+  {% else %}
   @NSManaged {{ accessModifier }} var {{ attribute.name }}: {{ attribute.typeName }}{% if attribute.usesScalarValueType == false %}{% if attribute.isOptional %}?{% else %}!{% endif %}{% endif %}
+  {% endif %}
   {% endfor %}
   {% for relationship in entity.relationships %}
   {% if relationship.isToMany %}

--- a/templates/coredata/swift4.stencil
+++ b/templates/coredata/swift4.stencil
@@ -32,7 +32,7 @@ import Foundation
     return NSFetchRequest<{{ entityClassName }}>(entityName: entityName())
   }
 
-  // swiftlint:disable implicitly_unwrapped_optional
+  // swiftlint:disable implicitly_unwrapped_optional discouraged_optional_boolean
   {% for attribute in entity.attributes %}
   {% if attribute.usesScalarValueType and attribute.isOptional %}
   {{ accessModifier }} var {{ attribute.name }}: {{ attribute.typeName }}? {
@@ -65,7 +65,7 @@ import Foundation
   {% for fetchedProperty in entity.fetchedProperties %}
   @NSManaged {{ accessModifier }} var {{ fetchedProperty.name }}: [{{ fetchedProperty.fetchRequest.entity }}]
   {% endfor %}
-  // swiftlint:enable implicitly_unwrapped_optional
+  // swiftlint:enable implicitly_unwrapped_optional discouraged_optional_boolean
 }
 
 {% for relationship in entity.relationships %}

--- a/templates/coredata/swift4.stencil
+++ b/templates/coredata/swift4.stencil
@@ -52,7 +52,7 @@ import Foundation
     }
   }
   {% else %}
-  @NSManaged {{ accessModifier }} var {{ attribute.name }}: {{ attribute.typeName }}{% if attribute.usesScalarValueType == false %}{% if attribute.isOptional %}?{% else %}!{% endif %}{% endif %}
+  @NSManaged {{ accessModifier }} var {{ attribute.name }}: {{ attribute.typeName }}{% if attribute.isOptional %}?{% endif %}
   {% endif %}
   {% endfor %}
   {% for relationship in entity.relationships %}

--- a/templates/coredata/swift4.stencil
+++ b/templates/coredata/swift4.stencil
@@ -57,7 +57,7 @@ import Foundation
   {% endfor %}
   {% for relationship in entity.relationships %}
   {% if relationship.isToMany %}
-  @NSManaged {{ accessModifier }} var {{ relationship.name }}: {% if relationship.isOrdered %}NSOrderedSet{% else %}Set<{{ model.entities[relationship.destinationEntity].className | default:"NSManagedObject" }}>{% endif %}
+  @NSManaged {{ accessModifier }} var {{ relationship.name }}: {% if relationship.isOrdered %}NSOrderedSet{% else %}Set<{{ model.entities[relationship.destinationEntity].className | default:"NSManagedObject" }}>{% endif %}{% if relationship.isOptional %}?{% endif %}
   {% else %}
   @NSManaged {{ accessModifier }} var {{ relationship.name }}: {{ model.entities[relationship.destinationEntity].className | default:"NSManagedObject" }}{% if relationship.isOptional %}?{% endif %}
   {% endif %}
@@ -68,8 +68,7 @@ import Foundation
   // swiftlint:enable discouraged_optional_boolean
 }
 
-{% for relationship in entity.relationships %}
-{% if relationship.isToMany %}
+{% for relationship in entity.relationships where relationship.isToMany %}
 {% set destinationEntityClassName %}{{ model.entities[relationship.destinationEntity].className | default:"NSManagedObject" }}{% endset %}
 {% set collectionClassName %}{% if relationship.isOrdered %}NSOrderedSet{% else %}Set<{{ destinationEntityClassName }}>{% endif %}{% endset %}
 {% set relationshipName %}{{ relationship.name | upperFirstLetter }}{% endset %}
@@ -109,7 +108,6 @@ extension {{ entityClassName }} {
   @NSManaged public func removeFrom{{ relationshipName }}(_ values: {{ collectionClassName }})
 }
 
-{% endif %}
 {% endfor %}
 {% if model.fetchRequests[entity.name].count > 0 %}
 // MARK: Fetch Requests


### PR DESCRIPTION
Closes #565.

Implements the changes discussed in #565, to correctly handle optional scalar attributes in a swifty way.