### PR TITLE
Add a help message if there's an error #trivial

### DIFF
--- a/Sources/SwiftGen/Commander/ConfigCommands.swift
+++ b/Sources/SwiftGen/Commander/ConfigCommands.swift
@@ -110,6 +110,13 @@ enum ConfigCLI {
       }
     } catch let error as Config.Error {
       logMessage(.error, error)
+      logMessage(.info, """
+        It seems like there was an error running SwiftGen. Please verify that your configuration file is valid by running:
+        > swiftgen config lint
+
+        If you have any other questions or issues, we have extensive documentation and an issue tracker on GitHub:
+        > https://github.com/SwiftGen/SwiftGen
+        """)
     }
   }
 }

--- a/Sources/SwiftGen/Config/Config.swift
+++ b/Sources/SwiftGen/Config/Config.swift
@@ -102,7 +102,7 @@ extension Config {
           .warning,
           """
           \(cmd).inputs: \(inputPath) is an absolute path. Prefer relative paths for portability \
-          when sharing your project.
+          when sharing your project (unless you are using environment variables).
           """
         )
       }
@@ -129,7 +129,7 @@ extension Config {
         .warning,
         """
         \(cmd).outputs.templatePath: \(templateRef) is an absolute path. Prefer relative paths \
-        for portability when sharing your project.
+        for portability when sharing your project (unless you are using environment variables).
         """
       )
     }
@@ -149,7 +149,7 @@ extension Config {
         .warning,
         """
         \(cmd).outputs.output: \(entryOutput.output) is an absolute path. Prefer relative paths \
-        for portability when sharing your project.
+        for portability when sharing your project (unless you are using environment variables).
         """
       )
     }

--- a/Sources/SwiftGen/Config/Config.swift
+++ b/Sources/SwiftGen/Config/Config.swift
@@ -76,10 +76,12 @@ extension Config {
       return "\(path) does not exist."
     }
 
-    static let intermediateFolders = """
-      Intermediate folders up to the output file must already exist to avoid misconfigurations, \
-      and won't be created for you.
-      """
+    static func doesntExistIntermediatesNeeded(_ path: CustomStringConvertible) -> String {
+      return """
+        \(path) does not exist. Intermediate folders up to the output file must already exist to avoid \
+        misconfigurations, and won't be created for you.
+        """
+      }
   }
 
   // Deprecated
