### PR TITLE
Core Data: `entityName` should be a `class var`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ _None_
 
 ### Bug Fixes
 
-_None_
+* Core Data: `entityName` is now correctly a `class var` instead of a `class func`.  
+  [David Jennes](https://github.com/djbe)
+  [#589](https://github.com/SwiftGen/SwiftGen/pull/589)
 
 ### Internal Changes
 

--- a/Tests/Fixtures/Generated/CoreData/swift3-context-defaults-generateObjcName.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift3-context-defaults-generateObjcName.swift
@@ -12,16 +12,16 @@ import Foundation
 
 @objc(AbstractEntity)
 internal class AbstractEntity: NSManagedObject {
-  internal class func entityName() -> String {
+  internal class var entityName: String {
     return "AbstractEntity"
   }
 
   internal class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc internal class func fetchRequest() -> NSFetchRequest<AbstractEntity> {
-    return NSFetchRequest<AbstractEntity>(entityName: entityName())
+    return NSFetchRequest<AbstractEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection
@@ -40,16 +40,16 @@ internal class AbstractEntity: NSManagedObject {
 
 @objc(ChildEntity)
 internal class ChildEntity: MainEntity {
-  override internal class func entityName() -> String {
+  override internal class var entityName: String {
     return "ChildEntity"
   }
 
   override internal class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc internal class func fetchRequest() -> NSFetchRequest<ChildEntity> {
-    return NSFetchRequest<ChildEntity>(entityName: entityName())
+    return NSFetchRequest<ChildEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection
@@ -64,16 +64,16 @@ internal class ChildEntity: MainEntity {
 
 @objc(MainEntity)
 internal class MainEntity: NSManagedObject {
-  internal class func entityName() -> String {
+  internal class var entityName: String {
     return "MainEntity"
   }
 
   internal class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc internal class func fetchRequest() -> NSFetchRequest<MainEntity> {
-    return NSFetchRequest<MainEntity>(entityName: entityName())
+    return NSFetchRequest<MainEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection
@@ -285,16 +285,16 @@ extension MainEntity {
 
 @objc(NewEntity)
 internal class NewEntity: AbstractEntity {
-  override internal class func entityName() -> String {
+  override internal class var entityName: String {
     return "NewEntity"
   }
 
   override internal class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc internal class func fetchRequest() -> NSFetchRequest<NewEntity> {
-    return NSFetchRequest<NewEntity>(entityName: entityName())
+    return NSFetchRequest<NewEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection
@@ -306,16 +306,16 @@ internal class NewEntity: AbstractEntity {
 
 @objc(SecondaryEntity)
 internal class SecondaryEntity: NSManagedObject {
-  internal class func entityName() -> String {
+  internal class var entityName: String {
     return "SecondaryEntity"
   }
 
   internal class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc internal class func fetchRequest() -> NSFetchRequest<SecondaryEntity> {
-    return NSFetchRequest<SecondaryEntity>(entityName: entityName())
+    return NSFetchRequest<SecondaryEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection

--- a/Tests/Fixtures/Generated/CoreData/swift3-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift3-context-defaults-publicAccess.swift
@@ -11,16 +11,16 @@ import Foundation
 // MARK: - AbstractEntity
 
 public class AbstractEntity: NSManagedObject {
-  public class func entityName() -> String {
+  public class var entityName: String {
     return "AbstractEntity"
   }
 
   public class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc public class func fetchRequest() -> NSFetchRequest<AbstractEntity> {
-    return NSFetchRequest<AbstractEntity>(entityName: entityName())
+    return NSFetchRequest<AbstractEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection
@@ -38,16 +38,16 @@ public class AbstractEntity: NSManagedObject {
 // MARK: - ChildEntity
 
 public class ChildEntity: MainEntity {
-  override public class func entityName() -> String {
+  override public class var entityName: String {
     return "ChildEntity"
   }
 
   override public class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc public class func fetchRequest() -> NSFetchRequest<ChildEntity> {
-    return NSFetchRequest<ChildEntity>(entityName: entityName())
+    return NSFetchRequest<ChildEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection
@@ -61,16 +61,16 @@ public class ChildEntity: MainEntity {
 // MARK: - MainEntity
 
 public class MainEntity: NSManagedObject {
-  public class func entityName() -> String {
+  public class var entityName: String {
     return "MainEntity"
   }
 
   public class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc public class func fetchRequest() -> NSFetchRequest<MainEntity> {
-    return NSFetchRequest<MainEntity>(entityName: entityName())
+    return NSFetchRequest<MainEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection
@@ -281,16 +281,16 @@ extension MainEntity {
 // MARK: - NewEntity
 
 public class NewEntity: AbstractEntity {
-  override public class func entityName() -> String {
+  override public class var entityName: String {
     return "NewEntity"
   }
 
   override public class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc public class func fetchRequest() -> NSFetchRequest<NewEntity> {
-    return NSFetchRequest<NewEntity>(entityName: entityName())
+    return NSFetchRequest<NewEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection
@@ -301,16 +301,16 @@ public class NewEntity: AbstractEntity {
 // MARK: - SecondaryEntity
 
 public class SecondaryEntity: NSManagedObject {
-  public class func entityName() -> String {
+  public class var entityName: String {
     return "SecondaryEntity"
   }
 
   public class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc public class func fetchRequest() -> NSFetchRequest<SecondaryEntity> {
-    return NSFetchRequest<SecondaryEntity>(entityName: entityName())
+    return NSFetchRequest<SecondaryEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection

--- a/Tests/Fixtures/Generated/CoreData/swift3-context-defaults.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift3-context-defaults.swift
@@ -11,16 +11,16 @@ import Foundation
 // MARK: - AbstractEntity
 
 internal class AbstractEntity: NSManagedObject {
-  internal class func entityName() -> String {
+  internal class var entityName: String {
     return "AbstractEntity"
   }
 
   internal class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc internal class func fetchRequest() -> NSFetchRequest<AbstractEntity> {
-    return NSFetchRequest<AbstractEntity>(entityName: entityName())
+    return NSFetchRequest<AbstractEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection
@@ -38,16 +38,16 @@ internal class AbstractEntity: NSManagedObject {
 // MARK: - ChildEntity
 
 internal class ChildEntity: MainEntity {
-  override internal class func entityName() -> String {
+  override internal class var entityName: String {
     return "ChildEntity"
   }
 
   override internal class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc internal class func fetchRequest() -> NSFetchRequest<ChildEntity> {
-    return NSFetchRequest<ChildEntity>(entityName: entityName())
+    return NSFetchRequest<ChildEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection
@@ -61,16 +61,16 @@ internal class ChildEntity: MainEntity {
 // MARK: - MainEntity
 
 internal class MainEntity: NSManagedObject {
-  internal class func entityName() -> String {
+  internal class var entityName: String {
     return "MainEntity"
   }
 
   internal class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc internal class func fetchRequest() -> NSFetchRequest<MainEntity> {
-    return NSFetchRequest<MainEntity>(entityName: entityName())
+    return NSFetchRequest<MainEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection
@@ -281,16 +281,16 @@ extension MainEntity {
 // MARK: - NewEntity
 
 internal class NewEntity: AbstractEntity {
-  override internal class func entityName() -> String {
+  override internal class var entityName: String {
     return "NewEntity"
   }
 
   override internal class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc internal class func fetchRequest() -> NSFetchRequest<NewEntity> {
-    return NSFetchRequest<NewEntity>(entityName: entityName())
+    return NSFetchRequest<NewEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection
@@ -301,16 +301,16 @@ internal class NewEntity: AbstractEntity {
 // MARK: - SecondaryEntity
 
 internal class SecondaryEntity: NSManagedObject {
-  internal class func entityName() -> String {
+  internal class var entityName: String {
     return "SecondaryEntity"
   }
 
   internal class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc internal class func fetchRequest() -> NSFetchRequest<SecondaryEntity> {
-    return NSFetchRequest<SecondaryEntity>(entityName: entityName())
+    return NSFetchRequest<SecondaryEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection

--- a/Tests/Fixtures/Generated/CoreData/swift4-context-defaults-generateObjcName.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift4-context-defaults-generateObjcName.swift
@@ -12,16 +12,16 @@ import Foundation
 
 @objc(AbstractEntity)
 internal class AbstractEntity: NSManagedObject {
-  internal class func entityName() -> String {
+  internal class var entityName: String {
     return "AbstractEntity"
   }
 
   internal class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc internal class func fetchRequest() -> NSFetchRequest<AbstractEntity> {
-    return NSFetchRequest<AbstractEntity>(entityName: entityName())
+    return NSFetchRequest<AbstractEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection
@@ -40,16 +40,16 @@ internal class AbstractEntity: NSManagedObject {
 
 @objc(ChildEntity)
 internal class ChildEntity: MainEntity {
-  override internal class func entityName() -> String {
+  override internal class var entityName: String {
     return "ChildEntity"
   }
 
   override internal class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc internal class func fetchRequest() -> NSFetchRequest<ChildEntity> {
-    return NSFetchRequest<ChildEntity>(entityName: entityName())
+    return NSFetchRequest<ChildEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection
@@ -64,16 +64,16 @@ internal class ChildEntity: MainEntity {
 
 @objc(MainEntity)
 internal class MainEntity: NSManagedObject {
-  internal class func entityName() -> String {
+  internal class var entityName: String {
     return "MainEntity"
   }
 
   internal class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc internal class func fetchRequest() -> NSFetchRequest<MainEntity> {
-    return NSFetchRequest<MainEntity>(entityName: entityName())
+    return NSFetchRequest<MainEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection
@@ -285,16 +285,16 @@ extension MainEntity {
 
 @objc(NewEntity)
 internal class NewEntity: AbstractEntity {
-  override internal class func entityName() -> String {
+  override internal class var entityName: String {
     return "NewEntity"
   }
 
   override internal class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc internal class func fetchRequest() -> NSFetchRequest<NewEntity> {
-    return NSFetchRequest<NewEntity>(entityName: entityName())
+    return NSFetchRequest<NewEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection
@@ -306,16 +306,16 @@ internal class NewEntity: AbstractEntity {
 
 @objc(SecondaryEntity)
 internal class SecondaryEntity: NSManagedObject {
-  internal class func entityName() -> String {
+  internal class var entityName: String {
     return "SecondaryEntity"
   }
 
   internal class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc internal class func fetchRequest() -> NSFetchRequest<SecondaryEntity> {
-    return NSFetchRequest<SecondaryEntity>(entityName: entityName())
+    return NSFetchRequest<SecondaryEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection

--- a/Tests/Fixtures/Generated/CoreData/swift4-context-defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift4-context-defaults-publicAccess.swift
@@ -11,16 +11,16 @@ import Foundation
 // MARK: - AbstractEntity
 
 public class AbstractEntity: NSManagedObject {
-  public class func entityName() -> String {
+  public class var entityName: String {
     return "AbstractEntity"
   }
 
   public class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc public class func fetchRequest() -> NSFetchRequest<AbstractEntity> {
-    return NSFetchRequest<AbstractEntity>(entityName: entityName())
+    return NSFetchRequest<AbstractEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection
@@ -38,16 +38,16 @@ public class AbstractEntity: NSManagedObject {
 // MARK: - ChildEntity
 
 public class ChildEntity: MainEntity {
-  override public class func entityName() -> String {
+  override public class var entityName: String {
     return "ChildEntity"
   }
 
   override public class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc public class func fetchRequest() -> NSFetchRequest<ChildEntity> {
-    return NSFetchRequest<ChildEntity>(entityName: entityName())
+    return NSFetchRequest<ChildEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection
@@ -61,16 +61,16 @@ public class ChildEntity: MainEntity {
 // MARK: - MainEntity
 
 public class MainEntity: NSManagedObject {
-  public class func entityName() -> String {
+  public class var entityName: String {
     return "MainEntity"
   }
 
   public class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc public class func fetchRequest() -> NSFetchRequest<MainEntity> {
-    return NSFetchRequest<MainEntity>(entityName: entityName())
+    return NSFetchRequest<MainEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection
@@ -281,16 +281,16 @@ extension MainEntity {
 // MARK: - NewEntity
 
 public class NewEntity: AbstractEntity {
-  override public class func entityName() -> String {
+  override public class var entityName: String {
     return "NewEntity"
   }
 
   override public class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc public class func fetchRequest() -> NSFetchRequest<NewEntity> {
-    return NSFetchRequest<NewEntity>(entityName: entityName())
+    return NSFetchRequest<NewEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection
@@ -301,16 +301,16 @@ public class NewEntity: AbstractEntity {
 // MARK: - SecondaryEntity
 
 public class SecondaryEntity: NSManagedObject {
-  public class func entityName() -> String {
+  public class var entityName: String {
     return "SecondaryEntity"
   }
 
   public class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc public class func fetchRequest() -> NSFetchRequest<SecondaryEntity> {
-    return NSFetchRequest<SecondaryEntity>(entityName: entityName())
+    return NSFetchRequest<SecondaryEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection

--- a/Tests/Fixtures/Generated/CoreData/swift4-context-defaults.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift4-context-defaults.swift
@@ -11,16 +11,16 @@ import Foundation
 // MARK: - AbstractEntity
 
 internal class AbstractEntity: NSManagedObject {
-  internal class func entityName() -> String {
+  internal class var entityName: String {
     return "AbstractEntity"
   }
 
   internal class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc internal class func fetchRequest() -> NSFetchRequest<AbstractEntity> {
-    return NSFetchRequest<AbstractEntity>(entityName: entityName())
+    return NSFetchRequest<AbstractEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection
@@ -38,16 +38,16 @@ internal class AbstractEntity: NSManagedObject {
 // MARK: - ChildEntity
 
 internal class ChildEntity: MainEntity {
-  override internal class func entityName() -> String {
+  override internal class var entityName: String {
     return "ChildEntity"
   }
 
   override internal class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc internal class func fetchRequest() -> NSFetchRequest<ChildEntity> {
-    return NSFetchRequest<ChildEntity>(entityName: entityName())
+    return NSFetchRequest<ChildEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection
@@ -61,16 +61,16 @@ internal class ChildEntity: MainEntity {
 // MARK: - MainEntity
 
 internal class MainEntity: NSManagedObject {
-  internal class func entityName() -> String {
+  internal class var entityName: String {
     return "MainEntity"
   }
 
   internal class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc internal class func fetchRequest() -> NSFetchRequest<MainEntity> {
-    return NSFetchRequest<MainEntity>(entityName: entityName())
+    return NSFetchRequest<MainEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection
@@ -281,16 +281,16 @@ extension MainEntity {
 // MARK: - NewEntity
 
 internal class NewEntity: AbstractEntity {
-  override internal class func entityName() -> String {
+  override internal class var entityName: String {
     return "NewEntity"
   }
 
   override internal class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc internal class func fetchRequest() -> NSFetchRequest<NewEntity> {
-    return NSFetchRequest<NewEntity>(entityName: entityName())
+    return NSFetchRequest<NewEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection
@@ -301,16 +301,16 @@ internal class NewEntity: AbstractEntity {
 // MARK: - SecondaryEntity
 
 internal class SecondaryEntity: NSManagedObject {
-  internal class func entityName() -> String {
+  internal class var entityName: String {
     return "SecondaryEntity"
   }
 
   internal class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc internal class func fetchRequest() -> NSFetchRequest<SecondaryEntity> {
-    return NSFetchRequest<SecondaryEntity>(entityName: entityName())
+    return NSFetchRequest<SecondaryEntity>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection

--- a/templates/coredata/swift3.stencil
+++ b/templates/coredata/swift3.stencil
@@ -27,16 +27,16 @@ import Foundation
 {% endif %}
 {{ accessModifier }} class {{ entityClassName }}: {{ superclass }} {
   {% set override %}{% if superclass != "NSManagedObject" %}override {% endif %}{% endset %}
-  {{ override }}{{ accessModifier }} class func entityName() -> String {
+  {{ override }}{{ accessModifier }} class var entityName: String {
     return "{{ entity.name }}"
   }
 
   {{ override }}{{ accessModifier }} class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc {{ accessModifier }} class func fetchRequest() -> NSFetchRequest<{{ entityClassName }}> {
-    return NSFetchRequest<{{ entityClassName }}>(entityName: entityName())
+    return NSFetchRequest<{{ entityClassName }}>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection

--- a/templates/coredata/swift4.stencil
+++ b/templates/coredata/swift4.stencil
@@ -27,16 +27,16 @@ import Foundation
 {% endif %}
 {{ accessModifier }} class {{ entityClassName }}: {{ superclass }} {
   {% set override %}{% if superclass != "NSManagedObject" %}override {% endif %}{% endset %}
-  {{ override }}{{ accessModifier }} class func entityName() -> String {
+  {{ override }}{{ accessModifier }} class var entityName: String {
     return "{{ entity.name }}"
   }
 
   {{ override }}{{ accessModifier }} class func entity(in managedObjectContext: NSManagedObjectContext) -> NSEntityDescription? {
-    return NSEntityDescription.entity(forEntityName: entityName(), in: managedObjectContext)
+    return NSEntityDescription.entity(forEntityName: entityName, in: managedObjectContext)
   }
 
   @nonobjc {{ accessModifier }} class func fetchRequest() -> NSFetchRequest<{{ entityClassName }}> {
-    return NSFetchRequest<{{ entityClassName }}>(entityName: entityName())
+    return NSFetchRequest<{{ entityClassName }}>(entityName: entityName)
   }
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection


### PR DESCRIPTION
Apparently we based ourselves a bit too much on old Mogenerator code 😅

This goes from:
```swift
class func entityName() -> String {
```

To:
```swift
class var entityName: String {
```

I'd honestly consider this a "bug fix", although it should be considered a breaking change.