### PR TITLE
Filter input files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ _None_
 * Expand environment variables in YAML files.  
   [Wolfgang Lutz](https://github.com/lutzifer)
   [#355](https://github.com/SwiftGen/SwiftGen/issues/#355)
+* Each command now accepts a `filter` option, which accepts a regular expression for filtering input paths. The filter is applied to individual paths as well as when the command recurses into directories.  
+  [David Jennes](https://github.com/djbe)
+  [#383](https://github.com/SwiftGen/SwiftGen/issues/383)
+  [#570](https://github.com/SwiftGen/SwiftGen/pull/570)
 
 ### Bug Fixes
 

--- a/Documentation/ConfigFile.md
+++ b/Documentation/ConfigFile.md
@@ -14,7 +14,8 @@ The configuration file is a YAML file structured like this (example):
 input_dir: Sources/Resources
 output_dir: Sources/Generated/
 strings:
-  inputs: Base.lproj/Localizable.strings
+  inputs: Base.lproj
+  filter: .*\.strings
   outputs:
     - templateName: structured-swift4
       output: L10n-Constants.swift
@@ -61,6 +62,7 @@ Each key corresponding to a SwiftGen subcommands (`colors`, `coredata`, `fonts`,
 | Subkey | Type | Description |
 |--------|------|-------------|
 | `inputs` | Path or Array of Paths | The file(s)/dir(s) to parse (e.g. the path to your assets catalog for the `xcassets` command, or your `Localizable.strings` file for the `strings` command, etc). |
+| `filter` | Regular Expression | The regular expression to apply to each input path, only paths matching the given filter will be used. Note that each command has a default built-in filter, which you can override with this option. |
 | `outputs` | Array | A list of output descriptions, composed of a template and a file output. |
 | `paths` | Path or Array of Paths | **Deprecated** The file(s)/dir(s) to parse (e.g. the path to your assets catalog for the `xcassets` command, or your `Localizable.strings` file for the `strings` command, etc). |
 | `templateName` | String | **Deprecated** The name of the template to use. If you provide a value for this, you shouldn't also provide a value for `templatePath`. |

--- a/Documentation/ConfigFile.md
+++ b/Documentation/ConfigFile.md
@@ -62,7 +62,7 @@ Each key corresponding to a SwiftGen subcommands (`colors`, `coredata`, `fonts`,
 | Subkey | Type | Description |
 |--------|------|-------------|
 | `inputs` | Path or Array of Paths | The file(s)/dir(s) to parse (e.g. the path to your assets catalog for the `xcassets` command, or your `Localizable.strings` file for the `strings` command, etc). |
-| `filter` | Regular Expression | The regular expression to apply to each input path, only paths matching the given filter will be used. Note that each command has a default built-in filter, which you can override with this option. |
+| `filter` | Regular Expression | The regular expression to apply to each input path, only paths matching the given filter will be used. Filters are applied to actual (relative) paths, not just the filename. Note that each command has a default built-in filter, which you can override with this option. |
 | `outputs` | Array | A list of output descriptions, composed of a template and a file output. |
 | `paths` | Path or Array of Paths | **Deprecated** The file(s)/dir(s) to parse (e.g. the path to your assets catalog for the `xcassets` command, or your `Localizable.strings` file for the `strings` command, etc). |
 | `templateName` | String | **Deprecated** The name of the template to use. If you provide a value for this, you shouldn't also provide a value for `templatePath`. |
@@ -70,7 +70,7 @@ Each key corresponding to a SwiftGen subcommands (`colors`, `coredata`, `fonts`,
 | `output` | Path | **Deprecated** The path of the output file to generate. _(Note: Any intermediate directory up to this file must already exist.)_ |
 | `params` | Dictionary | **Deprecated** Any optional parameter you want to pass to the template (similarly to `--param` in the CLI). |
 
-> 💡 Note: For custom filters, use `.+` to match multiple characters (at least one), and don't forget to escape the dot (`\.`) if you want to match a literal dot like for an extension. Add `$` at the end to ensure the path ends with the extension you want. For example, use `.+\.xib$` to match files with a `.xib` extension. Use a tool such as [RegExr](https://regexr.com) to ensure you're using a valid regular expression.
+> 💡 Note: For custom filters, use `.+` to match multiple characters (at least one), and don't forget to escape the dot (`\.`) if you want to match a literal dot like for an extension. Add `$` at the end to ensure the path ends with the extension you want. Regular expressions will be case sensitive by default, and not anchored to the start/end of a path. For example, use `.+\.xib$` to match files with a `.xib` extension. Use a tool such as [RegExr](https://regexr.com) to ensure you're using a valid regular expression.
 
 The `outputs` parameter accepts either a dictionary, or an array of dictionaries, with the keys described below. Each such "output" will take the input files, and use the output template to generate a file at the given output path. This allows you to generate multiple outputs for the same input files (which will only be parsed once).
 

--- a/Documentation/ConfigFile.md
+++ b/Documentation/ConfigFile.md
@@ -15,7 +15,7 @@ input_dir: Sources/Resources
 output_dir: Sources/Generated/
 strings:
   inputs: Base.lproj
-  filter: .*\.strings
+  filter: .+\.strings$
   outputs:
     - templateName: structured-swift4
       output: L10n-Constants.swift
@@ -36,7 +36,7 @@ xcassets:
 
 ℹ️ All _relative_ paths specified in the configuration file (`input_dir`, `output_dir`, `inputs`, `templatePath`, `output`) are relative to the location of the _configuration file_ itself.
 
-> 💡 We advise against using _absolute_ paths — starting with `/` — in the configuration file, so that they won't rely on where the project was cloned on your machine._
+> 💡 We advise against using _absolute_ paths — starting with `/` — in the configuration file, so that they won't rely on where the project was cloned on your machine.
 
 Here's a quick description of all the possible _root_ keys. All of them are optional.
 
@@ -69,6 +69,8 @@ Each key corresponding to a SwiftGen subcommands (`colors`, `coredata`, `fonts`,
 | `templatePath` | Path | **Deprecated** The path to the template to use. If you provide a value for this, you shouldn't also provide a value for `templateName`. |
 | `output` | Path | **Deprecated** The path of the output file to generate. _(Note: Any intermediate directory up to this file must already exist.)_ |
 | `params` | Dictionary | **Deprecated** Any optional parameter you want to pass to the template (similarly to `--param` in the CLI). |
+
+> 💡 Note: For custom filters, use `.+` to match multiple characters (at least one), and don't forget to escape the dot (`\.`) if you want to match a literal dot like for an extension. Add `$` at the end to ensure the path ends with the extension you want. For example, use `.+\.xib$` to match files with a `.xib` extension.
 
 The `outputs` parameter accepts either a dictionary, or an array of dictionaries, with the keys described below. Each such "output" will take the input files, and use the output template to generate a file at the given output path. This allows you to generate multiple outputs for the same input files (which will only be parsed once).
 

--- a/Documentation/ConfigFile.md
+++ b/Documentation/ConfigFile.md
@@ -70,7 +70,7 @@ Each key corresponding to a SwiftGen subcommands (`colors`, `coredata`, `fonts`,
 | `output` | Path | **Deprecated** The path of the output file to generate. _(Note: Any intermediate directory up to this file must already exist.)_ |
 | `params` | Dictionary | **Deprecated** Any optional parameter you want to pass to the template (similarly to `--param` in the CLI). |
 
-> 💡 Note: For custom filters, use `.+` to match multiple characters (at least one), and don't forget to escape the dot (`\.`) if you want to match a literal dot like for an extension. Add `$` at the end to ensure the path ends with the extension you want. For example, use `.+\.xib$` to match files with a `.xib` extension.
+> 💡 Note: For custom filters, use `.+` to match multiple characters (at least one), and don't forget to escape the dot (`\.`) if you want to match a literal dot like for an extension. Add `$` at the end to ensure the path ends with the extension you want. For example, use `.+\.xib$` to match files with a `.xib` extension. Use a tool such as [RegExr](https://regexr.com) to ensure you're using a valid regular expression.
 
 The `outputs` parameter accepts either a dictionary, or an array of dictionaries, with the keys described below. Each such "output" will take the input files, and use the output template to generate a file at the given output path. This allows you to generate multiple outputs for the same input files (which will only be parsed once).
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,8 @@ To use SwiftGen, simply create a `swiftgen.yml` YAML file to list all the subcom
 
 ```yaml
 strings:
-  inputs: Resources/Base.lproj/Localizable.strings
+  inputs: Resources/Base.lproj
+  filter: Localizable.*\.strings
   outputs:
     - templateName: structured-swift4
       output: Generated/strings.swift
@@ -223,6 +224,7 @@ Each subcommand generally accepts the same options and syntax, and they mirror t
 * `--templateName NAME` or `-n NAME`: define the Stencil template to use (by name, see [here for more info](Documentation/templates)) to generate the output.
 * `--templatePath PATH` or `-p PATH`: define the Stencil template to use, using a full path.
 * Note: you should specify one and only one template when invoking SwiftGen. You have to use either `-t` or `-p` but should not use both at the same time (it wouldn't make sense anyway and you'll get an error if you try)
+* `--filter REGEX` or `-f REGEX`: the filter to apply to each input path. Each command has a default filter that you can override with this option.
 * Each command supports multiple input files (or directories where applicable).
 * You can always use the `--help` flag to see what options a command accept, e.g. `swiftgen xcassets --help`.
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ To use SwiftGen, simply create a `swiftgen.yml` YAML file to list all the subcom
 ```yaml
 strings:
   inputs: Resources/Base.lproj
-  filter: Localizable.*\.strings
+  filter: .*\.strings
   outputs:
     - templateName: structured-swift4
       output: Generated/strings.swift
@@ -225,6 +225,7 @@ Each subcommand generally accepts the same options and syntax, and they mirror t
 * `--templatePath PATH` or `-p PATH`: define the Stencil template to use, using a full path.
 * Note: you should specify one and only one template when invoking SwiftGen. You have to use either `-t` or `-p` but should not use both at the same time (it wouldn't make sense anyway and you'll get an error if you try)
 * `--filter REGEX` or `-f REGEX`: the filter to apply to each input path. Each command has a default filter that you can override with this option.
+* Note: use `.*` to match any characters, and don't forget to escape the dot (`\.`) if you want to match a literal dot like for an extension. For example, use `.*\.xib` to match files with a `.xib` extension.
 * Each command supports multiple input files (or directories where applicable).
 * You can always use the `--help` flag to see what options a command accept, e.g. `swiftgen xcassets --help`.
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Each subcommand generally accepts the same options and syntax, and they mirror t
 * `--templatePath PATH` or `-p PATH`: define the Stencil template to use, using a full path.
 * Note: you should specify one and only one template when invoking SwiftGen. You have to use either `-t` or `-p` but should not use both at the same time (it wouldn't make sense anyway and you'll get an error if you try)
 * `--filter REGEX` or `-f REGEX`: the filter to apply to each input path. Each command has a default filter that you can override with this option.
-* Note: use `.+` to match multiple characters (at least one), and don't forget to escape the dot (`\.`) if you want to match a literal dot like for an extension. Add `$` at the end to ensure the path ends with the extension you want. For example, use `.+\.xib$` to match files with a `.xib` extension.
+* Note: use `.+` to match multiple characters (at least one), and don't forget to escape the dot (`\.`) if you want to match a literal dot like for an extension. Add `$` at the end to ensure the path ends with the extension you want. For example, use `.+\.xib$` to match files with a `.xib` extension. Use a tool such as [RegExr](https://regexr.com) to ensure you're using a valid regular expression.
 * Each command supports multiple input files (or directories where applicable).
 * You can always use the `--help` flag to see what options a command accept, e.g. `swiftgen xcassets --help`.
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ To use SwiftGen, simply create a `swiftgen.yml` YAML file to list all the subcom
 ```yaml
 strings:
   inputs: Resources/Base.lproj
-  filter: .*\.strings
+  filter: .+\.strings$
   outputs:
     - templateName: structured-swift4
       output: Generated/strings.swift
@@ -225,7 +225,7 @@ Each subcommand generally accepts the same options and syntax, and they mirror t
 * `--templatePath PATH` or `-p PATH`: define the Stencil template to use, using a full path.
 * Note: you should specify one and only one template when invoking SwiftGen. You have to use either `-t` or `-p` but should not use both at the same time (it wouldn't make sense anyway and you'll get an error if you try)
 * `--filter REGEX` or `-f REGEX`: the filter to apply to each input path. Each command has a default filter that you can override with this option.
-* Note: use `.*` to match any characters, and don't forget to escape the dot (`\.`) if you want to match a literal dot like for an extension. For example, use `.*\.xib` to match files with a `.xib` extension.
+* Note: use `.+` to match multiple characters (at least one), and don't forget to escape the dot (`\.`) if you want to match a literal dot like for an extension. Add `$` at the end to ensure the path ends with the extension you want. For example, use `.+\.xib$` to match files with a `.xib` extension.
 * Each command supports multiple input files (or directories where applicable).
 * You can always use the `--help` flag to see what options a command accept, e.g. `swiftgen xcassets --help`.
 

--- a/README.md
+++ b/README.md
@@ -224,8 +224,8 @@ Each subcommand generally accepts the same options and syntax, and they mirror t
 * `--templateName NAME` or `-n NAME`: define the Stencil template to use (by name, see [here for more info](Documentation/templates)) to generate the output.
 * `--templatePath PATH` or `-p PATH`: define the Stencil template to use, using a full path.
 * Note: you should specify one and only one template when invoking SwiftGen. You have to use either `-t` or `-p` but should not use both at the same time (it wouldn't make sense anyway and you'll get an error if you try)
-* `--filter REGEX` or `-f REGEX`: the filter to apply to each input path. Each command has a default filter that you can override with this option.
-* Note: use `.+` to match multiple characters (at least one), and don't forget to escape the dot (`\.`) if you want to match a literal dot like for an extension. Add `$` at the end to ensure the path ends with the extension you want. For example, use `.+\.xib$` to match files with a `.xib` extension. Use a tool such as [RegExr](https://regexr.com) to ensure you're using a valid regular expression.
+* `--filter REGEX` or `-f REGEX`: the filter to apply to each input path. Filters are applied to actual (relative) paths, not just the filename. Each command has a default filter that you can override with this option.
+* Note: use `.+` to match multiple characters (at least one), and don't forget to escape the dot (`\.`) if you want to match a literal dot like for an extension. Add `$` at the end to ensure the path ends with the extension you want. Regular expressions will be case sensitive by default, and not anchored to the start/end of a path. For example, use `.+\.xib$` to match files with a `.xib` extension. Use a tool such as [RegExr](https://regexr.com) to ensure you're using a valid regular expression.
 * Each command supports multiple input files (or directories where applicable).
 * You can always use the `--help` flag to see what options a command accept, e.g. `swiftgen xcassets --help`.
 

--- a/Sources/SwiftGen/Commander/ConfigCommands.swift
+++ b/Sources/SwiftGen/Commander/ConfigCommands.swift
@@ -33,7 +33,8 @@ extension ConfigEntry {
     let parser = try parserCommand.parserType.init(options: [:]) { msg, _, _ in
       logMessage(.warning, msg)
     }
-    try parser.parse(paths: self.inputs)
+    let filter = try Filter(pattern: self.filter ?? parserCommand.parserType.defaultFilter)
+    try parser.searchAndParse(paths: inputs, filter: filter)
     let context = parser.stencilContext()
 
     for entryOutput in outputs {

--- a/Sources/SwiftGen/Config/ConfigEntry.swift
+++ b/Sources/SwiftGen/Config/ConfigEntry.swift
@@ -15,6 +15,7 @@ import PathKit
 struct ConfigEntry {
   enum Keys {
     static let inputs = "inputs"
+    static let filter = "filter"
     static let outputs = "outputs"
 
     // Legacy: remove this once we stop supporting the output key at subcommand level
@@ -27,6 +28,7 @@ struct ConfigEntry {
   }
 
   var inputs: [Path]
+  var filter: String?
   var outputs: [ConfigEntryOutput]
 
   mutating func makingRelativeTo(inputDir: Path?, outputDir: Path?) {
@@ -56,6 +58,8 @@ extension ConfigEntry {
     } else {
       throw Config.Error.missingEntry(key: Keys.inputs)
     }
+
+    filter = yaml[Keys.filter] as? String
 
     if let outputs = yaml[Keys.outputs] {
       do {
@@ -111,7 +115,7 @@ extension ConfigEntry {
 extension ConfigEntry {
   func commandLine(forCommand cmd: String) -> [String] {
     return outputs.map {
-      $0.commandLine(forCommand: cmd, inputs: inputs)
+      $0.commandLine(forCommand: cmd, inputs: inputs, filter: filter)
     }
   }
 }

--- a/Sources/SwiftGen/Config/ConfigOutput.swift
+++ b/Sources/SwiftGen/Config/ConfigOutput.swift
@@ -55,8 +55,8 @@ extension ConfigEntryOutput {
   func commandLine(forCommand cmd: String, inputs: [Path], filter: String?) -> String {
     let tplFlag: String = {
       switch self.template {
-      case .name(let name): return "-t \(name)"
-      case .path(let path): return "-p \(path.string)"
+      case .name(let name): return "--templateName \(name)"
+      case .path(let path): return "--templatePath \(path.string)"
       }
     }()
     let filterFlag = filter.map { "--filter \($0)" } ?? ""
@@ -67,7 +67,7 @@ extension ConfigEntryOutput {
       cmd,
       tplFlag,
       params.map { "--param \($0)" }.joined(separator: " "),
-      "-o \(self.output)",
+      "--output \(self.output)",
       filterFlag,
       inputs.map { $0.string }.joined(separator: " ")
     ].filter { !$0.isEmpty }.joined(separator: " ")

--- a/Sources/SwiftGen/Config/ConfigOutput.swift
+++ b/Sources/SwiftGen/Config/ConfigOutput.swift
@@ -52,13 +52,14 @@ extension ConfigEntryOutput {
 /// Convert to CommandLine-equivalent string (for verbose mode, printing linting info, …)
 ///
 extension ConfigEntryOutput {
-  func commandLine(forCommand cmd: String, inputs: [Path]) -> String {
+  func commandLine(forCommand cmd: String, inputs: [Path], filter: String?) -> String {
     let tplFlag: String = {
       switch self.template {
       case .name(let name): return "-t \(name)"
       case .path(let path): return "-p \(path.string)"
       }
     }()
+    let filterFlag = filter.map { "--filter \($0)" } ?? ""
     let params = Parameters.flatten(dictionary: self.parameters)
 
     return [
@@ -67,6 +68,7 @@ extension ConfigEntryOutput {
       tplFlag,
       params.map { "--param \($0)" }.joined(separator: " "),
       "-o \(self.output)",
+      filterFlag,
       inputs.map { $0.string }.joined(separator: " ")
     ].filter { !$0.isEmpty }.joined(separator: " ")
   }

--- a/Sources/SwiftGen/Config/ConfigOutput.swift
+++ b/Sources/SwiftGen/Config/ConfigOutput.swift
@@ -53,7 +53,7 @@ extension ConfigEntryOutput {
 ///
 extension ConfigEntryOutput {
   func commandLine(forCommand cmd: String, inputs: [Path], filter: String?) -> String {
-    let tplFlag: String = {
+    let templateFlag: String = {
       switch self.template {
       case .name(let name): return "--templateName \(name)"
       case .path(let path): return "--templatePath \(path.string)"
@@ -65,7 +65,7 @@ extension ConfigEntryOutput {
     return [
       "swiftgen",
       cmd,
-      tplFlag,
+      templateFlag,
       params.map { "--param \($0)" }.joined(separator: " "),
       "--output \(self.output)",
       filterFlag,

--- a/Sources/SwiftGen/ParserCLI.swift
+++ b/Sources/SwiftGen/ParserCLI.swift
@@ -55,7 +55,7 @@ let allParserCommands: [ParserCLI] = [
     pathDescription: "Directory to scan for .storyboard files. Can also be a path to a single .storyboard"
   ),
   .init(
-    parserType: Yaml.Parser.self,
+    parserType: JSON.Parser.self,
     name: "json",
     description: "generate code for custom json configuration files",
     pathDescription: "JSON files (or directories that contain them) to parse."

--- a/Sources/SwiftGenKit/Parsers/AssetsCatalog/AssetsCatalogParser.swift
+++ b/Sources/SwiftGenKit/Parsers/AssetsCatalog/AssetsCatalogParser.swift
@@ -8,17 +8,6 @@ import Foundation
 import PathKit
 
 public enum AssetsCatalog {
-  public enum ParserError: Swift.Error, CustomStringConvertible {
-    case invalidFile
-
-    public var description: String {
-      switch self {
-      case .invalidFile:
-        return "error: File must be an asset catalog"
-      }
-    }
-  }
-
   public final class Parser: SwiftGenKit.Parser {
     var catalogs = [Catalog]()
     public var warningHandler: Parser.MessageHandler?

--- a/Sources/SwiftGenKit/Parsers/AssetsCatalog/AssetsCatalogParser.swift
+++ b/Sources/SwiftGenKit/Parsers/AssetsCatalog/AssetsCatalogParser.swift
@@ -19,10 +19,6 @@ public enum AssetsCatalog {
     }
   }
 
-  private enum Constants {
-    static let `extension` = "xcassets"
-  }
-
   public final class Parser: SwiftGenKit.Parser {
     var catalogs = [Catalog]()
     public var warningHandler: Parser.MessageHandler?
@@ -31,11 +27,9 @@ public enum AssetsCatalog {
       self.warningHandler = warningHandler
     }
 
-    public func parse(path: Path) throws {
-      guard path.extension == Constants.extension else {
-        throw ParserError.invalidFile
-      }
+    public static let defaultFilter = ".*\\.xcassets"
 
+    public func parse(path: Path, relativeTo parent: Path) throws {
       let catalog = Catalog(path: path)
       catalogs += [catalog]
     }

--- a/Sources/SwiftGenKit/Parsers/AssetsCatalog/AssetsCatalogParser.swift
+++ b/Sources/SwiftGenKit/Parsers/AssetsCatalog/AssetsCatalogParser.swift
@@ -16,7 +16,7 @@ public enum AssetsCatalog {
       self.warningHandler = warningHandler
     }
 
-    public static let defaultFilter = ".+\\.xcassets$"
+    public static let defaultFilter = "[^/]\\.xcassets$"
 
     public func parse(path: Path, relativeTo parent: Path) throws {
       let catalog = Catalog(path: path)

--- a/Sources/SwiftGenKit/Parsers/AssetsCatalog/AssetsCatalogParser.swift
+++ b/Sources/SwiftGenKit/Parsers/AssetsCatalog/AssetsCatalogParser.swift
@@ -16,7 +16,7 @@ public enum AssetsCatalog {
       self.warningHandler = warningHandler
     }
 
-    public static let defaultFilter = ".*\\.xcassets"
+    public static let defaultFilter = ".+\\.xcassets$"
 
     public func parse(path: Path, relativeTo parent: Path) throws {
       let catalog = Catalog(path: path)

--- a/Sources/SwiftGenKit/Parsers/Colors/ColorsParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Colors/ColorsParser.swift
@@ -56,7 +56,7 @@ public enum Colors {
 
     public func parse(path: Path, relativeTo parent: Path) throws {
       guard let parserType = parsers[path.extension?.lowercased() ?? ""] else {
-        throw ParserError.unsupportedFileType(path: path, supported: Array(parsers.keys.sorted()))
+        throw ParserError.unsupportedFileType(path: path, supported: parsers.keys.sorted())
       }
 
       let parser = parserType.init()

--- a/Sources/SwiftGenKit/Parsers/Colors/ColorsParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Colors/ColorsParser.swift
@@ -51,7 +51,7 @@ public enum Colors {
 
     public static var defaultFilter: String {
       let extensions = Parser.subParsers.flatMap { $0.extensions }.sorted().joined(separator: "|")
-      return ".+\\.(?i:\(extensions))$"
+      return "[^/]\\.(?i:\(extensions))$"
     }
 
     public func parse(path: Path, relativeTo parent: Path) throws {

--- a/Sources/SwiftGenKit/Parsers/Colors/ColorsParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Colors/ColorsParser.swift
@@ -51,7 +51,7 @@ public enum Colors {
 
     public static var defaultFilter: String {
       let extensions = Parser.subParsers.flatMap { $0.extensions }.sorted().joined(separator: "|")
-      return ".*\\.(?i:\(extensions))"
+      return ".+\\.(?i:\(extensions))$"
     }
 
     public func parse(path: Path, relativeTo parent: Path) throws {

--- a/Sources/SwiftGenKit/Parsers/CoreData/CoreDataParser.swift
+++ b/Sources/SwiftGenKit/Parsers/CoreData/CoreDataParser.swift
@@ -39,7 +39,7 @@ public enum CoreData {
       self.warningHandler = warningHandler
     }
 
-    public static let defaultFilter = ".*\\.xcdatamodeld?"
+    public static let defaultFilter = ".+\\.xcdatamodeld?$"
 
     public func parse(path: Path, relativeTo parent: Path) throws {
       if path.extension == Constants.modelBundleExtension {

--- a/Sources/SwiftGenKit/Parsers/CoreData/CoreDataParser.swift
+++ b/Sources/SwiftGenKit/Parsers/CoreData/CoreDataParser.swift
@@ -39,7 +39,7 @@ public enum CoreData {
       self.warningHandler = warningHandler
     }
 
-    public static let defaultFilter = ".+\\.xcdatamodeld?$"
+    public static let defaultFilter = "[^/]\\.xcdatamodeld?$"
 
     public func parse(path: Path, relativeTo parent: Path) throws {
       if path.extension == Constants.modelBundleExtension {

--- a/Sources/SwiftGenKit/Parsers/Filter.swift
+++ b/Sources/SwiftGenKit/Parsers/Filter.swift
@@ -39,7 +39,7 @@ extension Path {
   /// - Parameter filter: The regular expression to match
   /// - Returns: true if it matches
   func matches(filter: Filter) -> Bool {
-    let range = NSRange(location: 0, length: string.utf16.count)
+    let range = NSRange(string.startIndex..<string.endIndex, in: string)
     return filter.regex.firstMatch(in: string, options: [], range: range) != nil
   }
 }

--- a/Sources/SwiftGenKit/Parsers/Filter.swift
+++ b/Sources/SwiftGenKit/Parsers/Filter.swift
@@ -1,7 +1,7 @@
 //
 // SwiftGenKit
 // Copyright © 2019 SwiftGen
-// MIT License
+// MIT Licence
 //
 
 import Foundation

--- a/Sources/SwiftGenKit/Parsers/Filter.swift
+++ b/Sources/SwiftGenKit/Parsers/Filter.swift
@@ -1,0 +1,45 @@
+//
+// SwiftGenKit
+// Copyright © 2019 SwiftGen
+// MIT License
+//
+
+import Foundation
+import PathKit
+
+public struct Filter {
+  public enum Error: Swift.Error, CustomStringConvertible {
+    case invalidRegex(pattern: String)
+
+    public var description: String {
+      switch self {
+      case .invalidRegex(let pattern):
+        return "error: Unable to parse regular expression '\(pattern)'."
+      }
+    }
+  }
+
+  fileprivate let regex: NSRegularExpression
+
+  /// Creates a filter with the given pattern, must be a valid regular expression.
+  ///
+  /// - Parameter pattern: The regular expression provided by the user
+  public init(pattern: String) throws {
+    do {
+      regex = try NSRegularExpression(pattern: pattern, options: [])
+    } catch {
+      throw Error.invalidRegex(pattern: pattern)
+    }
+  }
+}
+
+extension Path {
+  /// Checks if this path matches the given filter (regular expression).
+  ///
+  /// - Parameter filter: The regular expression to match
+  /// - Returns: true if it matches
+  func matches(filter: Filter) -> Bool {
+    let range = NSRange(location: 0, length: string.utf16.count)
+    return filter.regex.firstMatch(in: string, options: [], range: range) != nil
+  }
+}

--- a/Sources/SwiftGenKit/Parsers/Fonts/FontsParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Fonts/FontsParser.swift
@@ -17,7 +17,7 @@ public enum Fonts {
       self.warningHandler = warningHandler
     }
 
-    public static let defaultFilter = ".+\\.(?i:otf|ttc|ttf)$"
+    public static let defaultFilter = "[^/]\\.(?i:otf|ttc|ttf)$"
 
     public func parse(path: Path, relativeTo parent: Path) throws {
       guard let values = try? path.url.resourceValues(forKeys: [.typeIdentifierKey]),

--- a/Sources/SwiftGenKit/Parsers/Fonts/FontsParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Fonts/FontsParser.swift
@@ -17,7 +17,7 @@ public enum Fonts {
       self.warningHandler = warningHandler
     }
 
-    public static let defaultFilter = ".*\\.(?i:otf|ttc|ttf)"
+    public static let defaultFilter = ".+\\.(?i:otf|ttc|ttf)$"
 
     public func parse(path: Path, relativeTo parent: Path) throws {
       guard let values = try? path.url.resourceValues(forKeys: [.typeIdentifierKey]),

--- a/Sources/SwiftGenKit/Parsers/InterfaceBuilder/InterfaceBuilderParser.swift
+++ b/Sources/SwiftGenKit/Parsers/InterfaceBuilder/InterfaceBuilderParser.swift
@@ -31,16 +31,10 @@ public enum InterfaceBuilder {
       self.warningHandler = warningHandler
     }
 
-    public func parse(path: Path) throws {
-      if path.extension == "storyboard" {
-        try addStoryboard(at: path)
-      } else {
-        let dirChildren = path.iterateChildren(options: [.skipsHiddenFiles, .skipsPackageDescendants])
+    public static let defaultFilter = ".*\\.storyboard"
 
-        for file in dirChildren where file.extension == "storyboard" {
-          try addStoryboard(at: file)
-        }
-      }
+    public func parse(path: Path, relativeTo parent: Path) throws {
+      try addStoryboard(at: path)
     }
 
     func addStoryboard(at path: Path) throws {

--- a/Sources/SwiftGenKit/Parsers/InterfaceBuilder/InterfaceBuilderParser.swift
+++ b/Sources/SwiftGenKit/Parsers/InterfaceBuilder/InterfaceBuilderParser.swift
@@ -31,7 +31,7 @@ public enum InterfaceBuilder {
       self.warningHandler = warningHandler
     }
 
-    public static let defaultFilter = ".+\\.storyboard$"
+    public static let defaultFilter = "[^/]\\.storyboard$"
 
     public func parse(path: Path, relativeTo parent: Path) throws {
       try addStoryboard(at: path)

--- a/Sources/SwiftGenKit/Parsers/InterfaceBuilder/InterfaceBuilderParser.swift
+++ b/Sources/SwiftGenKit/Parsers/InterfaceBuilder/InterfaceBuilderParser.swift
@@ -31,7 +31,7 @@ public enum InterfaceBuilder {
       self.warningHandler = warningHandler
     }
 
-    public static let defaultFilter = ".*\\.storyboard"
+    public static let defaultFilter = ".+\\.storyboard$"
 
     public func parse(path: Path, relativeTo parent: Path) throws {
       try addStoryboard(at: path)

--- a/Sources/SwiftGenKit/Parsers/Plist/PlistParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Plist/PlistParser.swift
@@ -29,27 +29,10 @@ public enum Plist {
       self.warningHandler = warningHandler
     }
 
-    enum SupportedTypes {
-      static let plist = "plist"
-      static let all = [plist]
+    public static let defaultFilter = ".*\\.(?i:plist)"
 
-      static func supports(extension: String) -> Bool {
-        return all.contains { $0.caseInsensitiveCompare(`extension`) == .orderedSame }
-      }
-    }
-
-    public func parse(path: Path) throws {
-      if path.isFile {
-        let parentDir = path.absolute().parent()
-        files.append(try File(path: path, relativeTo: parentDir))
-      } else {
-        let dirChildren = path.iterateChildren(options: [.skipsHiddenFiles, .skipsPackageDescendants])
-        let parentDir = path.absolute()
-
-        for file in dirChildren where SupportedTypes.supports(extension: file.extension ?? "") {
-          files.append(try File(path: file, relativeTo: parentDir))
-        }
-      }
+    public func parse(path: Path, relativeTo parent: Path) throws {
+      files.append(try File(path: path, relativeTo: parent))
     }
   }
 }

--- a/Sources/SwiftGenKit/Parsers/Plist/PlistParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Plist/PlistParser.swift
@@ -29,7 +29,7 @@ public enum Plist {
       self.warningHandler = warningHandler
     }
 
-    public static let defaultFilter = ".+\\.(?i:plist)$"
+    public static let defaultFilter = "[^/]\\.(?i:plist)$"
 
     public func parse(path: Path, relativeTo parent: Path) throws {
       files.append(try File(path: path, relativeTo: parent))

--- a/Sources/SwiftGenKit/Parsers/Plist/PlistParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Plist/PlistParser.swift
@@ -29,7 +29,7 @@ public enum Plist {
       self.warningHandler = warningHandler
     }
 
-    public static let defaultFilter = ".*\\.(?i:plist)"
+    public static let defaultFilter = ".+\\.(?i:plist)$"
 
     public func parse(path: Path, relativeTo parent: Path) throws {
       files.append(try File(path: path, relativeTo: parent))

--- a/Sources/SwiftGenKit/Parsers/Strings/StringsParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Strings/StringsParser.swift
@@ -36,8 +36,10 @@ public enum Strings {
       self.warningHandler = warningHandler
     }
 
+    public static let defaultFilter = ".*\\.strings"
+
     // Localizable.strings files are generally UTF16, not UTF8!
-    public func parse(path: Path) throws {
+    public func parse(path: Path, relativeTo parent: Path) throws {
       let name = path.lastComponentWithoutExtension
 
       guard tables[name] == nil else {

--- a/Sources/SwiftGenKit/Parsers/Strings/StringsParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Strings/StringsParser.swift
@@ -36,7 +36,7 @@ public enum Strings {
       self.warningHandler = warningHandler
     }
 
-    public static let defaultFilter = ".+\\.strings$"
+    public static let defaultFilter = "[^/]\\.strings$"
 
     // Localizable.strings files are generally UTF16, not UTF8!
     public func parse(path: Path, relativeTo parent: Path) throws {

--- a/Sources/SwiftGenKit/Parsers/Strings/StringsParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Strings/StringsParser.swift
@@ -36,7 +36,7 @@ public enum Strings {
       self.warningHandler = warningHandler
     }
 
-    public static let defaultFilter = ".*\\.strings"
+    public static let defaultFilter = ".+\\.strings$"
 
     // Localizable.strings files are generally UTF16, not UTF8!
     public func parse(path: Path, relativeTo parent: Path) throws {

--- a/Sources/SwiftGenKit/Parsers/Yaml/YamlParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Yaml/YamlParser.swift
@@ -22,37 +22,30 @@ public enum Yaml {
 
   // MARK: Yaml File Parser
 
-  public final class Parser: SwiftGenKit.Parser {
+  public class Parser: SwiftGenKit.Parser {
     var files: [File] = []
     public var warningHandler: Parser.MessageHandler?
 
-    public init(options: [String: Any] = [:], warningHandler: Parser.MessageHandler? = nil) {
+    public required init(options: [String: Any] = [:], warningHandler: Parser.MessageHandler? = nil) {
       self.warningHandler = warningHandler
     }
 
-    enum SupportedTypes {
-      static let json = "json"
-      static let yaml = "yaml"
-      static let yml = "yml"
-      static let all = [json, yaml, yml]
-
-      static func supports(extension: String) -> Bool {
-        return all.contains { $0.caseInsensitiveCompare(`extension`) == .orderedSame }
-      }
+    public class var defaultFilter: String {
+      return ".*\\.(?i:ya?ml)"
     }
 
-    public func parse(path: Path) throws {
-      if path.isFile {
-        let parentDir = path.absolute().parent()
-        files.append(try File(path: path, relativeTo: parentDir))
-      } else {
-        let dirChildren = path.iterateChildren(options: [.skipsHiddenFiles, .skipsPackageDescendants])
-        let parentDir = path.absolute()
+    public func parse(path: Path, relativeTo parent: Path) throws {
+      files.append(try File(path: path, relativeTo: parent))
+    }
+  }
+}
 
-        for file in dirChildren where SupportedTypes.supports(extension: file.extension ?? "") {
-          files.append(try File(path: file, relativeTo: parentDir))
-        }
-      }
+// MARK: JSON File Parser
+
+public enum JSON {
+  public final class Parser: Yaml.Parser {
+    override public static var defaultFilter: String {
+      return ".*\\.(?i:json)"
     }
   }
 }

--- a/Sources/SwiftGenKit/Parsers/Yaml/YamlParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Yaml/YamlParser.swift
@@ -31,7 +31,7 @@ public enum Yaml {
     }
 
     public class var defaultFilter: String {
-      return ".+\\.(?i:ya?ml)$"
+      return "[^/]\\.(?i:ya?ml)$"
     }
 
     public func parse(path: Path, relativeTo parent: Path) throws {

--- a/Sources/SwiftGenKit/Parsers/Yaml/YamlParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Yaml/YamlParser.swift
@@ -31,7 +31,7 @@ public enum Yaml {
     }
 
     public class var defaultFilter: String {
-      return ".*\\.(?i:ya?ml)"
+      return ".+\\.(?i:ya?ml)$"
     }
 
     public func parse(path: Path, relativeTo parent: Path) throws {
@@ -45,7 +45,7 @@ public enum Yaml {
 public enum JSON {
   public final class Parser: Yaml.Parser {
     override public static var defaultFilter: String {
-      return ".*\\.(?i:json)"
+      return ".*\\.(?i:json)$"
     }
   }
 }

--- a/Sources/SwiftGenKit/Utils/Path.swift
+++ b/Sources/SwiftGenKit/Utils/Path.swift
@@ -13,9 +13,9 @@ extension PathKit.Path {
   /// - Parameter parent: The parent Path to get the relative path against
   /// - Returns: The relative Path, or nil if parent was not a parent dir of self
   func relative(to parent: Path) -> Path? {
-    let parentComponents = parent.absolute().components
-    let currentComponents = self.absolute().components
-    return currentComponents.starts(with: parentComponents)
-      ? Path(components: currentComponents.dropFirst(parentComponents.count)) : nil
+    let parent = parent.absolute().components
+    let current = self.absolute().components
+
+    return current.starts(with: parent) ? Path(components: current.dropFirst(parent.count)) : nil
   }
 }

--- a/SwiftGen.xcodeproj/project.pbxproj
+++ b/SwiftGen.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		DD15F103213C40A000D081C7 /* PlistTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD15F102213C409F00D081C7 /* PlistTests.swift */; };
 		DD15F105213C412F00D081C7 /* JsonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD15F104213C412F00D081C7 /* JsonTests.swift */; };
 		DD15F107213C474600D081C7 /* YamlTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD15F106213C474600D081C7 /* YamlTests.swift */; };
+		DD2F4DE021DAE7E6002E9B8C /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD2F4DDF21DAE7E6002E9B8C /* Filter.swift */; };
 		DD2FA6BB2169401C0009CAA8 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD2FA6BA2169401C0009CAA8 /* Version.swift */; };
 		DD40284A209E56B50045FC76 /* config-with-multi-outputs.yml in Resources */ = {isa = PBXBuildFile; fileRef = DD402849209E56B50045FC76 /* config-with-multi-outputs.yml */; };
 		DD402850209FBF300045FC76 /* config-deprecated-paths.yml in Resources */ = {isa = PBXBuildFile; fileRef = DD40284D209FBF300045FC76 /* config-deprecated-paths.yml */; };
@@ -344,6 +345,7 @@
 		DD15F102213C409F00D081C7 /* PlistTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlistTests.swift; sourceTree = "<group>"; };
 		DD15F104213C412F00D081C7 /* JsonTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JsonTests.swift; sourceTree = "<group>"; };
 		DD15F106213C474600D081C7 /* YamlTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YamlTests.swift; sourceTree = "<group>"; };
+		DD2F4DDF21DAE7E6002E9B8C /* Filter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filter.swift; sourceTree = "<group>"; };
 		DD2FA6BA2169401C0009CAA8 /* Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
 		DD402849209E56B50045FC76 /* config-with-multi-outputs.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "config-with-multi-outputs.yml"; sourceTree = "<group>"; };
 		DD40284D209FBF300045FC76 /* config-deprecated-paths.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "config-deprecated-paths.yml"; sourceTree = "<group>"; };
@@ -609,13 +611,13 @@
 		C38E571320FF8F8F009C9C23 /* CoreData */ = {
 			isa = PBXGroup;
 			children = (
-				C38E571420FF8FB5009C9C23 /* CoreDataParser.swift */,
-				C33A1426210649A500D3CBA6 /* Configuration.swift */,
-				C350BE3720FFCD0F0043D7C5 /* Model.swift */,
-				C350BE3920FFCD750043D7C5 /* Entity.swift */,
-				C33A142821064E3400D3CBA6 /* FetchRequest.swift */,
-				C3BAC3C82112006000B6875A /* FetchedProperty.swift */,
 				C322627021012F42001AC9CD /* Attribute.swift */,
+				C33A1426210649A500D3CBA6 /* Configuration.swift */,
+				C38E571420FF8FB5009C9C23 /* CoreDataParser.swift */,
+				C350BE3920FFCD750043D7C5 /* Entity.swift */,
+				C3BAC3C82112006000B6875A /* FetchedProperty.swift */,
+				C33A142821064E3400D3CBA6 /* FetchRequest.swift */,
+				C350BE3720FFCD0F0043D7C5 /* Model.swift */,
 				C32262722101324E001AC9CD /* Relationship.swift */,
 				C3E39E4B2118EC58004B1CF9 /* UniquenessConstraints.swift */,
 				C3031AA021062C9A00BF00DE /* UserInfo.swift */,
@@ -660,6 +662,7 @@
 				DDB0B9A0209CE7CD00E467C2 /* Plist */,
 				DD9F68822095604E004EB720 /* Strings */,
 				DDB0B999209CE4A300E467C2 /* Yaml */,
+				DD2F4DDF21DAE7E6002E9B8C /* Filter.swift */,
 				DD428E0F1FC50FBF001649D6 /* Parser.swift */,
 			);
 			path = Parsers;
@@ -1409,6 +1412,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C3BAC3C92112006000B6875A /* FetchedProperty.swift in Sources */,
+				DD2F4DE021DAE7E6002E9B8C /* Filter.swift in Sources */,
 				DD9F688520956074004EB720 /* StringsEntry.swift in Sources */,
 				DD9F687A20955D51004EB720 /* CatalogEntry.swift in Sources */,
 				DD428E261FC50FBF001649D6 /* InterfaceBuilderContext.swift in Sources */,

--- a/SwiftGen.xcodeproj/project.pbxproj
+++ b/SwiftGen.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		C3E39E4C2118EC58004B1CF9 /* UniquenessConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3E39E4B2118EC58004B1CF9 /* UniquenessConstraints.swift */; };
 		C580E102337633038E486585 /* Pods_swiftgen_Templates_UnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8031AB7FD88D5F010179EDC /* Pods_swiftgen_Templates_UnitTests.framework */; };
 		DD112CBA2141675900B11A5D /* InterfaceBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD112CB92141675800B11A5D /* InterfaceBuilderTests.swift */; };
+		DD132AF321FE62C200A71960 /* FilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD132AF121FE628A00A71960 /* FilterTests.swift */; };
 		DD15F101213C3DDF00D081C7 /* YamsSerialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD15F100213C3DDF00D081C7 /* YamsSerialization.swift */; };
 		DD15F103213C40A000D081C7 /* PlistTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD15F102213C409F00D081C7 /* PlistTests.swift */; };
 		DD15F105213C412F00D081C7 /* JsonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD15F104213C412F00D081C7 /* JsonTests.swift */; };
@@ -341,6 +342,7 @@
 		C3E39E4B2118EC58004B1CF9 /* UniquenessConstraints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniquenessConstraints.swift; sourceTree = "<group>"; };
 		D662CF56C834C4E7CEA32364 /* Pods-SwiftGenKit-SwiftGenKit UnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftGenKit-SwiftGenKit UnitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftGenKit-SwiftGenKit UnitTests/Pods-SwiftGenKit-SwiftGenKit UnitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		DD112CB92141675800B11A5D /* InterfaceBuilderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterfaceBuilderTests.swift; sourceTree = "<group>"; };
+		DD132AF121FE628A00A71960 /* FilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterTests.swift; sourceTree = "<group>"; };
 		DD15F100213C3DDF00D081C7 /* YamsSerialization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = YamsSerialization.swift; sourceTree = "<group>"; };
 		DD15F102213C409F00D081C7 /* PlistTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlistTests.swift; sourceTree = "<group>"; };
 		DD15F104213C412F00D081C7 /* JsonTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JsonTests.swift; sourceTree = "<group>"; };
@@ -827,6 +829,7 @@
 				DDDE521B1FAF81BA004203BE /* ColorsTextFileTests.swift */,
 				DDDE51DF1FAF81B9004203BE /* ColorsXMLFileTests.swift */,
 				C34FEA112110D56800136871 /* CoreDataTests.swift */,
+				DD132AF121FE628A00A71960 /* FilterTests.swift */,
 				DDDE51DB1FAF81B9004203BE /* FontsTests.swift */,
 				DDDE521E1FAF81BA004203BE /* InterfaceBuilderiOSTests.swift */,
 				DDDE521C1FAF81BA004203BE /* InterfaceBuilderMacOSTests.swift */,
@@ -1492,6 +1495,7 @@
 				C34FEA132110D6EC00136871 /* CoreDataTests.swift in Sources */,
 				DDB0B9A6209CE7FC00E467C2 /* PlistTests.swift in Sources */,
 				DDDE52721FAF81BA004203BE /* TestsHelper.swift in Sources */,
+				DD132AF321FE62C200A71960 /* FilterTests.swift in Sources */,
 				DDDE523B1FAF81BA004203BE /* FontsTests.swift in Sources */,
 				DDDE523A1FAF81BA004203BE /* StringsTests.swift in Sources */,
 				DDDE52391FAF81BA004203BE /* StringParserTests.swift in Sources */,

--- a/Tests/Fixtures/Configs/config-with-params.yml
+++ b/Tests/Fixtures/Configs/config-with-params.yml
@@ -1,6 +1,7 @@
 output_dir: Common/Generated
 strings:
   inputs: Sources1/Folder
+  filter: .*\.strings
   outputs:
     templateName: structured-swift3
     output: strings.swift

--- a/Tests/SwiftGenKitTests/AssetCatalogTests.swift
+++ b/Tests/SwiftGenKitTests/AssetCatalogTests.swift
@@ -18,7 +18,7 @@ class AssetCatalogTests: XCTestCase {
 
   func testImages() throws {
     let parser = AssetsCatalog.Parser()
-    try parser.parse(path: Fixtures.path(for: "Images.xcassets", sub: .xcassets))
+    try parser.searchAndParse(path: Fixtures.path(for: "Images.xcassets", sub: .xcassets))
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "images", sub: .xcassets)
@@ -26,7 +26,7 @@ class AssetCatalogTests: XCTestCase {
 
   func testData() throws {
     let parser = AssetsCatalog.Parser()
-    try parser.parse(path: Fixtures.path(for: "Data.xcassets", sub: .xcassets))
+    try parser.searchAndParse(path: Fixtures.path(for: "Data.xcassets", sub: .xcassets))
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "data", sub: .xcassets)
@@ -34,7 +34,7 @@ class AssetCatalogTests: XCTestCase {
 
   func testColors() throws {
     let parser = AssetsCatalog.Parser()
-    try parser.parse(path: Fixtures.path(for: "Colors.xcassets", sub: .xcassets))
+    try parser.searchAndParse(path: Fixtures.path(for: "Colors.xcassets", sub: .xcassets))
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "colors", sub: .xcassets)
@@ -43,7 +43,7 @@ class AssetCatalogTests: XCTestCase {
   func testAll() throws {
     let parser = AssetsCatalog.Parser()
     let paths = ["Images.xcassets", "Colors.xcassets", "Data.xcassets"]
-    try parser.parse(paths: paths.map { Fixtures.path(for: $0, sub: .xcassets) })
+    try parser.searchAndParse(paths: paths.map { Fixtures.path(for: $0, sub: .xcassets) })
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "all", sub: .xcassets)

--- a/Tests/SwiftGenKitTests/ColorsTests.swift
+++ b/Tests/SwiftGenKitTests/ColorsTests.swift
@@ -44,7 +44,8 @@ class ColorParserTests: XCTestCase {
     parser.register(parser: TestFileParser1.self)
     parser.register(parser: TestFileParser2.self)
 
-    try parser.parse(path: "someFile.test1")
+    let filter = try Filter(pattern: ".*\\.(test1|test2)")
+    try parser.searchAndParse(path: "someFile.test1", filter: filter)
     XCTAssertEqual(parser.palettes.first?.name, "test1")
   }
 
@@ -54,7 +55,8 @@ class ColorParserTests: XCTestCase {
     parser.register(parser: TestFileParser2.self)
 
     do {
-      try parser.parse(path: "someFile.unknown")
+      let filter = try Filter(pattern: ".*\\.unknown")
+      try parser.searchAndParse(path: "someFile.unknown", filter: filter)
       XCTFail("Code did succeed while it was expected to fail for unknown extension")
     } catch Colors.ParserError.unsupportedFileType {
       // That's the expected exception we want to happen
@@ -81,8 +83,8 @@ class ColorParserTests: XCTestCase {
 
   func testParseMultipleFiles() throws {
     let parser = Colors.Parser()
-    try parser.parse(path: Fixtures.path(for: "colors.clr", sub: .colors))
-    try parser.parse(path: Fixtures.path(for: "extra.txt", sub: .colors))
+    try parser.searchAndParse(path: Fixtures.path(for: "colors.clr", sub: .colors))
+    try parser.searchAndParse(path: Fixtures.path(for: "extra.txt", sub: .colors))
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "multiple", sub: .colors)

--- a/Tests/SwiftGenKitTests/CoreDataTests.swift
+++ b/Tests/SwiftGenKitTests/CoreDataTests.swift
@@ -18,7 +18,7 @@ class CoreDataTests: XCTestCase {
   func testDefaults() {
     let parser = CoreData.Parser()
     do {
-      try parser.parse(path: Fixtures.path(for: "Model.xcdatamodeld", sub: .coreData))
+      try parser.searchAndParse(path: Fixtures.path(for: "Model.xcdatamodeld", sub: .coreData))
     } catch {
       print("Error: \(error.localizedDescription)")
     }

--- a/Tests/SwiftGenKitTests/FilterTests.swift
+++ b/Tests/SwiftGenKitTests/FilterTests.swift
@@ -1,0 +1,49 @@
+//
+// SwiftGenKit UnitTests
+// Copyright © 2019 SwiftGen
+// MIT Licence
+//
+
+import PathKit
+@testable import SwiftGenKit
+import XCTest
+
+class FilterTests: XCTestCase {
+  func testBasicRegex() throws {
+    let filter = try Filter(pattern: ".+\\.strings$")
+
+    XCTAssertTrue(Path("foo.strings").matches(filter: filter))
+    XCTAssertTrue(Path("Bar.strings").matches(filter: filter))
+    XCTAssertTrue(Path("A/B/C/baz.strings").matches(filter: filter))
+
+    XCTAssertFalse(Path("foo.Strings").matches(filter: filter))
+    XCTAssertFalse(Path("foo.stringsdict").matches(filter: filter))
+  }
+
+  func testCaseSensitive() throws {
+    let filter = try Filter(pattern: ".+\\.strings$")
+
+    XCTAssertTrue(Path("foo.strings").matches(filter: filter))
+    XCTAssertTrue(Path("Bar.strings").matches(filter: filter))
+    XCTAssertFalse(Path("foo.Strings").matches(filter: filter))
+    XCTAssertFalse(Path("Bar.STRINGS").matches(filter: filter))
+  }
+
+  func testCaseInsensitive() throws {
+    let filter = try Filter(pattern: ".+\\.(?i:json)$")
+
+    XCTAssertTrue(Path("foo.json").matches(filter: filter))
+    XCTAssertTrue(Path("foo.Json").matches(filter: filter))
+    XCTAssertTrue(Path("foo.JSON").matches(filter: filter))
+  }
+
+  func testComplex() throws {
+    // match json files with the filename beginning with "SG"
+    let filter = try Filter(pattern: "^(.+/)?SG[^/]*\\.json$")
+
+    XCTAssertTrue(Path("foo/bar/SGBaz.json").matches(filter: filter))
+    XCTAssertTrue(Path("SGQux.json").matches(filter: filter))
+    XCTAssertFalse(Path("foo/bar/SG/qux.json").matches(filter: filter))
+    XCTAssertFalse(Path("foo/bar/bazSGqux.json").matches(filter: filter))
+  }
+}

--- a/Tests/SwiftGenKitTests/FontsTests.swift
+++ b/Tests/SwiftGenKitTests/FontsTests.swift
@@ -17,9 +17,9 @@ class FontsTests: XCTestCase {
     XCTDiffContexts(result, expected: "empty", sub: .fonts)
   }
 
-  func testDefaults() {
+  func testDefaults() throws {
     let parser = Fonts.Parser()
-    parser.parse(path: Fixtures.directory(sub: .fonts))
+    try parser.searchAndParse(path: Fixtures.directory())
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "defaults", sub: .fonts)

--- a/Tests/SwiftGenKitTests/InterfaceBuilderMacOSTests.swift
+++ b/Tests/SwiftGenKitTests/InterfaceBuilderMacOSTests.swift
@@ -24,7 +24,7 @@ class InterfaceBuilderMacOSTests: XCTestCase {
   func testMessageStoryboard() {
     let parser = InterfaceBuilder.Parser()
     do {
-      try parser.parse(path: Fixtures.path(for: "Message.storyboard", sub: .interfaceBuilderMacOS))
+      try parser.searchAndParse(path: Fixtures.path(for: "Message.storyboard", sub: .interfaceBuilderMacOS))
     } catch {
       print("Error: \(error.localizedDescription)")
     }
@@ -36,7 +36,7 @@ class InterfaceBuilderMacOSTests: XCTestCase {
   func testAnonymousStoryboard() {
     let parser = InterfaceBuilder.Parser()
     do {
-      try parser.parse(path: Fixtures.path(for: "Anonymous.storyboard", sub: .interfaceBuilderMacOS))
+      try parser.searchAndParse(path: Fixtures.path(for: "Anonymous.storyboard", sub: .interfaceBuilderMacOS))
     } catch {
       print("Error: \(error.localizedDescription)")
     }
@@ -48,7 +48,7 @@ class InterfaceBuilderMacOSTests: XCTestCase {
   func testAllStoryboards() {
     let parser = InterfaceBuilder.Parser()
     do {
-      try parser.parse(path: Fixtures.directory(sub: .interfaceBuilderMacOS))
+      try parser.searchAndParse(path: Fixtures.directory(sub: .interfaceBuilderMacOS))
     } catch {
       print("Error: \(error.localizedDescription)")
     }
@@ -62,7 +62,7 @@ class InterfaceBuilderMacOSTests: XCTestCase {
     let fakeModuleName = "NotCurrentModule"
 
     let parser = InterfaceBuilder.Parser()
-    try parser.parse(path: Fixtures.directory(sub: .interfaceBuilderMacOS))
+    try parser.searchAndParse(path: Fixtures.directory(sub: .interfaceBuilderMacOS))
 
     XCTAssert(
       parser.storyboards.contains {

--- a/Tests/SwiftGenKitTests/InterfaceBuilderiOSTests.swift
+++ b/Tests/SwiftGenKitTests/InterfaceBuilderiOSTests.swift
@@ -24,7 +24,7 @@ class InterfaceBuilderiOSTests: XCTestCase {
   func testMessageStoryboard() {
     let parser = InterfaceBuilder.Parser()
     do {
-      try parser.parse(path: Fixtures.path(for: "Message.storyboard", sub: .interfaceBuilderiOS))
+      try parser.searchAndParse(path: Fixtures.path(for: "Message.storyboard", sub: .interfaceBuilderiOS))
     } catch {
       print("Error: \(error.localizedDescription)")
     }
@@ -36,7 +36,7 @@ class InterfaceBuilderiOSTests: XCTestCase {
   func testAnonymousStoryboard() {
     let parser = InterfaceBuilder.Parser()
     do {
-      try parser.parse(path: Fixtures.path(for: "Anonymous.storyboard", sub: .interfaceBuilderiOS))
+      try parser.searchAndParse(path: Fixtures.path(for: "Anonymous.storyboard", sub: .interfaceBuilderiOS))
     } catch {
       print("Error: \(error.localizedDescription)")
     }
@@ -48,7 +48,7 @@ class InterfaceBuilderiOSTests: XCTestCase {
   func testAllStoryboards() {
     let parser = InterfaceBuilder.Parser()
     do {
-      try parser.parse(path: Fixtures.directory(sub: .interfaceBuilderiOS))
+      try parser.searchAndParse(path: Fixtures.directory(sub: .interfaceBuilderiOS))
     } catch {
       print("Error: \(error.localizedDescription)")
     }
@@ -62,7 +62,7 @@ class InterfaceBuilderiOSTests: XCTestCase {
     let fakeModuleName = "NotCurrentModule"
 
     let parser = InterfaceBuilder.Parser()
-    try parser.parse(path: Fixtures.directory(sub: .interfaceBuilderiOS))
+    try parser.searchAndParse(path: Fixtures.directory(sub: .interfaceBuilderiOS))
 
     XCTAssert(
       parser.storyboards.contains {

--- a/Tests/SwiftGenKitTests/PlistTests.swift
+++ b/Tests/SwiftGenKitTests/PlistTests.swift
@@ -18,7 +18,7 @@ class PlistTests: XCTestCase {
 
   func testArray() throws {
     let parser = Plist.Parser()
-    try parser.parse(path: Fixtures.path(for: "shopping-list.plist", sub: .plistGood))
+    try parser.searchAndParse(path: Fixtures.path(for: "shopping-list.plist", sub: .plistGood))
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "shopping-list", sub: .plist)
@@ -26,7 +26,7 @@ class PlistTests: XCTestCase {
 
   func testDictionary() throws {
     let parser = Plist.Parser()
-    try parser.parse(path: Fixtures.path(for: "configuration.plist", sub: .plistGood))
+    try parser.searchAndParse(path: Fixtures.path(for: "configuration.plist", sub: .plistGood))
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "configuration", sub: .plist)
@@ -34,7 +34,7 @@ class PlistTests: XCTestCase {
 
   func testInfo() throws {
     let parser = Plist.Parser()
-    try parser.parse(path: Fixtures.path(for: "Info.plist", sub: .plistGood))
+    try parser.searchAndParse(path: Fixtures.path(for: "Info.plist", sub: .plistGood))
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "info", sub: .plist)
@@ -43,7 +43,7 @@ class PlistTests: XCTestCase {
   func testDirectoryInput() {
     do {
       let parser = Plist.Parser()
-      try parser.parse(path: Fixtures.directory(sub: .plistGood))
+      try parser.searchAndParse(path: Fixtures.directory(sub: .plistGood))
 
       let result = parser.stencilContext()
       XCTDiffContexts(result, expected: "all", sub: .plist)
@@ -54,7 +54,7 @@ class PlistTests: XCTestCase {
 
   func testFileWithBadSyntax() {
     do {
-      _ = try Plist.Parser().parse(path: Fixtures.path(for: "syntax.plist", sub: .plistBad))
+      _ = try Plist.Parser().searchAndParse(path: Fixtures.path(for: "syntax.plist", sub: .plistBad))
       XCTFail("Code did parse file successfully while it was expected to fail for bad syntax")
     } catch Plist.ParserError.invalidFile {
       // That's the expected exception we want to happen

--- a/Tests/SwiftGenKitTests/StringsTests.swift
+++ b/Tests/SwiftGenKitTests/StringsTests.swift
@@ -23,7 +23,7 @@ class StringsTests: XCTestCase {
 
   func testLocalizable() throws {
     let parser = Strings.Parser()
-    try parser.parse(path: Fixtures.path(for: "Localizable.strings", sub: .strings))
+    try parser.searchAndParse(path: Fixtures.path(for: "Localizable.strings", sub: .strings))
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "localizable", sub: .strings)
@@ -31,7 +31,7 @@ class StringsTests: XCTestCase {
 
   func testMultiline() throws {
     let parser = Strings.Parser()
-    try parser.parse(path: Fixtures.path(for: "LocMultiline.strings", sub: .strings))
+    try parser.searchAndParse(path: Fixtures.path(for: "LocMultiline.strings", sub: .strings))
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "multiline", sub: .strings)
@@ -39,7 +39,7 @@ class StringsTests: XCTestCase {
 
   func testUTF8File() throws {
     let parser = Strings.Parser()
-    try parser.parse(path: Fixtures.path(for: "LocUTF8.strings", sub: .strings))
+    try parser.searchAndParse(path: Fixtures.path(for: "LocUTF8.strings", sub: .strings))
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "utf8", sub: .strings)
@@ -47,7 +47,7 @@ class StringsTests: XCTestCase {
 
   func testStructuredOnly() throws {
     let parser = Strings.Parser()
-    try parser.parse(path: Fixtures.path(for: "LocStructuredOnly.strings", sub: .strings))
+    try parser.searchAndParse(path: Fixtures.path(for: "LocStructuredOnly.strings", sub: .strings))
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "structuredonly", sub: .strings)
@@ -55,8 +55,8 @@ class StringsTests: XCTestCase {
 
   func testMultipleFiles() throws {
     let parser = Strings.Parser()
-    try parser.parse(path: Fixtures.path(for: "Localizable.strings", sub: .strings))
-    try parser.parse(path: Fixtures.path(for: "LocMultiline.strings", sub: .strings))
+    try parser.searchAndParse(path: Fixtures.path(for: "Localizable.strings", sub: .strings))
+    try parser.searchAndParse(path: Fixtures.path(for: "LocMultiline.strings", sub: .strings))
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "multiple", sub: .strings)
@@ -64,10 +64,10 @@ class StringsTests: XCTestCase {
 
   func testMultipleFilesDuplicate() throws {
     let parser = Strings.Parser()
-    try parser.parse(path: Fixtures.path(for: "Localizable.strings", sub: .strings))
+    try parser.searchAndParse(path: Fixtures.path(for: "Localizable.strings", sub: .strings))
 
     do {
-      try parser.parse(path: Fixtures.path(for: "Localizable.strings", sub: .strings))
+      try parser.searchAndParse(path: Fixtures.path(for: "Localizable.strings", sub: .strings))
       XCTFail("Code did parse file successfully while it was expected to fail for duplicate file")
     } catch Strings.ParserError.duplicateTable {
       // That's the expected exception we want to happen

--- a/Tests/SwiftGenKitTests/TestsHelper.swift
+++ b/Tests/SwiftGenKitTests/TestsHelper.swift
@@ -227,3 +227,16 @@ class Fixtures {
     return result
   }
 }
+
+extension Parser {
+  func searchAndParse(path: Path) throws {
+    let filter = try Filter(pattern: Self.defaultFilter)
+    try searchAndParse(path: path, filter: filter)
+  }
+
+  func searchAndParse(paths: [Path]) throws {
+    for path in paths {
+      try searchAndParse(path: path)
+    }
+  }
+}

--- a/Tests/SwiftGenKitTests/YamlTests.swift
+++ b/Tests/SwiftGenKitTests/YamlTests.swift
@@ -18,7 +18,7 @@ class YamlTests: XCTestCase {
 
   func testSequence() throws {
     let parser = Yaml.Parser()
-    try parser.parse(path: Fixtures.path(for: "grocery-list.yaml", sub: .yamlGood))
+    try parser.searchAndParse(path: Fixtures.path(for: "grocery-list.yaml", sub: .yamlGood))
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "grocery-list", sub: .yaml)
@@ -26,15 +26,15 @@ class YamlTests: XCTestCase {
 
   func testMapping() throws {
     let parser = Yaml.Parser()
-    try parser.parse(path: Fixtures.path(for: "mapping.yaml", sub: .yamlGood))
+    try parser.searchAndParse(path: Fixtures.path(for: "mapping.yaml", sub: .yamlGood))
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "mapping", sub: .yaml)
   }
 
   func testJSON() throws {
-    let parser = Yaml.Parser()
-    try parser.parse(path: Fixtures.path(for: "configuration.json", sub: .yamlGood))
+    let parser = JSON.Parser()
+    try parser.searchAndParse(path: Fixtures.path(for: "configuration.json", sub: .yamlGood))
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "configuration", sub: .yaml)
@@ -42,7 +42,7 @@ class YamlTests: XCTestCase {
 
   func testScalar() throws {
     let parser = Yaml.Parser()
-    try parser.parse(path: Fixtures.path(for: "version.yaml", sub: .yamlGood))
+    try parser.searchAndParse(path: Fixtures.path(for: "version.yaml", sub: .yamlGood))
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "version", sub: .yaml)
@@ -50,7 +50,7 @@ class YamlTests: XCTestCase {
 
   func testMutlipleDocuments() throws {
     let parser = Yaml.Parser()
-    try parser.parse(path: Fixtures.path(for: "documents.yaml", sub: .yamlGood))
+    try parser.searchAndParse(path: Fixtures.path(for: "documents.yaml", sub: .yamlGood))
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "documents", sub: .yaml)
@@ -59,7 +59,8 @@ class YamlTests: XCTestCase {
   func testDirectoryInput() {
     do {
       let parser = Yaml.Parser()
-      try parser.parse(path: Fixtures.directory(sub: .yamlGood))
+      let filter = try Filter(pattern: ".*\\.(json|ya?ml)")
+      try parser.searchAndParse(path: Fixtures.directory(sub: .yamlGood), filter: filter)
 
       let result = parser.stencilContext()
       XCTDiffContexts(result, expected: "all", sub: .yaml)
@@ -70,7 +71,7 @@ class YamlTests: XCTestCase {
 
   func testFileWithBadSyntax() {
     do {
-      _ = try Yaml.Parser().parse(path: Fixtures.path(for: "syntax.yaml", sub: .yamlBad))
+      _ = try Yaml.Parser().searchAndParse(path: Fixtures.path(for: "syntax.yaml", sub: .yamlBad))
       XCTFail("Code did parse file successfully while it was expected to fail for bad syntax")
     } catch Yaml.ParserError.invalidFile {
       // That's the expected exception we want to happen

--- a/Tests/SwiftGenTests/ConfigReadTests.swift
+++ b/Tests/SwiftGenTests/ConfigReadTests.swift
@@ -29,6 +29,7 @@ class ConfigReadTests: XCTestCase {
       }
 
       XCTAssertEqual(entry.inputs, ["Sources1/Folder"])
+      XCTAssertEqual(entry.filter, ".*\\.strings")
 
       XCTAssertEqual(entry.outputs.count, 1)
       guard let output = entry.outputs.first else {


### PR DESCRIPTION
Fixes #383.

Config entries (or CLI invocations) now accept a `filter` flag (`-f`) that allows applying a regex to input paths (or the contents of directories). Each parser defines a default filter, which is also shown in the help output as a bonus.

One (almost fortunate) consequence of this PR is that every command now accepts a directory, and recurse into its contents as needed. Note that this PR partially replaces #371 and #32 (directory input for strings command). We may still want to add logic to detect multiple `lproj`s. 

Todo:
- [x] Write documentation about new `filter` config option
- [x] Write documentation about new `filter` CLI option
- [x] Tests maybe?