@@ -146,7 +148,7 @@ extension Config {
 
     let outputParent = entryOutput.output.parent()
     if !outputParent.exists {
-      logger(.error, "\(cmd).outputs.output: \(Message.doesntExist(outputParent)) \(Message.intermediateFolders)")
+      logger(.error, "\(cmd).outputs.output: \(Message.doesntExistIntermediatesNeeded(outputParent))")
     }
     if entryOutput.output.isAbsolute {
       logger(.warning, "\(cmd).outputs.output: \(Message.absolutePath(entryOutput.output))")

--- a/Tests/SwiftGenTests/ConfigLintTests.swift
+++ b/Tests/SwiftGenTests/ConfigLintTests.swift
@@ -57,15 +57,16 @@ class ConfigLintTests: XCTestCase {
       [
         (.warning, """
           \(cmd).inputs: /\(cmd)/paths is an absolute path. Prefer relative paths for portability \
-          when sharing your project.
+          when sharing your project (unless you are using environment variables).
           """),
         (.warning, """
           \(cmd).outputs.templatePath: /\(cmd)/templates.stencil is an absolute path. Prefer \
-          relative paths for portability when sharing your project.
+          relative paths for portability when sharing your project (unless you are using \
+          environment variables).
           """),
         (.warning, """
           \(cmd).outputs.output: /\(cmd)/out.swift is an absolute path. Prefer relative paths for \
-          portability when sharing your project.
+          portability when sharing your project (unless you are using environment variables).
           """)
       ]
     }
@@ -83,15 +84,17 @@ class ConfigLintTests: XCTestCase {
       [
         (.warning, """
           \(cmd).inputs: /input/\(cmd)/paths is an absolute path. Prefer relative paths for \
-          portability when sharing your project.
+          portability when sharing your project (unless you are using environment variables).
           """),
         (.warning, """
           \(cmd).outputs.templatePath: /templates/\(cmd)/templates.stencil is an absolute path. \
-          Prefer relative paths for portability when sharing your project.
+          Prefer relative paths for portability when sharing your project (unless you are using \
+          environment variables).
           """),
         (.warning, """
           \(cmd).outputs.output: /output/\(cmd)/out.swift is an absolute path. Prefer relative \
-          paths for portability when sharing your project.
+          paths for portability when sharing your project (unless you are using environment \
+          variables).
           """)
       ]
     }

--- a/Tests/SwiftGenTests/ConfigLintTests.swift
+++ b/Tests/SwiftGenTests/ConfigLintTests.swift
@@ -160,35 +160,23 @@ class ConfigLintTests: XCTestCase {
     _testLint(
       fixture: "config-with-multi-entries",
       expectedLogs: [
-        (.error, "input_dir: Input directory Fixtures/ does not exist"),
-        (.error, "output_dir: Output directory Generated/ does not exist"),
-        (.error, "strings.inputs: Fixtures/Strings/Localizable.strings does not exist"),
+        (.error, "input_dir: Input directory \(Config.Message.doesntExist("Fixtures/"))"),
+        (.error, "output_dir: Output directory \(Config.Message.doesntExist("Generated/"))"),
+        (.error, "strings.inputs: \(Config.Message.doesntExist("Fixtures/Strings/Localizable.strings"))"),
         (.error, "strings.outputs: Template not found at path templates/custom-swift3."),
-        (.error, """
-          strings.outputs.output: Generated does not exist. Intermediate folders up to the output \
-          file must already exist to avoid misconfigurations, and won't be created for you.
-          """),
-        (.error, "xcassets.inputs: Fixtures/XCAssets/Colors.xcassets does not exist"),
-        (.error, "xcassets.inputs: Fixtures/XCAssets/Colors.xcassets does not exist"),
-        (.error, "xcassets.inputs: Fixtures/XCAssets/Images.xcassets does not exist"),
-        (.error, "xcassets.inputs: Fixtures/XCAssets/Images.xcassets does not exist"),
+        (.error, "strings.outputs.output: \(Config.Message.doesntExistIntermediatesNeeded("Generated"))"),
+        (.error, "xcassets.inputs: \(Config.Message.doesntExist("Fixtures/XCAssets/Colors.xcassets"))"),
+        (.error, "xcassets.inputs: \(Config.Message.doesntExist("Fixtures/XCAssets/Colors.xcassets"))"),
+        (.error, "xcassets.inputs: \(Config.Message.doesntExist("Fixtures/XCAssets/Images.xcassets"))"),
+        (.error, "xcassets.inputs: \(Config.Message.doesntExist("Fixtures/XCAssets/Images.xcassets"))"),
         (.error, """
           xcassets.outputs: Template named custom-swift3 not found. Use `swiftgen templates list` \
           to list available named templates or use `templatePath` to specify a template by its \
           full path.
           """),
-        (.error, """
-          xcassets.outputs.output: Generated does not exist. Intermediate folders up to the output \
-          file must already exist to avoid misconfigurations, and won't be created for you.
-          """),
-        (.error, """
-          xcassets.outputs.output: Generated does not exist. Intermediate folders up to the output \
-          file must already exist to avoid misconfigurations, and won't be created for you.
-          """),
-        (.error, """
-          xcassets.outputs.output: Generated does not exist. Intermediate folders up to the output \
-          file must already exist to avoid misconfigurations, and won't be created for you.
-          """)
+        (.error, "xcassets.outputs.output: \(Config.Message.doesntExistIntermediatesNeeded("Generated"))"),
+        (.error, "xcassets.outputs.output: \(Config.Message.doesntExistIntermediatesNeeded("Generated"))"),
+        (.error, "xcassets.outputs.output: \(Config.Message.doesntExistIntermediatesNeeded("Generated"))")
       ],
       unwantedLevels: [.warning, .error],
       assertionMessage: "Linter should show errors for invalid paths and templates"
@@ -200,7 +188,7 @@ class ConfigLintTests: XCTestCase {
   func testDeprecatedCommands() {
     _testLint(
       fixture: "config-deprecated-commands",
-      expectedLogs: [(.warning, "`storyboards` action has been deprecated, please use `ib` instead.")],
+      expectedLogs: [(.warning, Config.Message.deprecatedAction("storyboards", for: "ib"))],
       assertionMessage: "Linter should warn about deprecated commands"
     )
   }

--- a/Tests/SwiftGenTests/ConfigLintTests.swift
+++ b/Tests/SwiftGenTests/ConfigLintTests.swift
@@ -55,19 +55,9 @@ class ConfigLintTests: XCTestCase {
     let commands = ["strings", "fonts", "ib", "colors", "xcassets"]
     let logs = commands.flatMap { (cmd: String) -> [(LogLevel, String)] in
       [
-        (.warning, """
-          \(cmd).inputs: /\(cmd)/paths is an absolute path. Prefer relative paths for portability \
-          when sharing your project (unless you are using environment variables).
-          """),
-        (.warning, """
-          \(cmd).outputs.templatePath: /\(cmd)/templates.stencil is an absolute path. Prefer \
-          relative paths for portability when sharing your project (unless you are using \
-          environment variables).
-          """),
-        (.warning, """
-          \(cmd).outputs.output: /\(cmd)/out.swift is an absolute path. Prefer relative paths for \
-          portability when sharing your project (unless you are using environment variables).
-          """)
+        (.warning, "\(cmd).inputs: \(Config.Message.absolutePath("/\(cmd)/paths"))"),
+        (.warning, "\(cmd).outputs.templatePath: \(Config.Message.absolutePath("/\(cmd)/templates.stencil"))"),
+        (.warning, "\(cmd).outputs.output: \(Config.Message.absolutePath("/\(cmd)/out.swift"))")
       ]
     }
 
@@ -82,20 +72,11 @@ class ConfigLintTests: XCTestCase {
     let commands = ["strings", "fonts", "ib", "colors", "xcassets"]
     let logs = commands.flatMap { (cmd: String) -> [(LogLevel, String)] in
       [
+        (.warning, "\(cmd).inputs: \(Config.Message.absolutePath("/input/\(cmd)/paths"))"),
         (.warning, """
-          \(cmd).inputs: /input/\(cmd)/paths is an absolute path. Prefer relative paths for \
-          portability when sharing your project (unless you are using environment variables).
+          \(cmd).outputs.templatePath: \(Config.Message.absolutePath("/templates/\(cmd)/templates.stencil"))
           """),
-        (.warning, """
-          \(cmd).outputs.templatePath: /templates/\(cmd)/templates.stencil is an absolute path. \
-          Prefer relative paths for portability when sharing your project (unless you are using \
-          environment variables).
-          """),
-        (.warning, """
-          \(cmd).outputs.output: /output/\(cmd)/out.swift is an absolute path. Prefer relative \
-          paths for portability when sharing your project (unless you are using environment \
-          variables).
-          """)
+        (.warning, "\(cmd).outputs.output: \(Config.Message.absolutePath("/output/\(cmd)/out.swift"))")
       ]
     }
 


### PR DESCRIPTION
I don't know how far we want to go with this. CocoaPods seems to display a quite nice error message with suggestions (when there's an error), we may want to take some inspiration from there.