### PR TITLE
Parser Options - Part 2: Safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Each command now accepts an `options` dictionary, with which you can set internal parser settings to change its behaviour. See the commands' specific documentation for available options.  
   [David Jennes](https://github.com/djbe)
   [#587](https://github.com/SwiftGen/SwiftGen/pull/587)
+  [#597](https://github.com/SwiftGen/SwiftGen/pull/597)
 * Strings: the parser now accepts a `separator` option, used to split keys into structured components. The default separator remains `.`. For more information, check the [command's documentation](Documentation/Commands/strings.md#customization).  
   [David Jennes](https://github.com/djbe)
   [#576](https://github.com/SwiftGen/SwiftGen/issue/576)

--- a/Sources/SwiftGen/Commander/ConfigCommands.swift
+++ b/Sources/SwiftGen/Commander/ConfigCommands.swift
@@ -50,7 +50,7 @@ extension ConfigEntry {
   }
 
   func run(parserCommand: ParserCLI) throws {
-    let parser = try parserCommand.parserType.createWith(options: options) { msg, _, _ in
+    let parser = try parserCommand.parserType.init(options: options) { msg, _, _ in
       logMessage(.warning, msg)
     }
 

--- a/Sources/SwiftGen/Commander/ConfigCommands.swift
+++ b/Sources/SwiftGen/Commander/ConfigCommands.swift
@@ -50,8 +50,7 @@ extension ConfigEntry {
   }
 
   func run(parserCommand: ParserCLI) throws {
-    try parserCommand.parserType.allOptions.check(options: options)
-    let parser = try parserCommand.parserType.init(options: options) { msg, _, _ in
+    let parser = try parserCommand.parserType.createWith(options: options) { msg, _, _ in
       logMessage(.warning, msg)
     }
 

--- a/Sources/SwiftGen/Commander/ConfigCommands.swift
+++ b/Sources/SwiftGen/Commander/ConfigCommands.swift
@@ -50,9 +50,11 @@ extension ConfigEntry {
   }
 
   func run(parserCommand: ParserCLI) throws {
-    let parser = try parserCommand.parserType.init(options: [:]) { msg, _, _ in
+    try parserCommand.parserType.allOptions.check(options: options)
+    let parser = try parserCommand.parserType.init(options: options) { msg, _, _ in
       logMessage(.warning, msg)
     }
+
     let filter = try Filter(pattern: self.filter ?? parserCommand.parserType.defaultFilter)
     try parser.searchAndParse(paths: inputs, filter: filter)
     let context = parser.stencilContext()

--- a/Sources/SwiftGen/Commander/ParserCLICommands.swift
+++ b/Sources/SwiftGen/Commander/ParserCLICommands.swift
@@ -77,7 +77,7 @@ extension ParserCLI {
     ) { oldTemplateName, templateName, templatePath, parserOptions, parameters, filter, output, paths in
       try ErrorPrettifier.execute {
         let options = try Parameters.parse(items: parserOptions)
-        let parser = try self.parserType.createWith(options: options) { msg, _, _ in
+        let parser = try self.parserType.init(options: options) { msg, _, _ in
           logMessage(.warning, msg)
         }
 

--- a/Sources/SwiftGen/Commander/ParserCLICommands.swift
+++ b/Sources/SwiftGen/Commander/ParserCLICommands.swift
@@ -30,11 +30,13 @@ extension ParserCLI {
       )
     }
 
-    static let options = VariadicOption<String>(
-      "option",
-      default: [],
-      description: "List of parser options"
-    )
+    static func options(for parser: ParserCLI) -> VariadicOption<String> {
+      return VariadicOption<String>(
+        "option",
+        default: [],
+        description: "List of parser options. \(parser.parserType.allOptions)"
+      )
+    }
 
     static let params = VariadicOption<String>(
       "param",
@@ -67,7 +69,7 @@ extension ParserCLI {
       CLIOption.deprecatedTemplateName,
       CLIOption.templateName,
       CLIOption.templatePath,
-      CLIOption.options,
+      CLIOption.options(for: self),
       CLIOption.params,
       CLIOption.filter(for: self),
       OutputDestination.cliOption,
@@ -75,9 +77,11 @@ extension ParserCLI {
     ) { oldTemplateName, templateName, templatePath, parserOptions, parameters, filter, output, paths in
       try ErrorPrettifier.execute {
         let options = try Parameters.parse(items: parserOptions)
+        try self.parserType.allOptions.check(options: options)
         let parser = try self.parserType.init(options: options) { msg, _, _ in
           logMessage(.warning, msg)
         }
+
         let filter = try Filter(pattern: filter)
         try parser.searchAndParse(paths: paths, filter: filter)
 

--- a/Sources/SwiftGen/Commander/ParserCLICommands.swift
+++ b/Sources/SwiftGen/Commander/ParserCLICommands.swift
@@ -77,8 +77,7 @@ extension ParserCLI {
     ) { oldTemplateName, templateName, templatePath, parserOptions, parameters, filter, output, paths in
       try ErrorPrettifier.execute {
         let options = try Parameters.parse(items: parserOptions)
-        try self.parserType.allOptions.check(options: options)
-        let parser = try self.parserType.init(options: options) { msg, _, _ in
+        let parser = try self.parserType.createWith(options: options) { msg, _, _ in
           logMessage(.warning, msg)
         }
 

--- a/Sources/SwiftGenKit/Parsers/AssetsCatalog/AssetsCatalogParser.swift
+++ b/Sources/SwiftGenKit/Parsers/AssetsCatalog/AssetsCatalogParser.swift
@@ -17,7 +17,6 @@ public enum AssetsCatalog {
     }
 
     public static let defaultFilter = "[^/]\\.xcassets$"
-    public static let allOptions = ParserOptionList()
 
     public func parse(path: Path, relativeTo parent: Path) throws {
       let catalog = Catalog(path: path)

--- a/Sources/SwiftGenKit/Parsers/AssetsCatalog/AssetsCatalogParser.swift
+++ b/Sources/SwiftGenKit/Parsers/AssetsCatalog/AssetsCatalogParser.swift
@@ -10,9 +10,11 @@ import PathKit
 public enum AssetsCatalog {
   public final class Parser: SwiftGenKit.Parser {
     var catalogs = [Catalog]()
+    private let options: ParserOptionValues
     public var warningHandler: Parser.MessageHandler?
 
-    public init(options: [String: Any] = [:], warningHandler: Parser.MessageHandler? = nil) {
+    public init(options: [String: Any] = [:], warningHandler: Parser.MessageHandler? = nil) throws {
+      self.options = try ParserOptionValues(options: options, available: Parser.allOptions)
       self.warningHandler = warningHandler
     }
 

--- a/Sources/SwiftGenKit/Parsers/AssetsCatalog/AssetsCatalogParser.swift
+++ b/Sources/SwiftGenKit/Parsers/AssetsCatalog/AssetsCatalogParser.swift
@@ -17,6 +17,7 @@ public enum AssetsCatalog {
     }
 
     public static let defaultFilter = "[^/]\\.xcassets$"
+    public static let allOptions = ParserOptionList()
 
     public func parse(path: Path, relativeTo parent: Path) throws {
       let catalog = Catalog(path: path)

--- a/Sources/SwiftGenKit/Parsers/Colors/ColorsCLRFileParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Colors/ColorsCLRFileParser.swift
@@ -13,7 +13,6 @@ extension Colors {
     init(options: [String: Any] = [:]) {
     }
 
-    static let allOptions = ParserOptionList()
     static let extensions = ["clr"]
 
     private enum Keys {

--- a/Sources/SwiftGenKit/Parsers/Colors/ColorsCLRFileParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Colors/ColorsCLRFileParser.swift
@@ -10,7 +10,7 @@ import PathKit
 
 extension Colors {
   final class CLRFileParser: ColorsFileTypeParser {
-    init(options: [String: Any] = [:]) {
+    init(options: ParserOptionValues) {
     }
 
     static let extensions = ["clr"]

--- a/Sources/SwiftGenKit/Parsers/Colors/ColorsCLRFileParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Colors/ColorsCLRFileParser.swift
@@ -10,6 +10,10 @@ import PathKit
 
 extension Colors {
   final class CLRFileParser: ColorsFileTypeParser {
+    init(options: [String: Any] = [:]) {
+    }
+
+    static let allOptions = ParserOptionList()
     static let extensions = ["clr"]
 
     private enum Keys {

--- a/Sources/SwiftGenKit/Parsers/Colors/ColorsFileTypeParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Colors/ColorsFileTypeParser.swift
@@ -16,9 +16,11 @@ extension Colors {
 }
 
 protocol ColorsFileTypeParser: AnyObject {
+  init(options: [String: Any])
+
+  static var allOptions: ParserOptionList { get }
   static var extensions: [String] { get }
 
-  init()
   func parseFile(at path: Path) throws -> Colors.Palette
 }
 

--- a/Sources/SwiftGenKit/Parsers/Colors/ColorsFileTypeParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Colors/ColorsFileTypeParser.swift
@@ -24,6 +24,12 @@ protocol ColorsFileTypeParser: AnyObject {
   func parseFile(at path: Path) throws -> Colors.Palette
 }
 
+extension ColorsFileTypeParser {
+  static var allOptions: ParserOptionList {
+    return []
+  }
+}
+
 // MARK: - Private Helpers
 
 extension Colors {

--- a/Sources/SwiftGenKit/Parsers/Colors/ColorsFileTypeParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Colors/ColorsFileTypeParser.swift
@@ -16,7 +16,7 @@ extension Colors {
 }
 
 protocol ColorsFileTypeParser: AnyObject {
-  init(options: [String: Any])
+  init(options: ParserOptionValues)
 
   static var allOptions: ParserOptionList { get }
   static var extensions: [String] { get }

--- a/Sources/SwiftGenKit/Parsers/Colors/ColorsJSONFileParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Colors/ColorsJSONFileParser.swift
@@ -9,6 +9,10 @@ import PathKit
 
 extension Colors {
   final class JSONFileParser: ColorsFileTypeParser {
+    init(options: [String: Any] = [:]) {
+    }
+
+    static let allOptions = ParserOptionList()
     static let extensions = ["json"]
 
     func parseFile(at path: Path) throws -> Palette {

--- a/Sources/SwiftGenKit/Parsers/Colors/ColorsJSONFileParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Colors/ColorsJSONFileParser.swift
@@ -9,7 +9,7 @@ import PathKit
 
 extension Colors {
   final class JSONFileParser: ColorsFileTypeParser {
-    init(options: [String: Any] = [:]) {
+    init(options: ParserOptionValues) {
     }
 
     static let extensions = ["json"]

--- a/Sources/SwiftGenKit/Parsers/Colors/ColorsJSONFileParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Colors/ColorsJSONFileParser.swift
@@ -12,7 +12,6 @@ extension Colors {
     init(options: [String: Any] = [:]) {
     }
 
-    static let allOptions = ParserOptionList()
     static let extensions = ["json"]
 
     func parseFile(at path: Path) throws -> Palette {

--- a/Sources/SwiftGenKit/Parsers/Colors/ColorsParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Colors/ColorsParser.swift
@@ -31,6 +31,7 @@ public enum Colors {
 
   public final class Parser: SwiftGenKit.Parser {
     private var parsers = [String: ColorsFileTypeParser.Type]()
+    private let options: [String: Any]
     var palettes = [Palette]()
     public var warningHandler: Parser.MessageHandler?
 
@@ -42,6 +43,7 @@ public enum Colors {
     ]
 
     public init(options: [String: Any] = [:], warningHandler: Parser.MessageHandler? = nil) {
+      self.options = options
       self.warningHandler = warningHandler
 
       for parser in Parser.subParsers {
@@ -54,12 +56,16 @@ public enum Colors {
       return "[^/]\\.(?i:\(extensions))$"
     }
 
+    public static var allOptions: ParserOptionList {
+      return ParserOptionList(lists: Parser.subParsers.map { $0.allOptions })
+    }
+
     public func parse(path: Path, relativeTo parent: Path) throws {
       guard let parserType = parsers[path.extension?.lowercased() ?? ""] else {
         throw ParserError.unsupportedFileType(path: path, supported: parsers.keys.sorted())
       }
 
-      let parser = parserType.init()
+      let parser = parserType.init(options: options)
       let palette = try parser.parseFile(at: path)
       palettes += [palette]
     }

--- a/Sources/SwiftGenKit/Parsers/Colors/ColorsParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Colors/ColorsParser.swift
@@ -31,7 +31,7 @@ public enum Colors {
 
   public final class Parser: SwiftGenKit.Parser {
     private var parsers = [String: ColorsFileTypeParser.Type]()
-    private let options: [String: Any]
+    private let options: ParserOptionValues
     var palettes = [Palette]()
     public var warningHandler: Parser.MessageHandler?
 
@@ -42,8 +42,8 @@ public enum Colors {
       XMLFileParser.self
     ]
 
-    public init(options: [String: Any] = [:], warningHandler: Parser.MessageHandler? = nil) {
-      self.options = options
+    public init(options: [String: Any] = [:], warningHandler: Parser.MessageHandler? = nil) throws {
+      self.options = try ParserOptionValues(options: options, available: Parser.allOptions)
       self.warningHandler = warningHandler
 
       for parser in Parser.subParsers {

--- a/Sources/SwiftGenKit/Parsers/Colors/ColorsTXTFileParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Colors/ColorsTXTFileParser.swift
@@ -11,7 +11,7 @@ extension Colors {
   final class TextFileParser: ColorsFileTypeParser {
     private var colors = [String: UInt32]()
 
-    init(options: [String: Any] = [:]) {
+    init(options: ParserOptionValues) {
     }
 
     static let extensions = ["txt"]

--- a/Sources/SwiftGenKit/Parsers/Colors/ColorsTXTFileParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Colors/ColorsTXTFileParser.swift
@@ -14,7 +14,6 @@ extension Colors {
     init(options: [String: Any] = [:]) {
     }
 
-    static let allOptions = ParserOptionList()
     static let extensions = ["txt"]
 
     // Text file expected to be:

--- a/Sources/SwiftGenKit/Parsers/Colors/ColorsXMLFileParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Colors/ColorsXMLFileParser.swift
@@ -10,7 +10,7 @@ import PathKit
 
 extension Colors {
   final class XMLFileParser: ColorsFileTypeParser {
-    init(options: [String: Any] = [:]) {
+    init(options: ParserOptionValues) {
     }
 
     static let extensions = ["xml"]

--- a/Sources/SwiftGenKit/Parsers/Colors/ColorsXMLFileParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Colors/ColorsXMLFileParser.swift
@@ -13,7 +13,6 @@ extension Colors {
     init(options: [String: Any] = [:]) {
     }
 
-    static let allOptions = ParserOptionList()
     static let extensions = ["xml"]
 
     private enum XML {

--- a/Sources/SwiftGenKit/Parsers/Colors/ColorsXMLFileParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Colors/ColorsXMLFileParser.swift
@@ -10,6 +10,10 @@ import PathKit
 
 extension Colors {
   final class XMLFileParser: ColorsFileTypeParser {
+    init(options: [String: Any] = [:]) {
+    }
+
+    static let allOptions = ParserOptionList()
     static let extensions = ["xml"]
 
     private enum XML {

--- a/Sources/SwiftGenKit/Parsers/CoreData/CoreDataParser.swift
+++ b/Sources/SwiftGenKit/Parsers/CoreData/CoreDataParser.swift
@@ -40,7 +40,6 @@ public enum CoreData {
     }
 
     public static let defaultFilter = "[^/]\\.xcdatamodeld?$"
-    public static let allOptions = ParserOptionList()
 
     public func parse(path: Path, relativeTo parent: Path) throws {
       if path.extension == Constants.modelBundleExtension {

--- a/Sources/SwiftGenKit/Parsers/CoreData/CoreDataParser.swift
+++ b/Sources/SwiftGenKit/Parsers/CoreData/CoreDataParser.swift
@@ -40,6 +40,7 @@ public enum CoreData {
     }
 
     public static let defaultFilter = "[^/]\\.xcdatamodeld?$"
+    public static let allOptions = ParserOptionList()
 
     public func parse(path: Path, relativeTo parent: Path) throws {
       if path.extension == Constants.modelBundleExtension {

--- a/Sources/SwiftGenKit/Parsers/CoreData/CoreDataParser.swift
+++ b/Sources/SwiftGenKit/Parsers/CoreData/CoreDataParser.swift
@@ -32,10 +32,12 @@ public enum CoreData {
   }
 
   public final class Parser: SwiftGenKit.Parser {
-    public var warningHandler: Parser.MessageHandler?
     var models: [Model] = []
+    private let options: ParserOptionValues
+    public var warningHandler: Parser.MessageHandler?
 
-    public init(options: [String: Any] = [:], warningHandler: Parser.MessageHandler? = nil) {
+    public init(options: [String: Any] = [:], warningHandler: Parser.MessageHandler? = nil) throws {
+      self.options = try ParserOptionValues(options: options, available: Parser.allOptions)
       self.warningHandler = warningHandler
     }
 

--- a/Sources/SwiftGenKit/Parsers/Fonts/FontsParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Fonts/FontsParser.swift
@@ -18,7 +18,6 @@ public enum Fonts {
     }
 
     public static let defaultFilter = "[^/]\\.(?i:otf|ttc|ttf)$"
-    public static let allOptions = ParserOptionList()
 
     public func parse(path: Path, relativeTo parent: Path) throws {
       guard let values = try? path.url.resourceValues(forKeys: [.typeIdentifierKey]),

--- a/Sources/SwiftGenKit/Parsers/Fonts/FontsParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Fonts/FontsParser.swift
@@ -18,6 +18,7 @@ public enum Fonts {
     }
 
     public static let defaultFilter = "[^/]\\.(?i:otf|ttc|ttf)$"
+    public static let allOptions = ParserOptionList()
 
     public func parse(path: Path, relativeTo parent: Path) throws {
       guard let values = try? path.url.resourceValues(forKeys: [.typeIdentifierKey]),

--- a/Sources/SwiftGenKit/Parsers/Fonts/FontsParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Fonts/FontsParser.swift
@@ -11,9 +11,11 @@ import PathKit
 public enum Fonts {
   public final class Parser: SwiftGenKit.Parser {
     var entries: [String: Set<Font>] = [:]
+    private let options: ParserOptionValues
     public var warningHandler: Parser.MessageHandler?
 
-    public init(options: [String: Any] = [:], warningHandler: Parser.MessageHandler? = nil) {
+    public init(options: [String: Any] = [:], warningHandler: Parser.MessageHandler? = nil) throws {
+      self.options = try ParserOptionValues(options: options, available: Parser.allOptions)
       self.warningHandler = warningHandler
     }
 

--- a/Sources/SwiftGenKit/Parsers/InterfaceBuilder/InterfaceBuilderParser.swift
+++ b/Sources/SwiftGenKit/Parsers/InterfaceBuilder/InterfaceBuilderParser.swift
@@ -32,7 +32,6 @@ public enum InterfaceBuilder {
     }
 
     public static let defaultFilter = "[^/]\\.storyboard$"
-    public static let allOptions = ParserOptionList()
 
     public func parse(path: Path, relativeTo parent: Path) throws {
       try addStoryboard(at: path)

--- a/Sources/SwiftGenKit/Parsers/InterfaceBuilder/InterfaceBuilderParser.swift
+++ b/Sources/SwiftGenKit/Parsers/InterfaceBuilder/InterfaceBuilderParser.swift
@@ -32,6 +32,7 @@ public enum InterfaceBuilder {
     }
 
     public static let defaultFilter = "[^/]\\.storyboard$"
+    public static let allOptions = ParserOptionList()
 
     public func parse(path: Path, relativeTo parent: Path) throws {
       try addStoryboard(at: path)

--- a/Sources/SwiftGenKit/Parsers/InterfaceBuilder/InterfaceBuilderParser.swift
+++ b/Sources/SwiftGenKit/Parsers/InterfaceBuilder/InterfaceBuilderParser.swift
@@ -24,10 +24,12 @@ public enum InterfaceBuilder {
   }
 
   public final class Parser: SwiftGenKit.Parser {
+    private let options: ParserOptionValues
     var storyboards = [Storyboard]()
     public var warningHandler: Parser.MessageHandler?
 
-    public init(options: [String: Any] = [:], warningHandler: Parser.MessageHandler? = nil) {
+    public init(options: [String: Any] = [:], warningHandler: Parser.MessageHandler? = nil) throws {
+      self.options = try ParserOptionValues(options: options, available: Parser.allOptions)
       self.warningHandler = warningHandler
     }
 

--- a/Sources/SwiftGenKit/Parsers/Parser.swift
+++ b/Sources/SwiftGenKit/Parsers/Parser.swift
@@ -40,17 +40,6 @@ public protocol Parser {
 }
 
 public extension Parser {
-  /// Factory method for safely creating a parser instance. Options will be checked against the list of
-  /// supported options (in `allOptions`).
-  ///
-  /// - Parameter options: Dictionary of options, checked against `allOptions`.
-  /// - Parameter warningHandler: Callback for logging issues.
-  /// - Returns: An instance of the parser.
-  static func createWith(options: [String: Any], warningHandler: MessageHandler?) throws -> Self {
-    try allOptions.check(options: options)
-    return try Self.init(options: options, warningHandler: warningHandler)
-  }
-
   /// Recursively search through the given paths, parsing any file or folder that matches the given filter.
   ///
   /// - Parameter paths: The paths to search recursively through.

--- a/Sources/SwiftGenKit/Parsers/Parser.swift
+++ b/Sources/SwiftGenKit/Parsers/Parser.swift
@@ -8,6 +8,11 @@ import Foundation
 import PathKit
 
 public protocol Parser {
+  /// Parser initializer. Please use the `createWith(options:warningHandler:)` factory method instead,
+  /// it'll ensure the safety of the provided options.
+  ///
+  /// - Parameter options: Dictionary of options, used to customize processing.
+  /// - Parameter warningHandler: Callback for logging issues.
   init(options: [String: Any], warningHandler: MessageHandler?) throws
 
   /// Regex for the default filter
@@ -35,12 +40,31 @@ public protocol Parser {
 }
 
 public extension Parser {
+  /// Factory method for safely creating a parser instance. Options will be checked against the list of
+  /// supported options (in `allOptions`).
+  ///
+  /// - Parameter options: Dictionary of options, checked against `allOptions`.
+  /// - Parameter warningHandler: Callback for logging issues.
+  /// - Returns: An instance of the parser.
+  static func createWith(options: [String: Any], warningHandler: MessageHandler?) throws -> Self {
+    try allOptions.check(options: options)
+    return try Self.init(options: options, warningHandler: warningHandler)
+  }
+
+  /// Recursively search through the given paths, parsing any file or folder that matches the given filter.
+  ///
+  /// - Parameter paths: The paths to search recursively through.
+  /// - Parameter filter: The filter to apply to each path.
   func searchAndParse(paths: [Path], filter: Filter) throws {
     for path in paths {
       try searchAndParse(path: path, filter: filter)
     }
   }
 
+  /// Recursively search through the given path, parsing any file or folder that matches the given filter.
+  ///
+  /// - Parameter path: The path to search recursively through.
+  /// - Parameter filter: The filter to apply to each path.
   func searchAndParse(path: Path, filter: Filter) throws {
     if path.matches(filter: filter) {
       let parentDir = path.absolute().parent()

--- a/Sources/SwiftGenKit/Parsers/Parser.swift
+++ b/Sources/SwiftGenKit/Parsers/Parser.swift
@@ -79,3 +79,9 @@ public extension Parser {
     }
   }
 }
+
+public extension Parser {
+  static var allOptions: ParserOptionList {
+    return []
+  }
+}

--- a/Sources/SwiftGenKit/Parsers/Parser.swift
+++ b/Sources/SwiftGenKit/Parsers/Parser.swift
@@ -10,11 +10,21 @@ import PathKit
 public protocol Parser {
   init(options: [String: Any], warningHandler: MessageHandler?) throws
 
-  // regex for the default filter
+  /// Regex for the default filter
   static var defaultFilter: String { get }
 
-  // Parsing and context generation
+  /// List of supported options
+  static var allOptions: ParserOptionList { get }
+
+  /// Try to parse the file (or directory) at the given path, relative to some parent path.
+  ///
+  /// - Parameter path: The file/directory to parse
+  /// - Parameter parent: The parent path (may not be the direct parent)
   func parse(path: Path, relativeTo parent: Path) throws
+
+  /// Generate the stencil context from the parsed content.
+  ///
+  /// - Returns: A dictionary representing the parsed data 
   func stencilContext() -> [String: Any]
 
   /// This callback will be called when a Parser want to emit a diagnostics message

--- a/Sources/SwiftGenKit/Parsers/ParserOption.swift
+++ b/Sources/SwiftGenKit/Parsers/ParserOption.swift
@@ -1,0 +1,37 @@
+//
+// SwiftGenKit
+// Copyright © 2019 SwiftGen
+// MIT Licence
+//
+
+import Foundation
+
+/// A parser option, used to modify how it processes data.
+public protocol AnyParserOption {
+  var key: String { get }
+}
+
+/// A parser option of a specific value type
+struct ParserOption<T>: AnyParserOption {
+  enum OptionError: Swift.Error {
+    case invalidType(key: String, expected: Any.Type, got: Any.Type, value: Any)
+  }
+
+  let key: String
+  let defaultValue: T
+  let help: String
+
+  func get(from dict: [String: Any]) throws -> T {
+    let value = dict[key] ?? defaultValue
+    guard let typed = value as? T else {
+      throw OptionError.invalidType(key: key, expected: T.self, got: type(of: value), value: value)
+    }
+    return typed
+  }
+}
+
+extension ParserOption: CustomStringConvertible {
+  public var description: String {
+    return "\(key) (\(T.self)) [default: \(defaultValue)]: \(help)"
+  }
+}

--- a/Sources/SwiftGenKit/Parsers/ParserOption.swift
+++ b/Sources/SwiftGenKit/Parsers/ParserOption.swift
@@ -9,6 +9,9 @@ import Foundation
 /// A parser option, used to modify how it processes data.
 public protocol AnyParserOption {
   var key: String { get }
+
+  /// Check if the given dictionary contains a valid value for this option.
+  func check(dict: [String: Any]) -> Bool
 }
 
 /// A parser option of a specific value type
@@ -27,6 +30,11 @@ struct ParserOption<T>: AnyParserOption {
       throw OptionError.invalidType(key: key, expected: T.self, got: type(of: value), value: value)
     }
     return typed
+  }
+
+  func check(dict: [String: Any]) -> Bool {
+    guard let value = dict[key] else { return true }
+    return value is T
   }
 }
 

--- a/Sources/SwiftGenKit/Parsers/ParserOptionList.swift
+++ b/Sources/SwiftGenKit/Parsers/ParserOptionList.swift
@@ -24,7 +24,7 @@ public struct ParserOptionList {
   /// Check if the given dictionary of key values are all supported options.
   ///
   /// - Parameter options: a dictionary of options
-  public func check(options: [String: Any]) throws {
+  func check(options: [String: Any]) throws {
     let known = Set(self.options.map { $0.key })
     for option in options where !known.contains(option.key) {
       throw Error.unknownOption(key: option.key, value: option.value)

--- a/Sources/SwiftGenKit/Parsers/ParserOptionList.swift
+++ b/Sources/SwiftGenKit/Parsers/ParserOptionList.swift
@@ -1,0 +1,40 @@
+//
+// SwiftGenKit
+// Copyright © 2019 SwiftGen
+// MIT Licence
+//
+
+import Foundation
+
+public struct ParserOptionList {
+  enum Error: Swift.Error {
+    case unknownOption(key: String, value: Any)
+  }
+
+  private let options: [AnyParserOption]
+
+  init(options: [AnyParserOption] = []) {
+    self.options = options
+  }
+
+  /// Check if the given dictionary of key values are all supported options.
+  ///
+  /// - Parameter options: a dictionary of options
+  public func check(options: [String: Any]) throws {
+    let known = Set(self.options.map { $0.key })
+    for option in options where !known.contains(option.key) {
+      throw Error.unknownOption(key: option.key, value: option.value)
+    }
+  }
+}
+
+extension ParserOptionList: CustomStringConvertible {
+  public var description: String {
+    if options.isEmpty {
+      return "This parser currently doesn't accept any options."
+    } else {
+      return "Supported options:\n" +
+        options.map { "       - \($0)" }.joined(separator: "\n")
+    }
+  }
+}

--- a/Sources/SwiftGenKit/Parsers/ParserOptionList.swift
+++ b/Sources/SwiftGenKit/Parsers/ParserOptionList.swift
@@ -11,24 +11,32 @@ public struct ParserOptionList {
     case unknownOption(key: String, value: Any)
   }
 
-  private let options: [AnyParserOption]
+  let knownKeys: Set<String>
+  let options: [AnyParserOption]
 
   init(options: [AnyParserOption] = []) {
     self.options = options
+    self.knownKeys = Set(options.map { $0.key })
   }
 
   init(lists: [ParserOptionList]) {
-    self.options = lists.flatMap { $0.options }
+    self.init(options: lists.flatMap { $0.options })
   }
 
   /// Check if the given dictionary of key values are all supported options.
   ///
   /// - Parameter options: a dictionary of options
   func check(options: [String: Any]) throws {
-    let knownKeys = Set(self.options.map { $0.key })
     if let badOption = options.first(where: { !knownKeys.contains($0.key) }) {
       throw Error.unknownOption(key: badOption.key, value: badOption.value)
     }
+  }
+
+  /// Check if the given key is a known option
+  ///
+  /// - Parameter option: an option name
+  func has(option: AnyParserOption) -> Bool {
+    return knownKeys.contains(option.key)
   }
 }
 

--- a/Sources/SwiftGenKit/Parsers/ParserOptionList.swift
+++ b/Sources/SwiftGenKit/Parsers/ParserOptionList.swift
@@ -17,6 +17,10 @@ public struct ParserOptionList {
     self.options = options
   }
 
+  init(lists: [ParserOptionList]) {
+    self.options = lists.flatMap { $0.options }
+  }
+
   /// Check if the given dictionary of key values are all supported options.
   ///
   /// - Parameter options: a dictionary of options

--- a/Sources/SwiftGenKit/Parsers/ParserOptionList.swift
+++ b/Sources/SwiftGenKit/Parsers/ParserOptionList.swift
@@ -25,9 +25,9 @@ public struct ParserOptionList {
   ///
   /// - Parameter options: a dictionary of options
   func check(options: [String: Any]) throws {
-    let known = Set(self.options.map { $0.key })
-    for option in options where !known.contains(option.key) {
-      throw Error.unknownOption(key: option.key, value: option.value)
+    let knownKeys = Set(self.options.map { $0.key })
+    if let badOption = options.first(where: { !knownKeys.contains($0.key) }) {
+      throw Error.unknownOption(key: badOption.key, value: badOption.value)
     }
   }
 }
@@ -40,5 +40,11 @@ extension ParserOptionList: CustomStringConvertible {
       return "Supported options:\n" +
         options.map { "       - \($0)" }.joined(separator: "\n")
     }
+  }
+}
+
+extension ParserOptionList: ExpressibleByArrayLiteral {
+  public init(arrayLiteral elements: AnyParserOption...) {
+    self.init(options: elements)
   }
 }

--- a/Sources/SwiftGenKit/Parsers/ParserOptionList.swift
+++ b/Sources/SwiftGenKit/Parsers/ParserOptionList.swift
@@ -38,6 +38,21 @@ public struct ParserOptionList {
   func has(option: AnyParserOption) -> Bool {
     return knownKeys.contains(option.key)
   }
+
+  /// Verify the given dictionary and generate a list of messages for any issues.
+  ///
+  /// - Parameter dict: the dictionary to verify
+  /// - Returns: a list of messages if there are any issues
+  public func lint(options dict: [String: Any]) -> [String] {
+    let unknownKeys = Set(dict.keys).subtracting(knownKeys).map {
+      "\($0) is not a valid option."
+    }
+    let invalidValues = options.filter { !$0.check(dict: dict) }.map {
+      "Invalid value for option \($0)."
+    }
+
+    return unknownKeys + invalidValues
+  }
 }
 
 extension ParserOptionList: CustomStringConvertible {

--- a/Sources/SwiftGenKit/Parsers/ParserOptionValues.swift
+++ b/Sources/SwiftGenKit/Parsers/ParserOptionValues.swift
@@ -1,0 +1,25 @@
+//
+// SwiftGenKit
+// Copyright © 2019 SwiftGen
+// MIT Licence
+//
+
+import Foundation
+
+struct ParserOptionValues {
+  private let options: [String: Any]
+  private let available: ParserOptionList
+
+  init(options: [String: Any], available: ParserOptionList) throws {
+    try available.check(options: options)
+    self.options = options
+    self.available = available
+  }
+
+  subscript<T>(option: ParserOption<T>) -> T {
+    guard available.has(option: option) else {
+      fatalError("Trying to get unknown option \(option.key)")
+    }
+    return (try? option.get(from: options)) ?? option.defaultValue
+  }
+}

--- a/Sources/SwiftGenKit/Parsers/Plist/PlistParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Plist/PlistParser.swift
@@ -30,7 +30,6 @@ public enum Plist {
     }
 
     public static let defaultFilter = "[^/]\\.(?i:plist)$"
-    public static let allOptions = ParserOptionList()
 
     public func parse(path: Path, relativeTo parent: Path) throws {
       files.append(try File(path: path, relativeTo: parent))

--- a/Sources/SwiftGenKit/Parsers/Plist/PlistParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Plist/PlistParser.swift
@@ -30,6 +30,7 @@ public enum Plist {
     }
 
     public static let defaultFilter = "[^/]\\.(?i:plist)$"
+    public static let allOptions = ParserOptionList()
 
     public func parse(path: Path, relativeTo parent: Path) throws {
       files.append(try File(path: path, relativeTo: parent))

--- a/Sources/SwiftGenKit/Parsers/Plist/PlistParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Plist/PlistParser.swift
@@ -22,10 +22,12 @@ public enum Plist {
   // MARK: Plist File Parser
 
   public final class Parser: SwiftGenKit.Parser {
+    private let options: ParserOptionValues
     var files: [File] = []
     public var warningHandler: Parser.MessageHandler?
 
-    public init(options: [String: Any] = [:], warningHandler: Parser.MessageHandler? = nil) {
+    public init(options: [String: Any] = [:], warningHandler: Parser.MessageHandler? = nil) throws {
+      self.options = try ParserOptionValues(options: options, available: Parser.allOptions)
       self.warningHandler = warningHandler
     }
 

--- a/Sources/SwiftGenKit/Parsers/Strings/StringsEntry.swift
+++ b/Sources/SwiftGenKit/Parsers/Strings/StringsEntry.swift
@@ -28,8 +28,6 @@ extension Strings {
 
     // MARK: - Structured keys
 
-    static let defaultSeparator = "."
-
     private static func split(key: String, separator: String) -> [String] {
       return key
         .components(separatedBy: separator)

--- a/Sources/SwiftGenKit/Parsers/Strings/StringsParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Strings/StringsParser.swift
@@ -29,7 +29,11 @@ public enum Strings {
   }
 
   private enum Option {
-    static let separator = "separator"
+    static let separator = ParserOption(
+      key: "separator",
+      defaultValue: ".",
+      help: "Separator used to split keys into components"
+    )
   }
 
   public final class Parser: SwiftGenKit.Parser {
@@ -37,13 +41,13 @@ public enum Strings {
     public var warningHandler: Parser.MessageHandler?
     private let keyStructureSeparator: String
 
-    public init(options: [String: Any] = [:], warningHandler: Parser.MessageHandler? = nil) {
+    public init(options: [String: Any] = [:], warningHandler: Parser.MessageHandler? = nil) throws {
       self.warningHandler = warningHandler
-      self.keyStructureSeparator = (options[Option.separator] as? String) ?? Entry.defaultSeparator
+      self.keyStructureSeparator = try Option.separator.get(from: options)
     }
 
     public static let defaultFilter = "[^/]\\.strings$"
-    public static let allOptions = ParserOptionList()
+    public static let allOptions = ParserOptionList(options: [Option.separator])
 
     // Localizable.strings files are generally UTF16, not UTF8!
     public func parse(path: Path, relativeTo parent: Path) throws {

--- a/Sources/SwiftGenKit/Parsers/Strings/StringsParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Strings/StringsParser.swift
@@ -28,7 +28,7 @@ public enum Strings {
     }
   }
 
-  private enum Option {
+  public enum Option {
     static let separator = ParserOption(
       key: "separator",
       defaultValue: ".",
@@ -47,7 +47,7 @@ public enum Strings {
     }
 
     public static let defaultFilter = "[^/]\\.strings$"
-    public static let allOptions = ParserOptionList(options: [Option.separator])
+    public static let allOptions: ParserOptionList = [Option.separator]
 
     // Localizable.strings files are generally UTF16, not UTF8!
     public func parse(path: Path, relativeTo parent: Path) throws {

--- a/Sources/SwiftGenKit/Parsers/Strings/StringsParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Strings/StringsParser.swift
@@ -43,6 +43,7 @@ public enum Strings {
     }
 
     public static let defaultFilter = "[^/]\\.strings$"
+    public static let allOptions = ParserOptionList()
 
     // Localizable.strings files are generally UTF16, not UTF8!
     public func parse(path: Path, relativeTo parent: Path) throws {

--- a/Sources/SwiftGenKit/Parsers/Strings/StringsParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Strings/StringsParser.swift
@@ -37,13 +37,13 @@ public enum Strings {
   }
 
   public final class Parser: SwiftGenKit.Parser {
+    private let options: ParserOptionValues
     var tables = [String: [Entry]]()
     public var warningHandler: Parser.MessageHandler?
-    private let keyStructureSeparator: String
 
     public init(options: [String: Any] = [:], warningHandler: Parser.MessageHandler? = nil) throws {
+      self.options = try ParserOptionValues(options: options, available: Parser.allOptions)
       self.warningHandler = warningHandler
-      self.keyStructureSeparator = try Option.separator.get(from: options)
     }
 
     public static let defaultFilter = "[^/]\\.strings$"
@@ -66,7 +66,7 @@ public enum Strings {
       }
 
       tables[name] = try dict.map { key, translation in
-        try Entry(key: key, translation: translation, keyStructureSeparator: keyStructureSeparator)
+        try Entry(key: key, translation: translation, keyStructureSeparator: options[Option.separator])
       }
     }
   }

--- a/Sources/SwiftGenKit/Parsers/Yaml/YamlParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Yaml/YamlParser.swift
@@ -34,6 +34,8 @@ public enum Yaml {
       return "[^/]\\.(?i:ya?ml)$"
     }
 
+    public static let allOptions = ParserOptionList()
+
     public func parse(path: Path, relativeTo parent: Path) throws {
       files.append(try File(path: path, relativeTo: parent))
     }

--- a/Sources/SwiftGenKit/Parsers/Yaml/YamlParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Yaml/YamlParser.swift
@@ -23,10 +23,12 @@ public enum Yaml {
   // MARK: Yaml File Parser
 
   public class Parser: SwiftGenKit.Parser {
+    private let options: ParserOptionValues
     var files: [File] = []
     public var warningHandler: Parser.MessageHandler?
 
-    public required init(options: [String: Any] = [:], warningHandler: Parser.MessageHandler? = nil) {
+    public required init(options: [String: Any] = [:], warningHandler: Parser.MessageHandler? = nil) throws {
+      self.options = try ParserOptionValues(options: options, available: Parser.allOptions)
       self.warningHandler = warningHandler
     }
 

--- a/Sources/SwiftGenKit/Parsers/Yaml/YamlParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Yaml/YamlParser.swift
@@ -34,8 +34,6 @@ public enum Yaml {
       return "[^/]\\.(?i:ya?ml)$"
     }
 
-    public static let allOptions = ParserOptionList()
-
     public func parse(path: Path, relativeTo parent: Path) throws {
       files.append(try File(path: path, relativeTo: parent))
     }

--- a/SwiftGen.xcodeproj/project.pbxproj
+++ b/SwiftGen.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		DD428E261FC50FBF001649D6 /* InterfaceBuilderContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD428E161FC50FBF001649D6 /* InterfaceBuilderContext.swift */; };
 		DD428E271FC50FBF001649D6 /* StringsContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD428E171FC50FBF001649D6 /* StringsContext.swift */; };
 		DD4738A81FE07596006CB6BB /* StencilContexts in Resources */ = {isa = PBXBuildFile; fileRef = DDDE52761FAF81DB004203BE /* StencilContexts */; };
+		DD48AD802210ACBD00336621 /* ParserOptionValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD48AD7E2210AC5E00336621 /* ParserOptionValues.swift */; };
 		DD906FA81EE777C600C29B8A /* ParserCLICommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD906FA71EE777C600C29B8A /* ParserCLICommands.swift */; };
 		DD9F687420955D0C004EB720 /* ColorsFileTypeParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9F687320955D0B004EB720 /* ColorsFileTypeParser.swift */; };
 		DD9F687A20955D51004EB720 /* CatalogEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9F687720955D51004EB720 /* CatalogEntry.swift */; };
@@ -370,6 +371,7 @@
 		DD428E161FC50FBF001649D6 /* InterfaceBuilderContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterfaceBuilderContext.swift; sourceTree = "<group>"; };
 		DD428E171FC50FBF001649D6 /* StringsContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringsContext.swift; sourceTree = "<group>"; };
 		DD428E181FC50FBF001649D6 /* SwiftGenKit-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "SwiftGenKit-Info.plist"; sourceTree = "<group>"; };
+		DD48AD7E2210AC5E00336621 /* ParserOptionValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParserOptionValues.swift; sourceTree = "<group>"; };
 		DD906FA71EE777C600C29B8A /* ParserCLICommands.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParserCLICommands.swift; sourceTree = "<group>"; };
 		DD9F687320955D0B004EB720 /* ColorsFileTypeParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorsFileTypeParser.swift; sourceTree = "<group>"; };
 		DD9F687720955D51004EB720 /* CatalogEntry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CatalogEntry.swift; sourceTree = "<group>"; };
@@ -669,6 +671,7 @@
 				DD428E0F1FC50FBF001649D6 /* Parser.swift */,
 				DDCC331A220E3FE700982694 /* ParserOption.swift */,
 				DDCC331C220E491600982694 /* ParserOptionList.swift */,
+				DD48AD7E2210AC5E00336621 /* ParserOptionValues.swift */,
 			);
 			path = Parsers;
 			sourceTree = "<group>";
@@ -1440,6 +1443,7 @@
 				DD9F688620956074004EB720 /* PlaceholderType.swift in Sources */,
 				DD428E251FC50FBF001649D6 /* AssetsCatalogContext.swift in Sources */,
 				C3031AA121062C9A00BF00DE /* UserInfo.swift in Sources */,
+				DD48AD802210ACBD00336621 /* ParserOptionValues.swift in Sources */,
 				DDCC331B220E3FE700982694 /* ParserOption.swift in Sources */,
 				DD428E1A1FC50FBF001649D6 /* ColorsCLRFileParser.swift in Sources */,
 				C350BE3820FFCD0F0043D7C5 /* Model.swift in Sources */,

--- a/SwiftGen.xcodeproj/project.pbxproj
+++ b/SwiftGen.xcodeproj/project.pbxproj
@@ -110,6 +110,8 @@
 		DDC335E47ABB50395E595AB0 /* Pods_swiftgen_SwiftGen_UnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C29A8876ECE7B9852963F6B5 /* Pods_swiftgen_SwiftGen_UnitTests.framework */; };
 		DDC8211520967180007A55F3 /* Path.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC8211420967180007A55F3 /* Path.swift */; };
 		DDC82117209672E1007A55F3 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC82116209672E1007A55F3 /* String.swift */; };
+		DDCC331B220E3FE700982694 /* ParserOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCC331A220E3FE700982694 /* ParserOption.swift */; };
+		DDCC331D220E491600982694 /* ParserOptionList.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCC331C220E491600982694 /* ParserOptionList.swift */; };
 		DDCCACDA209551240017FB43 /* Storyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCCACD6209551230017FB43 /* Storyboard.swift */; };
 		DDCCACDB209551240017FB43 /* Platform.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCCACD7209551230017FB43 /* Platform.swift */; };
 		DDCCACDC209551240017FB43 /* Segue.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCCACD8209551230017FB43 /* Segue.swift */; };
@@ -390,6 +392,8 @@
 		DDC09D011E1D199A005C6EE6 /* templates */ = {isa = PBXFileReference; lastKnownFileType = folder; name = templates; path = ../templates; sourceTree = "<group>"; };
 		DDC8211420967180007A55F3 /* Path.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Path.swift; sourceTree = "<group>"; };
 		DDC82116209672E1007A55F3 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
+		DDCC331A220E3FE700982694 /* ParserOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParserOption.swift; sourceTree = "<group>"; };
+		DDCC331C220E491600982694 /* ParserOptionList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParserOptionList.swift; sourceTree = "<group>"; };
 		DDCCACD6209551230017FB43 /* Storyboard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Storyboard.swift; sourceTree = "<group>"; };
 		DDCCACD7209551230017FB43 /* Platform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Platform.swift; sourceTree = "<group>"; };
 		DDCCACD8209551230017FB43 /* Segue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Segue.swift; sourceTree = "<group>"; };
@@ -663,6 +667,8 @@
 				DDB0B999209CE4A300E467C2 /* Yaml */,
 				DD2F4DDF21DAE7E6002E9B8C /* Filter.swift */,
 				DD428E0F1FC50FBF001649D6 /* Parser.swift */,
+				DDCC331A220E3FE700982694 /* ParserOption.swift */,
+				DDCC331C220E491600982694 /* ParserOptionList.swift */,
 			);
 			path = Parsers;
 			sourceTree = "<group>";
@@ -1434,6 +1440,7 @@
 				DD9F688620956074004EB720 /* PlaceholderType.swift in Sources */,
 				DD428E251FC50FBF001649D6 /* AssetsCatalogContext.swift in Sources */,
 				C3031AA121062C9A00BF00DE /* UserInfo.swift in Sources */,
+				DDCC331B220E3FE700982694 /* ParserOption.swift in Sources */,
 				DD428E1A1FC50FBF001649D6 /* ColorsCLRFileParser.swift in Sources */,
 				C350BE3820FFCD0F0043D7C5 /* Model.swift in Sources */,
 				C32262732101324E001AC9CD /* Relationship.swift in Sources */,
@@ -1448,6 +1455,7 @@
 				DD9F687420955D0C004EB720 /* ColorsFileTypeParser.swift in Sources */,
 				DD9F687C20955D51004EB720 /* Catalog.swift in Sources */,
 				C322627121012F42001AC9CD /* Attribute.swift in Sources */,
+				DDCC331D220E491600982694 /* ParserOptionList.swift in Sources */,
 				DD428E271FC50FBF001649D6 /* StringsContext.swift in Sources */,
 				C38E571520FF8FB5009C9C23 /* CoreDataParser.swift in Sources */,
 				C322626F21012C42001AC9CD /* Bool.swift in Sources */,

--- a/Tests/SwiftGenKitTests/AssetCatalogTests.swift
+++ b/Tests/SwiftGenKitTests/AssetCatalogTests.swift
@@ -5,7 +5,7 @@
 //
 
 import PathKit
-import SwiftGenKit
+@testable import SwiftGenKit
 import XCTest
 
 class AssetCatalogTests: XCTestCase {
@@ -47,5 +47,18 @@ class AssetCatalogTests: XCTestCase {
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "all", sub: .xcassets)
+  }
+
+  // MARK: - Custom options
+
+  func testUnknownOption() throws {
+    do {
+      _ = try AssetsCatalog.Parser(options: ["SomeOptionThatDoesntExist": "foo"])
+      XCTFail("Parser successfully created with an invalid option")
+    } catch ParserOptionList.Error.unknownOption {
+      // That's the expected exception we want to happen
+    } catch let error {
+      XCTFail("Unexpected error occured: \(error)")
+    }
   }
 }

--- a/Tests/SwiftGenKitTests/AssetCatalogTests.swift
+++ b/Tests/SwiftGenKitTests/AssetCatalogTests.swift
@@ -9,15 +9,15 @@ import SwiftGenKit
 import XCTest
 
 class AssetCatalogTests: XCTestCase {
-  func testEmpty() {
-    let parser = AssetsCatalog.Parser()
+  func testEmpty() throws {
+    let parser = try AssetsCatalog.Parser()
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "empty", sub: .xcassets)
   }
 
   func testColors() throws {
-    let parser = AssetsCatalog.Parser()
+    let parser = try AssetsCatalog.Parser()
     try parser.searchAndParse(path: Fixtures.path(for: "Styles.xcassets", sub: .xcassets))
 
     let result = parser.stencilContext()
@@ -25,7 +25,7 @@ class AssetCatalogTests: XCTestCase {
   }
 
   func testData() throws {
-    let parser = AssetsCatalog.Parser()
+    let parser = try AssetsCatalog.Parser()
     try parser.searchAndParse(path: Fixtures.path(for: "Files.xcassets", sub: .xcassets))
 
     let result = parser.stencilContext()
@@ -33,7 +33,7 @@ class AssetCatalogTests: XCTestCase {
   }
 
   func testImages() throws {
-    let parser = AssetsCatalog.Parser()
+    let parser = try AssetsCatalog.Parser()
     try parser.searchAndParse(path: Fixtures.path(for: "Food.xcassets", sub: .xcassets))
 
     let result = parser.stencilContext()
@@ -41,7 +41,7 @@ class AssetCatalogTests: XCTestCase {
   }
 
   func testAll() throws {
-    let parser = AssetsCatalog.Parser()
+    let parser = try AssetsCatalog.Parser()
     let paths = ["Files.xcassets", "Food.xcassets", "Styles.xcassets"]
     try parser.searchAndParse(paths: paths.map { Fixtures.path(for: $0, sub: .xcassets) })
 

--- a/Tests/SwiftGenKitTests/AssetCatalogTests.swift
+++ b/Tests/SwiftGenKitTests/AssetCatalogTests.swift
@@ -55,8 +55,9 @@ class AssetCatalogTests: XCTestCase {
     do {
       _ = try AssetsCatalog.Parser(options: ["SomeOptionThatDoesntExist": "foo"])
       XCTFail("Parser successfully created with an invalid option")
-    } catch ParserOptionList.Error.unknownOption {
+    } catch ParserOptionList.Error.unknownOption(let key, _) {
       // That's the expected exception we want to happen
+      XCTAssertEqual(key, "SomeOptionThatDoesntExist", "Failed for unexpected option \(key)")
     } catch let error {
       XCTFail("Unexpected error occured: \(error)")
     }

--- a/Tests/SwiftGenKitTests/ColorsCLRFileTests.swift
+++ b/Tests/SwiftGenKitTests/ColorsCLRFileTests.swift
@@ -10,8 +10,9 @@ import XCTest
 
 class ColorsCLRFileTests: XCTestCase {
   func testFileWithDefaults() throws {
-    let parser = Colors.Parser()
-    parser.palettes = [try Colors.CLRFileParser().parseFile(at: Fixtures.path(for: "colors.clr", sub: .colors))]
+    let parser = try Colors.Parser()
+    let clrParser = Colors.CLRFileParser(options: try ParserOptionValues(options: [:], available: []))
+    parser.palettes = [try clrParser.parseFile(at: Fixtures.path(for: "colors.clr", sub: .colors))]
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "defaults", sub: .colors)
@@ -19,7 +20,8 @@ class ColorsCLRFileTests: XCTestCase {
 
   func testFileWithBadFile() {
     do {
-      _ = try Colors.CLRFileParser().parseFile(at: Fixtures.path(for: "bad.clr", sub: .colors))
+      let clrParser = Colors.CLRFileParser(options: try ParserOptionValues(options: [:], available: []))
+      _ = try clrParser.parseFile(at: Fixtures.path(for: "bad.clr", sub: .colors))
       XCTFail("Code did parse file successfully while it was expected to fail for bad file")
     } catch Colors.ParserError.invalidFile {
       // That's the expected exception we want to happen

--- a/Tests/SwiftGenKitTests/ColorsJSONFileTests.swift
+++ b/Tests/SwiftGenKitTests/ColorsJSONFileTests.swift
@@ -10,8 +10,9 @@ import XCTest
 
 class ColorsJSONFileTests: XCTestCase {
   func testFileWithDefaults() throws {
-    let parser = Colors.Parser()
-    parser.palettes = [try Colors.JSONFileParser().parseFile(at: Fixtures.path(for: "colors.json", sub: .colors))]
+    let parser = try Colors.Parser()
+    let jsonParser = Colors.JSONFileParser(options: try ParserOptionValues(options: [:], available: []))
+    parser.palettes = [try jsonParser.parseFile(at: Fixtures.path(for: "colors.json", sub: .colors))]
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "defaults", sub: .colors)
@@ -19,7 +20,8 @@ class ColorsJSONFileTests: XCTestCase {
 
   func testFileWithBadSyntax() {
     do {
-      _ = try Colors.JSONFileParser().parseFile(at: Fixtures.path(for: "bad-syntax.json", sub: .colors))
+      let jsonParser = Colors.JSONFileParser(options: try ParserOptionValues(options: [:], available: []))
+      _ = try jsonParser.parseFile(at: Fixtures.path(for: "bad-syntax.json", sub: .colors))
       XCTFail("Code did parse file successfully while it was expected to fail for bad syntax")
     } catch Colors.ParserError.invalidFile {
       // That's the expected exception we want to happen
@@ -30,7 +32,8 @@ class ColorsJSONFileTests: XCTestCase {
 
   func testFileWithBadValue() {
     do {
-      _ = try Colors.JSONFileParser().parseFile(at: Fixtures.path(for: "bad-value.json", sub: .colors))
+      let jsonParser = Colors.JSONFileParser(options: try ParserOptionValues(options: [:], available: []))
+      _ = try jsonParser.parseFile(at: Fixtures.path(for: "bad-value.json", sub: .colors))
       XCTFail("Code did parse file successfully while it was expected to fail for bad value")
     } catch Colors.ParserError.invalidHexColor(path: _, string: "this isn't a color", key: "ArticleTitle"?) {
       // That's the expected exception we want to happen

--- a/Tests/SwiftGenKitTests/ColorsTests.swift
+++ b/Tests/SwiftGenKitTests/ColorsTests.swift
@@ -9,7 +9,7 @@ import PathKit
 import XCTest
 
 final class TestFileParser1: ColorsFileTypeParser {
-  init(options: [String: Any]) {}
+  init(options: ParserOptionValues) {}
   static let extensions = ["test1"]
   func parseFile(at path: Path) throws -> Colors.Palette {
     return Colors.Palette(name: "test1", colors: [:])
@@ -17,7 +17,7 @@ final class TestFileParser1: ColorsFileTypeParser {
 }
 
 final class TestFileParser2: ColorsFileTypeParser {
-  init(options: [String: Any]) {}
+  init(options: ParserOptionValues) {}
   static let extensions = ["test2"]
   func parseFile(at path: Path) throws -> Colors.Palette {
     return Colors.Palette(name: "test2", colors: [:])
@@ -25,7 +25,7 @@ final class TestFileParser2: ColorsFileTypeParser {
 }
 
 final class TestFileParser3: ColorsFileTypeParser {
-  init(options: [String: Any]) {}
+  init(options: ParserOptionValues) {}
   static let extensions = ["test1"]
   func parseFile(at path: Path) throws -> Colors.Palette {
     return Colors.Palette(name: "test3", colors: [:])
@@ -34,7 +34,7 @@ final class TestFileParser3: ColorsFileTypeParser {
 
 class ColorParserTests: XCTestCase {
   func testEmpty() throws {
-    let parser = Colors.Parser()
+    let parser = try Colors.Parser()
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "empty", sub: .colors)
@@ -43,7 +43,7 @@ class ColorParserTests: XCTestCase {
   // MARK: - Dispatch
 
   func testDispatchKnowExtension() throws {
-    let parser = Colors.Parser()
+    let parser = try Colors.Parser()
     parser.register(parser: TestFileParser1.self)
     parser.register(parser: TestFileParser2.self)
 
@@ -53,7 +53,7 @@ class ColorParserTests: XCTestCase {
   }
 
   func testDispatchUnknownExtension() throws {
-    let parser = Colors.Parser()
+    let parser = try Colors.Parser()
     parser.register(parser: TestFileParser1.self)
     parser.register(parser: TestFileParser2.self)
 
@@ -71,7 +71,7 @@ class ColorParserTests: XCTestCase {
   func testDuplicateExtensionWarning() throws {
     var warned = false
 
-    let parser = Colors.Parser()
+    let parser = try Colors.Parser()
     parser.warningHandler = { message, file, line in
       warned = true
     }
@@ -85,7 +85,7 @@ class ColorParserTests: XCTestCase {
   // MARK: - Multiple palettes
 
   func testParseMultipleFiles() throws {
-    let parser = Colors.Parser()
+    let parser = try Colors.Parser()
     try parser.searchAndParse(path: Fixtures.path(for: "colors.clr", sub: .colors))
     try parser.searchAndParse(path: Fixtures.path(for: "extra.txt", sub: .colors))
 

--- a/Tests/SwiftGenKitTests/ColorsTests.swift
+++ b/Tests/SwiftGenKitTests/ColorsTests.swift
@@ -9,6 +9,8 @@ import PathKit
 import XCTest
 
 final class TestFileParser1: ColorsFileTypeParser {
+  init(options: [String: Any]) {}
+  static let allOptions = ParserOptionList()
   static let extensions = ["test1"]
   func parseFile(at path: Path) throws -> Colors.Palette {
     return Colors.Palette(name: "test1", colors: [:])
@@ -16,6 +18,8 @@ final class TestFileParser1: ColorsFileTypeParser {
 }
 
 final class TestFileParser2: ColorsFileTypeParser {
+  init(options: [String: Any]) {}
+  static let allOptions = ParserOptionList()
   static let extensions = ["test2"]
   func parseFile(at path: Path) throws -> Colors.Palette {
     return Colors.Palette(name: "test2", colors: [:])
@@ -23,6 +27,8 @@ final class TestFileParser2: ColorsFileTypeParser {
 }
 
 final class TestFileParser3: ColorsFileTypeParser {
+  init(options: [String: Any]) {}
+  static let allOptions = ParserOptionList()
   static let extensions = ["test1"]
   func parseFile(at path: Path) throws -> Colors.Palette {
     return Colors.Palette(name: "test3", colors: [:])

--- a/Tests/SwiftGenKitTests/ColorsTests.swift
+++ b/Tests/SwiftGenKitTests/ColorsTests.swift
@@ -10,7 +10,6 @@ import XCTest
 
 final class TestFileParser1: ColorsFileTypeParser {
   init(options: [String: Any]) {}
-  static let allOptions = ParserOptionList()
   static let extensions = ["test1"]
   func parseFile(at path: Path) throws -> Colors.Palette {
     return Colors.Palette(name: "test1", colors: [:])
@@ -19,7 +18,6 @@ final class TestFileParser1: ColorsFileTypeParser {
 
 final class TestFileParser2: ColorsFileTypeParser {
   init(options: [String: Any]) {}
-  static let allOptions = ParserOptionList()
   static let extensions = ["test2"]
   func parseFile(at path: Path) throws -> Colors.Palette {
     return Colors.Palette(name: "test2", colors: [:])
@@ -28,7 +26,6 @@ final class TestFileParser2: ColorsFileTypeParser {
 
 final class TestFileParser3: ColorsFileTypeParser {
   init(options: [String: Any]) {}
-  static let allOptions = ParserOptionList()
   static let extensions = ["test1"]
   func parseFile(at path: Path) throws -> Colors.Palette {
     return Colors.Palette(name: "test3", colors: [:])

--- a/Tests/SwiftGenKitTests/ColorsTests.swift
+++ b/Tests/SwiftGenKitTests/ColorsTests.swift
@@ -129,4 +129,17 @@ class ColorParserTests: XCTestCase {
       XCTAssertEqual(color.hexValue, value)
     }
   }
+
+  // MARK: - Custom options
+
+  func testUnknownOption() throws {
+    do {
+      _ = try Colors.Parser(options: ["SomeOptionThatDoesntExist": "foo"])
+      XCTFail("Parser successfully created with an invalid option")
+    } catch ParserOptionList.Error.unknownOption {
+      // That's the expected exception we want to happen
+    } catch let error {
+      XCTFail("Unexpected error occured: \(error)")
+    }
+  }
 }

--- a/Tests/SwiftGenKitTests/ColorsTests.swift
+++ b/Tests/SwiftGenKitTests/ColorsTests.swift
@@ -136,8 +136,9 @@ class ColorParserTests: XCTestCase {
     do {
       _ = try Colors.Parser(options: ["SomeOptionThatDoesntExist": "foo"])
       XCTFail("Parser successfully created with an invalid option")
-    } catch ParserOptionList.Error.unknownOption {
+    } catch ParserOptionList.Error.unknownOption(let key, _) {
       // That's the expected exception we want to happen
+      XCTAssertEqual(key, "SomeOptionThatDoesntExist", "Failed for unexpected option \(key)")
     } catch let error {
       XCTFail("Unexpected error occured: \(error)")
     }

--- a/Tests/SwiftGenKitTests/ColorsTextFileTests.swift
+++ b/Tests/SwiftGenKitTests/ColorsTextFileTests.swift
@@ -10,8 +10,9 @@ import XCTest
 
 class ColorsTextFileTests: XCTestCase {
   func testFileWithDefaults() throws {
-    let parser = Colors.Parser()
-    parser.palettes = [try Colors.TextFileParser().parseFile(at: Fixtures.path(for: "extra.txt", sub: .colors))]
+    let parser = try Colors.Parser()
+    let txtParser = Colors.TextFileParser(options: try ParserOptionValues(options: [:], available: []))
+    parser.palettes = [try txtParser.parseFile(at: Fixtures.path(for: "extra.txt", sub: .colors))]
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "extra", sub: .colors)
@@ -19,7 +20,8 @@ class ColorsTextFileTests: XCTestCase {
 
   func testFileWithBadSyntax() {
     do {
-      _ = try Colors.TextFileParser().parseFile(at: Fixtures.path(for: "bad-syntax.txt", sub: .colors))
+      let txtParser = Colors.TextFileParser(options: try ParserOptionValues(options: [:], available: []))
+      _ = try txtParser.parseFile(at: Fixtures.path(for: "bad-syntax.txt", sub: .colors))
       XCTFail("Code did parse file successfully while it was expected to fail for bad syntax")
     } catch Colors.ParserError.invalidFile {
       // That's the expected exception we want to happen
@@ -30,7 +32,8 @@ class ColorsTextFileTests: XCTestCase {
 
   func testFileWithBadValue() {
     do {
-      _ = try Colors.TextFileParser().parseFile(at: Fixtures.path(for: "bad-value.txt", sub: .colors))
+      let txtParser = Colors.TextFileParser(options: try ParserOptionValues(options: [:], available: []))
+      _ = try txtParser.parseFile(at: Fixtures.path(for: "bad-value.txt", sub: .colors))
       XCTFail("Code did parse file successfully while it was expected to fail for bad value")
     } catch Colors.ParserError.invalidHexColor(path: _, string: "thisIsn'tAColor", key: "ArticleTitle"?) {
       // That's the expected exception we want to happen

--- a/Tests/SwiftGenKitTests/ColorsXMLFileTests.swift
+++ b/Tests/SwiftGenKitTests/ColorsXMLFileTests.swift
@@ -10,8 +10,9 @@ import XCTest
 
 class ColorsXMLFileTests: XCTestCase {
   func testFileWithDefaults() throws {
-    let parser = Colors.Parser()
-    parser.palettes = [try Colors.XMLFileParser().parseFile(at: Fixtures.path(for: "colors.xml", sub: .colors))]
+    let parser = try Colors.Parser()
+    let xmlParser = Colors.XMLFileParser(options: try ParserOptionValues(options: [:], available: []))
+    parser.palettes = [try xmlParser.parseFile(at: Fixtures.path(for: "colors.xml", sub: .colors))]
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "defaults", sub: .colors)
@@ -19,7 +20,8 @@ class ColorsXMLFileTests: XCTestCase {
 
   func testFileWithBadSyntax() {
     do {
-      _ = try Colors.XMLFileParser().parseFile(at: Fixtures.path(for: "bad-syntax.xml", sub: .colors))
+      let xmlParser = Colors.XMLFileParser(options: try ParserOptionValues(options: [:], available: []))
+      _ = try xmlParser.parseFile(at: Fixtures.path(for: "bad-syntax.xml", sub: .colors))
       XCTFail("Code did parse file successfully while it was expected to fail for bad syntax")
     } catch Colors.ParserError.invalidFile {
       // That's the expected exception we want to happen
@@ -30,7 +32,8 @@ class ColorsXMLFileTests: XCTestCase {
 
   func testFileWithBadValue() {
     do {
-      _ = try Colors.XMLFileParser().parseFile(at: Fixtures.path(for: "bad-value.xml", sub: .colors))
+      let xmlParser = Colors.XMLFileParser(options: try ParserOptionValues(options: [:], available: []))
+      _ = try xmlParser.parseFile(at: Fixtures.path(for: "bad-value.xml", sub: .colors))
       XCTFail("Code did parse file successfully while it was expected to fail for bad value")
     } catch Colors.ParserError.invalidHexColor(path: _, string: "this isn't a color", key: "ArticleTitle"?) {
       // That's the expected exception we want to happen

--- a/Tests/SwiftGenKitTests/CoreDataTests.swift
+++ b/Tests/SwiftGenKitTests/CoreDataTests.swift
@@ -26,4 +26,17 @@ class CoreDataTests: XCTestCase {
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "defaults", sub: .coreData)
   }
+
+  // MARK: - Custom options
+
+  func testUnknownOption() throws {
+    do {
+      _ = try CoreData.Parser(options: ["SomeOptionThatDoesntExist": "foo"])
+      XCTFail("Parser successfully created with an invalid option")
+    } catch ParserOptionList.Error.unknownOption {
+      // That's the expected exception we want to happen
+    } catch let error {
+      XCTFail("Unexpected error occured: \(error)")
+    }
+  }
 }

--- a/Tests/SwiftGenKitTests/CoreDataTests.swift
+++ b/Tests/SwiftGenKitTests/CoreDataTests.swift
@@ -8,15 +8,15 @@
 import XCTest
 
 class CoreDataTests: XCTestCase {
-  func testEmpty() {
-    let parser = CoreData.Parser()
+  func testEmpty() throws {
+    let parser = try CoreData.Parser()
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "empty", sub: .coreData)
   }
 
-  func testDefaults() {
-    let parser = CoreData.Parser()
+  func testDefaults() throws {
+    let parser = try CoreData.Parser()
     do {
       try parser.searchAndParse(path: Fixtures.path(for: "Model.xcdatamodeld", sub: .coreData))
     } catch {

--- a/Tests/SwiftGenKitTests/CoreDataTests.swift
+++ b/Tests/SwiftGenKitTests/CoreDataTests.swift
@@ -33,8 +33,9 @@ class CoreDataTests: XCTestCase {
     do {
       _ = try CoreData.Parser(options: ["SomeOptionThatDoesntExist": "foo"])
       XCTFail("Parser successfully created with an invalid option")
-    } catch ParserOptionList.Error.unknownOption {
+    } catch ParserOptionList.Error.unknownOption(let key, _) {
       // That's the expected exception we want to happen
+      XCTAssertEqual(key, "SomeOptionThatDoesntExist", "Failed for unexpected option \(key)")
     } catch let error {
       XCTFail("Unexpected error occured: \(error)")
     }

--- a/Tests/SwiftGenKitTests/FontsTests.swift
+++ b/Tests/SwiftGenKitTests/FontsTests.swift
@@ -25,6 +25,19 @@ class FontsTests: XCTestCase {
     XCTDiffContexts(result, expected: "defaults", sub: .fonts)
   }
 
+  // MARK: - Custom options
+
+  func testUnknownOption() throws {
+    do {
+      _ = try Fonts.Parser(options: ["SomeOptionThatDoesntExist": "foo"])
+      XCTFail("Parser successfully created with an invalid option")
+    } catch ParserOptionList.Error.unknownOption {
+      // That's the expected exception we want to happen
+    } catch let error {
+      XCTFail("Unexpected error occured: \(error)")
+    }
+  }
+
   // MARK: - Path relative(to:)
 
   func testPathRelativeTo_UnrelatedIsNil() throws {

--- a/Tests/SwiftGenKitTests/FontsTests.swift
+++ b/Tests/SwiftGenKitTests/FontsTests.swift
@@ -10,15 +10,15 @@ import PathKit
 import XCTest
 
 class FontsTests: XCTestCase {
-  func testEmpty() {
-    let parser = Fonts.Parser()
+  func testEmpty() throws {
+    let parser = try Fonts.Parser()
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "empty", sub: .fonts)
   }
 
   func testDefaults() throws {
-    let parser = Fonts.Parser()
+    let parser = try Fonts.Parser()
     try parser.searchAndParse(path: Fixtures.directory())
 
     let result = parser.stencilContext()

--- a/Tests/SwiftGenKitTests/FontsTests.swift
+++ b/Tests/SwiftGenKitTests/FontsTests.swift
@@ -31,8 +31,9 @@ class FontsTests: XCTestCase {
     do {
       _ = try Fonts.Parser(options: ["SomeOptionThatDoesntExist": "foo"])
       XCTFail("Parser successfully created with an invalid option")
-    } catch ParserOptionList.Error.unknownOption {
+    } catch ParserOptionList.Error.unknownOption(let key, _) {
       // That's the expected exception we want to happen
+      XCTAssertEqual(key, "SomeOptionThatDoesntExist", "Failed for unexpected option \(key)")
     } catch let error {
       XCTFail("Unexpected error occured: \(error)")
     }

--- a/Tests/SwiftGenKitTests/InterfaceBuilderMacOSTests.swift
+++ b/Tests/SwiftGenKitTests/InterfaceBuilderMacOSTests.swift
@@ -14,15 +14,15 @@ import XCTest
  */
 
 class InterfaceBuilderMacOSTests: XCTestCase {
-  func testEmpty() {
-    let parser = InterfaceBuilder.Parser()
+  func testEmpty() throws {
+    let parser = try InterfaceBuilder.Parser()
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "empty", sub: .interfaceBuilderMacOS)
   }
 
-  func testMessageStoryboard() {
-    let parser = InterfaceBuilder.Parser()
+  func testMessageStoryboard() throws {
+    let parser = try InterfaceBuilder.Parser()
     do {
       try parser.searchAndParse(path: Fixtures.path(for: "Message.storyboard", sub: .interfaceBuilderMacOS))
     } catch {
@@ -33,8 +33,8 @@ class InterfaceBuilderMacOSTests: XCTestCase {
     XCTDiffContexts(result, expected: "messages", sub: .interfaceBuilderMacOS)
   }
 
-  func testAnonymousStoryboard() {
-    let parser = InterfaceBuilder.Parser()
+  func testAnonymousStoryboard() throws {
+    let parser = try InterfaceBuilder.Parser()
     do {
       try parser.searchAndParse(path: Fixtures.path(for: "Anonymous.storyboard", sub: .interfaceBuilderMacOS))
     } catch {
@@ -45,8 +45,8 @@ class InterfaceBuilderMacOSTests: XCTestCase {
     XCTDiffContexts(result, expected: "anonymous", sub: .interfaceBuilderMacOS)
   }
 
-  func testAllStoryboards() {
-    let parser = InterfaceBuilder.Parser()
+  func testAllStoryboards() throws {
+    let parser = try InterfaceBuilder.Parser()
     do {
       try parser.searchAndParse(path: Fixtures.directory(sub: .interfaceBuilderMacOS))
     } catch {
@@ -61,7 +61,7 @@ class InterfaceBuilderMacOSTests: XCTestCase {
   func testConsistencyOfModules() throws {
     let fakeModuleName = "NotCurrentModule"
 
-    let parser = InterfaceBuilder.Parser()
+    let parser = try InterfaceBuilder.Parser()
     try parser.searchAndParse(path: Fixtures.directory(sub: .interfaceBuilderMacOS))
 
     XCTAssert(

--- a/Tests/SwiftGenKitTests/InterfaceBuilderMacOSTests.swift
+++ b/Tests/SwiftGenKitTests/InterfaceBuilderMacOSTests.swift
@@ -7,12 +7,6 @@
 @testable import SwiftGenKit
 import XCTest
 
-/**
- * Important: In order for the "*.storyboard" files in fixtures/ to be copied as-is in the test bundle
- * (as opposed to being compiled when the test bundle is compiled), a custom "Build Rule" has been added to the target.
- * See Project -> Target "UnitTests" -> Build Rules -> « Files "*.storyboard" using PBXCp »
- */
-
 class InterfaceBuilderMacOSTests: XCTestCase {
   func testEmpty() throws {
     let parser = try InterfaceBuilder.Parser()
@@ -70,5 +64,18 @@ class InterfaceBuilderMacOSTests: XCTestCase {
         $0.segues.contains { $0.moduleIsPlaceholder && $0.module == fakeModuleName }
       }
     )
+  }
+
+  // MARK: - Custom options
+
+  func testUnknownOption() throws {
+    do {
+      _ = try InterfaceBuilder.Parser(options: ["SomeOptionThatDoesntExist": "foo"])
+      XCTFail("Parser successfully created with an invalid option")
+    } catch ParserOptionList.Error.unknownOption {
+      // That's the expected exception we want to happen
+    } catch let error {
+      XCTFail("Unexpected error occured: \(error)")
+    }
   }
 }

--- a/Tests/SwiftGenKitTests/InterfaceBuilderMacOSTests.swift
+++ b/Tests/SwiftGenKitTests/InterfaceBuilderMacOSTests.swift
@@ -72,8 +72,9 @@ class InterfaceBuilderMacOSTests: XCTestCase {
     do {
       _ = try InterfaceBuilder.Parser(options: ["SomeOptionThatDoesntExist": "foo"])
       XCTFail("Parser successfully created with an invalid option")
-    } catch ParserOptionList.Error.unknownOption {
+    } catch ParserOptionList.Error.unknownOption(let key, _) {
       // That's the expected exception we want to happen
+      XCTAssertEqual(key, "SomeOptionThatDoesntExist", "Failed for unexpected option \(key)")
     } catch let error {
       XCTFail("Unexpected error occured: \(error)")
     }

--- a/Tests/SwiftGenKitTests/InterfaceBuilderiOSTests.swift
+++ b/Tests/SwiftGenKitTests/InterfaceBuilderiOSTests.swift
@@ -14,15 +14,15 @@ import XCTest
  */
 
 class InterfaceBuilderiOSTests: XCTestCase {
-  func testEmpty() {
-    let parser = InterfaceBuilder.Parser()
+  func testEmpty() throws {
+    let parser = try InterfaceBuilder.Parser()
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "empty", sub: .interfaceBuilderiOS)
   }
 
-  func testMessageStoryboard() {
-    let parser = InterfaceBuilder.Parser()
+  func testMessageStoryboard() throws {
+    let parser = try InterfaceBuilder.Parser()
     do {
       try parser.searchAndParse(path: Fixtures.path(for: "Message.storyboard", sub: .interfaceBuilderiOS))
     } catch {
@@ -33,8 +33,8 @@ class InterfaceBuilderiOSTests: XCTestCase {
     XCTDiffContexts(result, expected: "messages", sub: .interfaceBuilderiOS)
   }
 
-  func testAnonymousStoryboard() {
-    let parser = InterfaceBuilder.Parser()
+  func testAnonymousStoryboard() throws {
+    let parser = try InterfaceBuilder.Parser()
     do {
       try parser.searchAndParse(path: Fixtures.path(for: "Anonymous.storyboard", sub: .interfaceBuilderiOS))
     } catch {
@@ -45,8 +45,8 @@ class InterfaceBuilderiOSTests: XCTestCase {
     XCTDiffContexts(result, expected: "anonymous", sub: .interfaceBuilderiOS)
   }
 
-  func testAllStoryboards() {
-    let parser = InterfaceBuilder.Parser()
+  func testAllStoryboards() throws {
+    let parser = try InterfaceBuilder.Parser()
     do {
       try parser.searchAndParse(path: Fixtures.directory(sub: .interfaceBuilderiOS))
     } catch {
@@ -61,7 +61,7 @@ class InterfaceBuilderiOSTests: XCTestCase {
   func testConsistencyOfModules() throws {
     let fakeModuleName = "NotCurrentModule"
 
-    let parser = InterfaceBuilder.Parser()
+    let parser = try InterfaceBuilder.Parser()
     try parser.searchAndParse(path: Fixtures.directory(sub: .interfaceBuilderiOS))
 
     XCTAssert(

--- a/Tests/SwiftGenKitTests/InterfaceBuilderiOSTests.swift
+++ b/Tests/SwiftGenKitTests/InterfaceBuilderiOSTests.swift
@@ -7,12 +7,6 @@
 @testable import SwiftGenKit
 import XCTest
 
-/**
- * Important: In order for the "*.storyboard" files in fixtures/ to be copied as-is in the test bundle
- * (as opposed to being compiled when the test bundle is compiled), a custom "Build Rule" has been added to the target.
- * See Project -> Target "UnitTests" -> Build Rules -> « Files "*.storyboard" using PBXCp »
- */
-
 class InterfaceBuilderiOSTests: XCTestCase {
   func testEmpty() throws {
     let parser = try InterfaceBuilder.Parser()
@@ -70,5 +64,18 @@ class InterfaceBuilderiOSTests: XCTestCase {
         $0.segues.contains { $0.moduleIsPlaceholder && $0.module == fakeModuleName }
       }
     )
+  }
+
+  // MARK: - Custom options
+
+  func testUnknownOption() throws {
+    do {
+      _ = try InterfaceBuilder.Parser(options: ["SomeOptionThatDoesntExist": "foo"])
+      XCTFail("Parser successfully created with an invalid option")
+    } catch ParserOptionList.Error.unknownOption {
+      // That's the expected exception we want to happen
+    } catch let error {
+      XCTFail("Unexpected error occured: \(error)")
+    }
   }
 }

--- a/Tests/SwiftGenKitTests/InterfaceBuilderiOSTests.swift
+++ b/Tests/SwiftGenKitTests/InterfaceBuilderiOSTests.swift
@@ -72,8 +72,9 @@ class InterfaceBuilderiOSTests: XCTestCase {
     do {
       _ = try InterfaceBuilder.Parser(options: ["SomeOptionThatDoesntExist": "foo"])
       XCTFail("Parser successfully created with an invalid option")
-    } catch ParserOptionList.Error.unknownOption {
+    } catch ParserOptionList.Error.unknownOption(let key, _) {
       // That's the expected exception we want to happen
+      XCTAssertEqual(key, "SomeOptionThatDoesntExist", "Failed for unexpected option \(key)")
     } catch let error {
       XCTFail("Unexpected error occured: \(error)")
     }

--- a/Tests/SwiftGenKitTests/PlistTests.swift
+++ b/Tests/SwiftGenKitTests/PlistTests.swift
@@ -62,4 +62,17 @@ class PlistTests: XCTestCase {
       XCTFail("Unexpected error occured while parsing: \(error)")
     }
   }
+
+  // MARK: - Custom options
+
+  func testUnknownOption() throws {
+    do {
+      _ = try AssetsCatalog.Parser(options: ["SomeOptionThatDoesntExist": "foo"])
+      XCTFail("Parser successfully created with an invalid option")
+    } catch ParserOptionList.Error.unknownOption {
+      // That's the expected exception we want to happen
+    } catch let error {
+      XCTFail("Unexpected error occured: \(error)")
+    }
+  }
 }

--- a/Tests/SwiftGenKitTests/PlistTests.swift
+++ b/Tests/SwiftGenKitTests/PlistTests.swift
@@ -9,15 +9,15 @@ import PathKit
 import XCTest
 
 class PlistTests: XCTestCase {
-  func testEmpty() {
-    let parser = Plist.Parser()
+  func testEmpty() throws {
+    let parser = try Plist.Parser()
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "empty", sub: .plist)
   }
 
   func testArray() throws {
-    let parser = Plist.Parser()
+    let parser = try Plist.Parser()
     try parser.searchAndParse(path: Fixtures.path(for: "shopping-list.plist", sub: .plistGood))
 
     let result = parser.stencilContext()
@@ -25,7 +25,7 @@ class PlistTests: XCTestCase {
   }
 
   func testDictionary() throws {
-    let parser = Plist.Parser()
+    let parser = try Plist.Parser()
     try parser.searchAndParse(path: Fixtures.path(for: "configuration.plist", sub: .plistGood))
 
     let result = parser.stencilContext()
@@ -33,7 +33,7 @@ class PlistTests: XCTestCase {
   }
 
   func testInfo() throws {
-    let parser = Plist.Parser()
+    let parser = try Plist.Parser()
     try parser.searchAndParse(path: Fixtures.path(for: "Info.plist", sub: .plistGood))
 
     let result = parser.stencilContext()
@@ -42,7 +42,7 @@ class PlistTests: XCTestCase {
 
   func testDirectoryInput() {
     do {
-      let parser = Plist.Parser()
+      let parser = try Plist.Parser()
       try parser.searchAndParse(path: Fixtures.directory(sub: .plistGood))
 
       let result = parser.stencilContext()

--- a/Tests/SwiftGenKitTests/PlistTests.swift
+++ b/Tests/SwiftGenKitTests/PlistTests.swift
@@ -69,8 +69,9 @@ class PlistTests: XCTestCase {
     do {
       _ = try AssetsCatalog.Parser(options: ["SomeOptionThatDoesntExist": "foo"])
       XCTFail("Parser successfully created with an invalid option")
-    } catch ParserOptionList.Error.unknownOption {
+    } catch ParserOptionList.Error.unknownOption(let key, _) {
       // That's the expected exception we want to happen
+      XCTAssertEqual(key, "SomeOptionThatDoesntExist", "Failed for unexpected option \(key)")
     } catch let error {
       XCTFail("Unexpected error occured: \(error)")
     }

--- a/Tests/SwiftGenKitTests/StringsTests.swift
+++ b/Tests/SwiftGenKitTests/StringsTests.swift
@@ -4,14 +4,8 @@
 // MIT Licence
 //
 
-import SwiftGenKit
+@testable import SwiftGenKit
 import XCTest
-
-/**
- * Important: In order for the "*.strings" files in fixtures/ to be copied as-is in the test bundle
- * (as opposed to being compiled when the test bundle is compiled), a custom "Build Rule" has been added to the target.
- * See Project -> Target "UnitTests" -> Build Rules -> « Files "*.strings" using PBXCp »
- */
 
 class StringsTests: XCTestCase {
   func testEmpty() throws {
@@ -76,11 +70,24 @@ class StringsTests: XCTestCase {
     }
   }
 
+  // MARK: - Custom options
+
   func testCustomSeparator() throws {
     let parser = try Strings.Parser(options: ["separator": "__"])
     try parser.searchAndParse(path: Fixtures.path(for: "Localizable.strings", sub: .strings))
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "custom-separator", sub: .strings)
+  }
+
+  func testUnknownOption() throws {
+    do {
+      _ = try Strings.Parser(options: ["SomeOptionThatDoesntExist": "foo"])
+      XCTFail("Parser successfully created with an invalid option")
+    } catch ParserOptionList.Error.unknownOption {
+      // That's the expected exception we want to happen
+    } catch let error {
+      XCTFail("Unexpected error occured: \(error)")
+    }
   }
 }

--- a/Tests/SwiftGenKitTests/StringsTests.swift
+++ b/Tests/SwiftGenKitTests/StringsTests.swift
@@ -14,15 +14,15 @@ import XCTest
  */
 
 class StringsTests: XCTestCase {
-  func testEmpty() {
-    let parser = Strings.Parser()
+  func testEmpty() throws {
+    let parser = try Strings.Parser()
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "empty", sub: .strings)
   }
 
   func testLocalizable() throws {
-    let parser = Strings.Parser()
+    let parser = try Strings.Parser()
     try parser.searchAndParse(path: Fixtures.path(for: "Localizable.strings", sub: .strings))
 
     let result = parser.stencilContext()
@@ -30,7 +30,7 @@ class StringsTests: XCTestCase {
   }
 
   func testMultiline() throws {
-    let parser = Strings.Parser()
+    let parser = try Strings.Parser()
     try parser.searchAndParse(path: Fixtures.path(for: "LocMultiline.strings", sub: .strings))
 
     let result = parser.stencilContext()
@@ -38,7 +38,7 @@ class StringsTests: XCTestCase {
   }
 
   func testUTF8File() throws {
-    let parser = Strings.Parser()
+    let parser = try Strings.Parser()
     try parser.searchAndParse(path: Fixtures.path(for: "LocUTF8.strings", sub: .strings))
 
     let result = parser.stencilContext()
@@ -46,7 +46,7 @@ class StringsTests: XCTestCase {
   }
 
   func testStructuredOnly() throws {
-    let parser = Strings.Parser()
+    let parser = try Strings.Parser()
     try parser.searchAndParse(path: Fixtures.path(for: "LocStructuredOnly.strings", sub: .strings))
 
     let result = parser.stencilContext()
@@ -54,7 +54,7 @@ class StringsTests: XCTestCase {
   }
 
   func testMultipleFiles() throws {
-    let parser = Strings.Parser()
+    let parser = try Strings.Parser()
     try parser.searchAndParse(path: Fixtures.path(for: "Localizable.strings", sub: .strings))
     try parser.searchAndParse(path: Fixtures.path(for: "LocMultiline.strings", sub: .strings))
 
@@ -63,7 +63,7 @@ class StringsTests: XCTestCase {
   }
 
   func testMultipleFilesDuplicate() throws {
-    let parser = Strings.Parser()
+    let parser = try Strings.Parser()
     try parser.searchAndParse(path: Fixtures.path(for: "Localizable.strings", sub: .strings))
 
     do {
@@ -77,7 +77,7 @@ class StringsTests: XCTestCase {
   }
 
   func testCustomSeparator() throws {
-    let parser = Strings.Parser(options: ["separator": "__"])
+    let parser = try Strings.Parser(options: ["separator": "__"])
     try parser.searchAndParse(path: Fixtures.path(for: "Localizable.strings", sub: .strings))
 
     let result = parser.stencilContext()

--- a/Tests/SwiftGenKitTests/StringsTests.swift
+++ b/Tests/SwiftGenKitTests/StringsTests.swift
@@ -84,8 +84,9 @@ class StringsTests: XCTestCase {
     do {
       _ = try Strings.Parser(options: ["SomeOptionThatDoesntExist": "foo"])
       XCTFail("Parser successfully created with an invalid option")
-    } catch ParserOptionList.Error.unknownOption {
+    } catch ParserOptionList.Error.unknownOption(let key, _) {
       // That's the expected exception we want to happen
+      XCTAssertEqual(key, "SomeOptionThatDoesntExist", "Failed for unexpected option \(key)")
     } catch let error {
       XCTFail("Unexpected error occured: \(error)")
     }

--- a/Tests/SwiftGenKitTests/YamlTests.swift
+++ b/Tests/SwiftGenKitTests/YamlTests.swift
@@ -79,4 +79,17 @@ class YamlTests: XCTestCase {
       XCTFail("Unexpected error occured while parsing: \(error)")
     }
   }
+
+  // MARK: - Custom options
+
+  func testUnknownOption() throws {
+    do {
+      _ = try Yaml.Parser(options: ["SomeOptionThatDoesntExist": "foo"])
+      XCTFail("Parser successfully created with an invalid option")
+    } catch ParserOptionList.Error.unknownOption {
+      // That's the expected exception we want to happen
+    } catch let error {
+      XCTFail("Unexpected error occured: \(error)")
+    }
+  }
 }

--- a/Tests/SwiftGenKitTests/YamlTests.swift
+++ b/Tests/SwiftGenKitTests/YamlTests.swift
@@ -9,15 +9,15 @@ import PathKit
 import XCTest
 
 class YamlTests: XCTestCase {
-  func testEmpty() {
-    let parser = Yaml.Parser()
+  func testEmpty() throws {
+    let parser = try Yaml.Parser()
 
     let result = parser.stencilContext()
     XCTDiffContexts(result, expected: "empty", sub: .yaml)
   }
 
   func testSequence() throws {
-    let parser = Yaml.Parser()
+    let parser = try Yaml.Parser()
     try parser.searchAndParse(path: Fixtures.path(for: "grocery-list.yaml", sub: .yamlGood))
 
     let result = parser.stencilContext()
@@ -25,7 +25,7 @@ class YamlTests: XCTestCase {
   }
 
   func testMapping() throws {
-    let parser = Yaml.Parser()
+    let parser = try Yaml.Parser()
     try parser.searchAndParse(path: Fixtures.path(for: "mapping.yaml", sub: .yamlGood))
 
     let result = parser.stencilContext()
@@ -33,7 +33,7 @@ class YamlTests: XCTestCase {
   }
 
   func testJSON() throws {
-    let parser = JSON.Parser()
+    let parser = try JSON.Parser()
     try parser.searchAndParse(path: Fixtures.path(for: "configuration.json", sub: .yamlGood))
 
     let result = parser.stencilContext()
@@ -41,7 +41,7 @@ class YamlTests: XCTestCase {
   }
 
   func testScalar() throws {
-    let parser = Yaml.Parser()
+    let parser = try Yaml.Parser()
     try parser.searchAndParse(path: Fixtures.path(for: "version.yaml", sub: .yamlGood))
 
     let result = parser.stencilContext()
@@ -49,7 +49,7 @@ class YamlTests: XCTestCase {
   }
 
   func testMutlipleDocuments() throws {
-    let parser = Yaml.Parser()
+    let parser = try Yaml.Parser()
     try parser.searchAndParse(path: Fixtures.path(for: "documents.yaml", sub: .yamlGood))
 
     let result = parser.stencilContext()
@@ -58,7 +58,7 @@ class YamlTests: XCTestCase {
 
   func testDirectoryInput() {
     do {
-      let parser = Yaml.Parser()
+      let parser = try Yaml.Parser()
       let filter = try Filter(pattern: "[^/]*\\.(json|ya?ml)$")
       try parser.searchAndParse(path: Fixtures.directory(sub: .yamlGood), filter: filter)
 

--- a/Tests/SwiftGenKitTests/YamlTests.swift
+++ b/Tests/SwiftGenKitTests/YamlTests.swift
@@ -86,8 +86,9 @@ class YamlTests: XCTestCase {
     do {
       _ = try Yaml.Parser(options: ["SomeOptionThatDoesntExist": "foo"])
       XCTFail("Parser successfully created with an invalid option")
-    } catch ParserOptionList.Error.unknownOption {
+    } catch ParserOptionList.Error.unknownOption(let key, _) {
       // That's the expected exception we want to happen
+      XCTAssertEqual(key, "SomeOptionThatDoesntExist", "Failed for unexpected option \(key)")
     } catch let error {
       XCTFail("Unexpected error occured: \(error)")
     }


### PR DESCRIPTION
As discussed in #588 and in Slack, this PR adds better safety checks for parser options.
Initial implementation by @AliSoftware, added some code for checking if options match those we know.

Still need to:
- [x] Add some tests
- [ ] Maybe some way of displaying available options for config users?