### PR TITLE
Assets: improve colors performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,13 @@ _None_
 
 ### Bug Fixes
 
+* Assets: improved the performance for color assets by caching the resolved colors.  
+  [David Jennes](https://github.com/djbe)
+  [#578](https://github.com/SwiftGen/SwiftGen/issue/578)
+  [#589](https://github.com/SwiftGen/SwiftGen/pull/589)
 * Core Data: `entityName` is now correctly a `class var` instead of a `class func`.  
   [David Jennes](https://github.com/djbe)
-  [#589](https://github.com/SwiftGen/SwiftGen/pull/589)
+  [#590](https://github.com/SwiftGen/SwiftGen/pull/590)
 
 ### Internal Changes
 

--- a/Tests/Fixtures/Generated/XCAssets/swift3-context-all-allValues.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift3-context-all-allValues.swift
@@ -95,15 +95,17 @@ internal enum Asset {
 
 // MARK: - Implementation Details
 
-internal struct ColorAsset {
+internal final class ColorAsset {
   internal fileprivate(set) var name: String
 
   #if swift(>=3.2)
   @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
-  internal var color: AssetColorTypeAlias {
-    return AssetColorTypeAlias(asset: self)
-  }
+  internal fileprivate(set) lazy var color: AssetColorTypeAlias = AssetColorTypeAlias(asset: self)
   #endif
+
+  fileprivate init(name: String) {
+    self.name = name
+  }
 }
 
 internal extension AssetColorTypeAlias {

--- a/Tests/Fixtures/Generated/XCAssets/swift3-context-all-customName.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift3-context-all-customName.swift
@@ -56,15 +56,17 @@ internal enum XCTAssets {
 
 // MARK: - Implementation Details
 
-internal struct XCTColorAsset {
+internal final class XCTColorAsset {
   internal fileprivate(set) var name: String
 
   #if swift(>=3.2)
   @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
-  internal var color: XCTColor {
-    return XCTColor(asset: self)
-  }
+  internal fileprivate(set) lazy var color: XCTColor = XCTColor(asset: self)
   #endif
+
+  fileprivate init(name: String) {
+    self.name = name
+  }
 }
 
 internal extension XCTColor {

--- a/Tests/Fixtures/Generated/XCAssets/swift3-context-all-forceNamespaces.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift3-context-all-forceNamespaces.swift
@@ -58,15 +58,17 @@ internal enum Asset {
 
 // MARK: - Implementation Details
 
-internal struct ColorAsset {
+internal final class ColorAsset {
   internal fileprivate(set) var name: String
 
   #if swift(>=3.2)
   @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
-  internal var color: AssetColorTypeAlias {
-    return AssetColorTypeAlias(asset: self)
-  }
+  internal fileprivate(set) lazy var color: AssetColorTypeAlias = AssetColorTypeAlias(asset: self)
   #endif
+
+  fileprivate init(name: String) {
+    self.name = name
+  }
 }
 
 internal extension AssetColorTypeAlias {

--- a/Tests/Fixtures/Generated/XCAssets/swift3-context-all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift3-context-all-publicAccess.swift
@@ -56,15 +56,17 @@ public enum Asset {
 
 // MARK: - Implementation Details
 
-public struct ColorAsset {
+public final class ColorAsset {
   public fileprivate(set) var name: String
 
   #if swift(>=3.2)
   @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
-  public var color: AssetColorTypeAlias {
-    return AssetColorTypeAlias(asset: self)
-  }
+  public fileprivate(set) lazy var color: AssetColorTypeAlias = AssetColorTypeAlias(asset: self)
   #endif
+
+  fileprivate init(name: String) {
+    self.name = name
+  }
 }
 
 public extension AssetColorTypeAlias {

--- a/Tests/Fixtures/Generated/XCAssets/swift3-context-all.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift3-context-all.swift
@@ -56,15 +56,17 @@ internal enum Asset {
 
 // MARK: - Implementation Details
 
-internal struct ColorAsset {
+internal final class ColorAsset {
   internal fileprivate(set) var name: String
 
   #if swift(>=3.2)
   @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
-  internal var color: AssetColorTypeAlias {
-    return AssetColorTypeAlias(asset: self)
-  }
+  internal fileprivate(set) lazy var color: AssetColorTypeAlias = AssetColorTypeAlias(asset: self)
   #endif
+
+  fileprivate init(name: String) {
+    self.name = name
+  }
 }
 
 internal extension AssetColorTypeAlias {

--- a/Tests/Fixtures/Generated/XCAssets/swift4-context-all-allValues.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift4-context-all-allValues.swift
@@ -95,12 +95,14 @@ internal enum Asset {
 
 // MARK: - Implementation Details
 
-internal struct ColorAsset {
+internal final class ColorAsset {
   internal fileprivate(set) var name: String
 
   @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
-  internal var color: AssetColorTypeAlias {
-    return AssetColorTypeAlias(asset: self)
+  internal private(set) lazy var color: AssetColorTypeAlias = AssetColorTypeAlias(asset: self)
+
+  fileprivate init(name: String) {
+    self.name = name
   }
 }
 

--- a/Tests/Fixtures/Generated/XCAssets/swift4-context-all-customName.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift4-context-all-customName.swift
@@ -56,12 +56,14 @@ internal enum XCTAssets {
 
 // MARK: - Implementation Details
 
-internal struct XCTColorAsset {
+internal final class XCTColorAsset {
   internal fileprivate(set) var name: String
 
   @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
-  internal var color: XCTColor {
-    return XCTColor(asset: self)
+  internal private(set) lazy var color: XCTColor = XCTColor(asset: self)
+
+  fileprivate init(name: String) {
+    self.name = name
   }
 }
 

--- a/Tests/Fixtures/Generated/XCAssets/swift4-context-all-forceNamespaces.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift4-context-all-forceNamespaces.swift
@@ -58,12 +58,14 @@ internal enum Asset {
 
 // MARK: - Implementation Details
 
-internal struct ColorAsset {
+internal final class ColorAsset {
   internal fileprivate(set) var name: String
 
   @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
-  internal var color: AssetColorTypeAlias {
-    return AssetColorTypeAlias(asset: self)
+  internal private(set) lazy var color: AssetColorTypeAlias = AssetColorTypeAlias(asset: self)
+
+  fileprivate init(name: String) {
+    self.name = name
   }
 }
 

--- a/Tests/Fixtures/Generated/XCAssets/swift4-context-all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift4-context-all-publicAccess.swift
@@ -56,12 +56,14 @@ public enum Asset {
 
 // MARK: - Implementation Details
 
-public struct ColorAsset {
+public final class ColorAsset {
   public fileprivate(set) var name: String
 
   @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
-  public var color: AssetColorTypeAlias {
-    return AssetColorTypeAlias(asset: self)
+  public private(set) lazy var color: AssetColorTypeAlias = AssetColorTypeAlias(asset: self)
+
+  fileprivate init(name: String) {
+    self.name = name
   }
 }
 

--- a/Tests/Fixtures/Generated/XCAssets/swift4-context-all.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift4-context-all.swift
@@ -56,12 +56,14 @@ internal enum Asset {
 
 // MARK: - Implementation Details
 
-internal struct ColorAsset {
+internal final class ColorAsset {
   internal fileprivate(set) var name: String
 
   @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
-  internal var color: AssetColorTypeAlias {
-    return AssetColorTypeAlias(asset: self)
+  internal private(set) lazy var color: AssetColorTypeAlias = AssetColorTypeAlias(asset: self)
+
+  fileprivate init(name: String) {
+    self.name = name
   }
 }
 

--- a/templates/xcassets/swift3.stencil
+++ b/templates/xcassets/swift3.stencil
@@ -88,15 +88,17 @@
 
 // MARK: - Implementation Details
 
-{{accessModifier}} struct {{colorType}} {
+{{accessModifier}} final class {{colorType}} {
   {{accessModifier}} fileprivate(set) var name: String
 
   #if swift(>=3.2)
   @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
-  {{accessModifier}} var color: {{colorAlias}} {
-    return {{colorAlias}}(asset: self)
-  }
+  {{accessModifier}} fileprivate(set) lazy var color: {{colorAlias}} = {{colorAlias}}(asset: self)
   #endif
+
+  fileprivate init(name: String) {
+    self.name = name
+  }
 }
 
 {{accessModifier}} extension {{colorAlias}} {

--- a/templates/xcassets/swift4.stencil
+++ b/templates/xcassets/swift4.stencil
@@ -88,12 +88,14 @@
 
 // MARK: - Implementation Details
 
-{{accessModifier}} struct {{colorType}} {
+{{accessModifier}} final class {{colorType}} {
   {{accessModifier}} fileprivate(set) var name: String
 
   @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
-  {{accessModifier}} var color: {{colorAlias}} {
-    return {{colorAlias}}(asset: self)
+  {{accessModifier}} private(set) lazy var color: {{colorAlias}} = {{colorAlias}}(asset: self)
+
+  fileprivate init(name: String) {
+    self.name = name
   }
 }
 


### PR DESCRIPTION
Fixes #578.

To use `lazy var`, had to switch to `final class` with our own `init`. This is better than parsing the color during `init` as we can keep the `@availability` annotation for the `color` property.