### PR TITLE
Fix CLI args in scheme & docs #trivial

### DIFF
--- a/Documentation/Articles/Xcode-Integration.md
+++ b/Documentation/Articles/Xcode-Integration.md
@@ -48,16 +48,16 @@ Note: Those script phase examples above all assume that you're [using a `swiftge
 
 When adding SwiftGen as a build phase in your project, if instead of using a Config file you invoked subcommands from the command line, then sometimes builds can cancel because Xcode doesn't like source code changes happening mid-build. It can also cause issues with `IBDesignable` views triggering looping builds when opening storyboards.
 
-To avoid this, we highly recommand using a `swiftgen.yml` configuration file instead of invoking the subcommands directly from the command line, or if you still want to invoke subcommands from the command line, be sure to use `--output` to specify the output file to write (instead of a `> output-file.swift` redirection for example). Doing this allows SwiftGen to avoid re-writing the file to disk if the content is not modified.
+To avoid this, **we highly recommand using a `swiftgen.yml` configuration file instead of invoking the subcommands directly from the command line**. But if you still want to invoke subcommands from the command line, be sure to use `--output` to specify the output file to write (instead of a `> output-file.swift` redirection for example). Doing this allows SwiftGen to avoid re-writing the file to disk if the content is not modified.
 
 Typically don't use:
 ```sh
-swiftgen xcassets Resources/Images.xcassets -t swift4 > "Constants/Assets+Generated.swift"
+swiftgen xcassets Resources/Images.xcassets --templateName swift4 > "Constants/Assets+Generated.swift"
 ```
 
 But use:
 ```sh
-swiftgen xcassets Resources/Images.xcassets -t swift4 --output "Constants/Assets+Generated.swift"
+swiftgen xcassets Resources/Images.xcassets --templateName swift4 --output "Constants/Assets+Generated.swift"
 ```
 
 Or even better, just use `swiftgen` in your Script Build Phase, and specify this in your `swiftgen.yml` config file:

--- a/Documentation/MigrationGuide.md
+++ b/Documentation/MigrationGuide.md
@@ -123,6 +123,9 @@ SwiftGen 6.0 uses the latest Stencil and StencilSwiftKit libraries, so there are
 
 There have been a few minor context changes, see [SwiftGenKit's own Migration Guide](SwiftGenKit%20Contexts/MigrationGuide.md#swiftgenkit-20-swiftgen-50-migration-guide) for more information.
 
+## Command Line invocation
+
+If you still invoked SwiftGen subcommands directly using command line flags and options (instead of a configuration file), be sure to use `--templateName` or `--templatePath` instead of the `--template`/`-t` option (which has been deprecated).
 
 # SwiftGen 5.1 Migration Guide
 

--- a/Sources/SwiftGenKit/Parsers/Yaml/YamlParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Yaml/YamlParser.swift
@@ -44,7 +44,7 @@ public enum Yaml {
 
 public enum JSON {
   public final class Parser: Yaml.Parser {
-    override public static var defaultFilter: String {
+    override public class var defaultFilter: String {
       return ".*\\.(?i:json)$"
     }
   }

--- a/SwiftGen.xcodeproj/xcshareddata/xcschemes/swiftgen.xcscheme
+++ b/SwiftGen.xcodeproj/xcshareddata/xcschemes/swiftgen.xcscheme
@@ -133,39 +133,43 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "coredata --template swift4 $(PROJECT_DIR)/Tests/Fixtures/Resources/CoreData/Model.xcdatamodeld"
+            argument = "colors --templateName swift4 $(PROJECT_DIR)/Tests/Fixtures/Resources/Colors/colors.xml"
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "colors -t swift4 $(PROJECT_DIR)/Tests/Fixtures/Resources/Colors/colors.xml"
+            argument = "coredata --templateName swift4 $(PROJECT_DIR)/Tests/Fixtures/Resources/CoreData/Model.xcdatamodeld"
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "fonts -t swift4 $(PROJECT_DIR)/Tests/Fixtures/Resources/Fonts"
+            argument = "fonts --templateName swift4 $(PROJECT_DIR)/Tests/Fixtures/Resources/Fonts"
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "ib -t swift4 $(PROJECT_DIR)/Tests/Fixtures/Resources/Storyboards-iOS"
+            argument = "ib --templateName scenes-swift4 $(PROJECT_DIR)/Tests/Fixtures/Resources/IB-iOS"
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "plist $(PROJECT_DIR)/Tests/Fixtures/Resources/Plist/good/Info.plist"
+            argument = "ib --templateName segues-swift4 $(PROJECT_DIR)/Tests/Fixtures/Resources/IB-iOS"
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "strings -t structured-swift4 $(PROJECT_DIR)/Tests/Fixtures/Resources/Strings/Localizable.strings"
+            argument = "plist --templateName inline-swift4 $(PROJECT_DIR)/Tests/Fixtures/Resources/Plist/good/Info.plist"
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "xcassets -t swift4 $(PROJECT_DIR)/Tests/Fixtures/Resources/XCAssets/Images.xcassets"
+            argument = "strings --templateName structured-swift4 $(PROJECT_DIR)/Tests/Fixtures/Resources/Strings/Localizable.strings"
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "xcassets -t swift4 $(PROJECT_DIR)/Tests/Fixtures/Resources/XCAssets/Data.xcassets"
+            argument = "xcassets --templateName swift4 $(PROJECT_DIR)/Tests/Fixtures/Resources/XCAssets/Images.xcassets"
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "yaml $(PROJECT_DIR)/Tests/Fixtures/Resources/YAML/good/documents.yaml"
+            argument = "xcassets --templateName swift4 $(PROJECT_DIR)/Tests/Fixtures/Resources/XCAssets/Data.xcassets"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "yaml --templateName inline-swift4 $(PROJECT_DIR)/Tests/Fixtures/Resources/YAML/good/documents.yaml"
             isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Tests/SwiftGenKitTests/ColorsTests.swift
+++ b/Tests/SwiftGenKitTests/ColorsTests.swift
@@ -44,7 +44,7 @@ class ColorParserTests: XCTestCase {
     parser.register(parser: TestFileParser1.self)
     parser.register(parser: TestFileParser2.self)
 
-    let filter = try Filter(pattern: ".*\\.(test1|test2)")
+    let filter = try Filter(pattern: ".*\\.(test1|test2)$")
     try parser.searchAndParse(path: "someFile.test1", filter: filter)
     XCTAssertEqual(parser.palettes.first?.name, "test1")
   }
@@ -55,7 +55,7 @@ class ColorParserTests: XCTestCase {
     parser.register(parser: TestFileParser2.self)
 
     do {
-      let filter = try Filter(pattern: ".*\\.unknown")
+      let filter = try Filter(pattern: ".*\\.unknown$")
       try parser.searchAndParse(path: "someFile.unknown", filter: filter)
       XCTFail("Code did succeed while it was expected to fail for unknown extension")
     } catch Colors.ParserError.unsupportedFileType {

--- a/Tests/SwiftGenKitTests/YamlTests.swift
+++ b/Tests/SwiftGenKitTests/YamlTests.swift
@@ -59,7 +59,7 @@ class YamlTests: XCTestCase {
   func testDirectoryInput() {
     do {
       let parser = Yaml.Parser()
-      let filter = try Filter(pattern: ".*\\.(json|ya?ml)")
+      let filter = try Filter(pattern: "[^/]*\\.(json|ya?ml)$")
       try parser.searchAndParse(path: Fixtures.directory(sub: .yamlGood), filter: filter)
 
       let result = parser.stencilContext()


### PR DESCRIPTION
Some small fixes regarding `-t` => `--templateName`, command line arguments saved in scheme, and other nitpicks