### PR TITLE
CoreData: expand RawRepresentable to non-enum types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,12 @@
   [David Jennes](https://github.com/djbe)
   [#591](https://github.com/SwiftGen/SwiftGen/issue/591)
   [#592](https://github.com/SwiftGen/SwiftGen/pull/592)
-* Core Data: the built-in templates now support `RawRepresentable` attributes (such as `enum`, `OptionSet`, …). They'll check the "User Info" of an attribute for a `RawType` key, which should be set to the type name you want to use for that attribute. For more information, check the [template's documentation](Documentation/templates/coredata/swift4.md#userinfo-keys).  
+* Core Data: the built-in templates now support `RawRepresentable` attributes (such as `enum`, `OptionSet`, …). They'll check the "User Info" of an attribute for a `RawType` key, which should be set to the type name you want to use for that attribute. To avoid optional attributes, you can also add the `unwrapOptional` user info key. For more information, check the [template's documentation](Documentation/templates/coredata/swift4.md#userinfo-keys).  
   [David Jennes](https://github.com/djbe)
   [#566](https://github.com/SwiftGen/SwiftGen/issue/566)
+  [#609](https://github.com/SwiftGen/SwiftGen/issue/609)
   [#593](https://github.com/SwiftGen/SwiftGen/pull/593)
+  [#610](https://github.com/SwiftGen/SwiftGen/pull/610)
 * Strings: the built-in templates now accept a parameter for customizing the localization function.  
   [Steven Magdy](https://github.com/StevenMagdy)
   [426](https://github.com/SwiftGen/SwiftGen/issues/426)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
   [David Jennes](https://github.com/djbe)
   [#591](https://github.com/SwiftGen/SwiftGen/issue/591)
   [#592](https://github.com/SwiftGen/SwiftGen/pull/592)
-* Core Data: the built-in templates now support `enum` attributes. They'll check the "User Info" of an attribute for a `enumType` key, which should be set to the enum type name you want to use for that attribute. For more information, check the [template's documentation](Documentation/templates/coredata/swift4.md#userinfo-keys).  
+* Core Data: the built-in templates now support `RawRepresentable` attributes (such as `enum`, `OptionSet`, …). They'll check the "User Info" of an attribute for a `RawType` key, which should be set to the type name you want to use for that attribute. For more information, check the [template's documentation](Documentation/templates/coredata/swift4.md#userinfo-keys).  
   [David Jennes](https://github.com/djbe)
   [#566](https://github.com/SwiftGen/SwiftGen/issue/566)
   [#593](https://github.com/SwiftGen/SwiftGen/pull/593)

--- a/Documentation/templates/coredata/swift3.md
+++ b/Documentation/templates/coredata/swift3.md
@@ -31,6 +31,7 @@ This template also make use of UserInfo keys that you can set on your Data Model
 | Scope | UserInfo Key | Description |
 |-------|--------------|-------------|
 | Attribute | `RawType` | The name of the `RawRepresentable` type to associate to this attribute's type. The type in question is expected to be declared in your code (SwiftGen won't generate it) or in an external module (see the`extraImports` parameter).<br />The type must be `RawRepresentable` (e.g. `enum Foo: String` or `struct Foo: OptionSet`) and its `RawValue` must match the attribute's type in your Data Model. |
+| Attribute | `unwrapOptional` | For use together with the `rawType` user info key. If set, this will adapt the generated attribute code slightly so that it is no longer an optional attribute, and will throw a `fatalError` when unwrapping fails.  |
 
 ## Generated Code
 

--- a/Documentation/templates/coredata/swift3.md
+++ b/Documentation/templates/coredata/swift3.md
@@ -30,7 +30,7 @@ This template also make use of UserInfo keys that you can set on your Data Model
 
 | Scope | UserInfo Key | Description |
 |-------|--------------|-------------|
-| Attribute | `enumType` | The name of the `enum` to associate to this attribute's type. The `enum` in question is expected to be declared in your code (SwiftGen won't generate it) or in an external module (see the`extraImports` parameter).<br />The `enum` must be `RawRepresentable` (e.g. `enum Foo: Int` or `enum Foo: String`) and its `RawValue` must match the attribute's type in your Data Model. |
+| Attribute | `RawType` | The name of the `RawRepresentable` type to associate to this attribute's type. The type in question is expected to be declared in your code (SwiftGen won't generate it) or in an external module (see the`extraImports` parameter).<br />The type must be `RawRepresentable` (e.g. `enum Foo: String` or `struct Foo: OptionSet`) and its `RawValue` must match the attribute's type in your Data Model. |
 
 ## Generated Code
 

--- a/Documentation/templates/coredata/swift4.md
+++ b/Documentation/templates/coredata/swift4.md
@@ -30,6 +30,7 @@ This template also make use of UserInfo keys that you can set on your Data Model
 | Scope | UserInfo Key | Description |
 |-------|--------------|-------------|
 | Attribute | `RawType` | The name of the `RawRepresentable` type to associate to this attribute's type. The type in question is expected to be declared in your code (SwiftGen won't generate it) or in an external module (see the`extraImports` parameter).<br />The type must be `RawRepresentable` (e.g. `enum Foo: String` or `struct Foo: OptionSet`) and its `RawValue` must match the attribute's type in your Data Model. |
+| Attribute | `unwrapOptional` | For use together with the `rawType` user info key. If set, this will adapt the generated attribute code slightly so that it is no longer an optional attribute, and will throw a `fatalError` when unwrapping fails.  |
 
 ## Generated Code
 

--- a/Documentation/templates/coredata/swift4.md
+++ b/Documentation/templates/coredata/swift4.md
@@ -29,7 +29,7 @@ This template also make use of UserInfo keys that you can set on your Data Model
 
 | Scope | UserInfo Key | Description |
 |-------|--------------|-------------|
-| Attribute | `enumType` | The name of the `enum` to associate to this attribute's type. The `enum` in question is expected to be declared in your code (SwiftGen won't generate it) or in an external module (see the`extraImports` parameter).<br />The `enum` must be `RawRepresentable` (e.g. `enum Foo: Int` or `enum Foo: String`) and its `RawValue` must match the attribute's type in your Data Model. |
+| Attribute | `RawType` | The name of the `RawRepresentable` type to associate to this attribute's type. The type in question is expected to be declared in your code (SwiftGen won't generate it) or in an external module (see the`extraImports` parameter).<br />The type must be `RawRepresentable` (e.g. `enum Foo: String` or `struct Foo: OptionSet`) and its `RawValue` must match the attribute's type in your Data Model. |
 
 ## Generated Code
 

--- a/Tests/Fixtures/Generated/CoreData/swift3/defaults-extraImports.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift3/defaults-extraImports.swift
@@ -87,23 +87,24 @@ internal class MainEntity: NSManagedObject {
   @NSManaged internal var int16: Int16
   @NSManaged internal var int32: Int32
   @NSManaged internal var int64: Int64
-  internal var integerEnum: IntegerEnum? {
+  internal var integerEnum: IntegerEnum {
     get {
       let key = "integerEnum"
       willAccessValue(forKey: key)
       defer { didAccessValue(forKey: key) }
 
-      guard let value = primitiveValue(forKey: key) as? IntegerEnum.RawValue else {
-        return nil
+      guard let value = primitiveValue(forKey: key) as? IntegerEnum.RawValue,
+        let result = IntegerEnum(rawValue: value) else {
+        fatalError("Could not convert value for key '\(key)' to type 'IntegerEnum'")
       }
-      return IntegerEnum(rawValue: value)
+      return result
     }
     set {
       let key = "integerEnum"
       willChangeValue(forKey: key)
       defer { didChangeValue(forKey: key) }
 
-      setPrimitiveValue(newValue?.rawValue, forKey: key)
+      setPrimitiveValue(newValue.rawValue, forKey: key)
     }
   }
   internal var optionalBoolean: Bool? {

--- a/Tests/Fixtures/Generated/CoreData/swift3/defaults-generateObjcName.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift3/defaults-generateObjcName.swift
@@ -88,23 +88,24 @@ internal class MainEntity: NSManagedObject {
   @NSManaged internal var int16: Int16
   @NSManaged internal var int32: Int32
   @NSManaged internal var int64: Int64
-  internal var integerEnum: IntegerEnum? {
+  internal var integerEnum: IntegerEnum {
     get {
       let key = "integerEnum"
       willAccessValue(forKey: key)
       defer { didAccessValue(forKey: key) }
 
-      guard let value = primitiveValue(forKey: key) as? IntegerEnum.RawValue else {
-        return nil
+      guard let value = primitiveValue(forKey: key) as? IntegerEnum.RawValue,
+        let result = IntegerEnum(rawValue: value) else {
+        fatalError("Could not convert value for key '\(key)' to type 'IntegerEnum'")
       }
-      return IntegerEnum(rawValue: value)
+      return result
     }
     set {
       let key = "integerEnum"
       willChangeValue(forKey: key)
       defer { didChangeValue(forKey: key) }
 
-      setPrimitiveValue(newValue?.rawValue, forKey: key)
+      setPrimitiveValue(newValue.rawValue, forKey: key)
     }
   }
   internal var optionalBoolean: Bool? {

--- a/Tests/Fixtures/Generated/CoreData/swift3/defaults-importCoreLocation.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift3/defaults-importCoreLocation.swift
@@ -86,23 +86,24 @@ internal class MainEntity: NSManagedObject {
   @NSManaged internal var int16: Int16
   @NSManaged internal var int32: Int32
   @NSManaged internal var int64: Int64
-  internal var integerEnum: IntegerEnum? {
+  internal var integerEnum: IntegerEnum {
     get {
       let key = "integerEnum"
       willAccessValue(forKey: key)
       defer { didAccessValue(forKey: key) }
 
-      guard let value = primitiveValue(forKey: key) as? IntegerEnum.RawValue else {
-        return nil
+      guard let value = primitiveValue(forKey: key) as? IntegerEnum.RawValue,
+        let result = IntegerEnum(rawValue: value) else {
+        fatalError("Could not convert value for key '\(key)' to type 'IntegerEnum'")
       }
-      return IntegerEnum(rawValue: value)
+      return result
     }
     set {
       let key = "integerEnum"
       willChangeValue(forKey: key)
       defer { didChangeValue(forKey: key) }
 
-      setPrimitiveValue(newValue?.rawValue, forKey: key)
+      setPrimitiveValue(newValue.rawValue, forKey: key)
     }
   }
   internal var optionalBoolean: Bool? {

--- a/Tests/Fixtures/Generated/CoreData/swift3/defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift3/defaults-publicAccess.swift
@@ -85,23 +85,24 @@ public class MainEntity: NSManagedObject {
   @NSManaged public var int16: Int16
   @NSManaged public var int32: Int32
   @NSManaged public var int64: Int64
-  public var integerEnum: IntegerEnum? {
+  public var integerEnum: IntegerEnum {
     get {
       let key = "integerEnum"
       willAccessValue(forKey: key)
       defer { didAccessValue(forKey: key) }
 
-      guard let value = primitiveValue(forKey: key) as? IntegerEnum.RawValue else {
-        return nil
+      guard let value = primitiveValue(forKey: key) as? IntegerEnum.RawValue,
+        let result = IntegerEnum(rawValue: value) else {
+        fatalError("Could not convert value for key '\(key)' to type 'IntegerEnum'")
       }
-      return IntegerEnum(rawValue: value)
+      return result
     }
     set {
       let key = "integerEnum"
       willChangeValue(forKey: key)
       defer { didChangeValue(forKey: key) }
 
-      setPrimitiveValue(newValue?.rawValue, forKey: key)
+      setPrimitiveValue(newValue.rawValue, forKey: key)
     }
   }
   public var optionalBoolean: Bool? {

--- a/Tests/Fixtures/Generated/CoreData/swift3/defaults.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift3/defaults.swift
@@ -85,23 +85,24 @@ internal class MainEntity: NSManagedObject {
   @NSManaged internal var int16: Int16
   @NSManaged internal var int32: Int32
   @NSManaged internal var int64: Int64
-  internal var integerEnum: IntegerEnum? {
+  internal var integerEnum: IntegerEnum {
     get {
       let key = "integerEnum"
       willAccessValue(forKey: key)
       defer { didAccessValue(forKey: key) }
 
-      guard let value = primitiveValue(forKey: key) as? IntegerEnum.RawValue else {
-        return nil
+      guard let value = primitiveValue(forKey: key) as? IntegerEnum.RawValue,
+        let result = IntegerEnum(rawValue: value) else {
+        fatalError("Could not convert value for key '\(key)' to type 'IntegerEnum'")
       }
-      return IntegerEnum(rawValue: value)
+      return result
     }
     set {
       let key = "integerEnum"
       willChangeValue(forKey: key)
       defer { didChangeValue(forKey: key) }
 
-      setPrimitiveValue(newValue?.rawValue, forKey: key)
+      setPrimitiveValue(newValue.rawValue, forKey: key)
     }
   }
   internal var optionalBoolean: Bool? {

--- a/Tests/Fixtures/Generated/CoreData/swift4/defaults-extraImports.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift4/defaults-extraImports.swift
@@ -87,23 +87,24 @@ internal class MainEntity: NSManagedObject {
   @NSManaged internal var int16: Int16
   @NSManaged internal var int32: Int32
   @NSManaged internal var int64: Int64
-  internal var integerEnum: IntegerEnum? {
+  internal var integerEnum: IntegerEnum {
     get {
       let key = "integerEnum"
       willAccessValue(forKey: key)
       defer { didAccessValue(forKey: key) }
 
-      guard let value = primitiveValue(forKey: key) as? IntegerEnum.RawValue else {
-        return nil
+      guard let value = primitiveValue(forKey: key) as? IntegerEnum.RawValue,
+        let result = IntegerEnum(rawValue: value) else {
+        fatalError("Could not convert value for key '\(key)' to type 'IntegerEnum'")
       }
-      return IntegerEnum(rawValue: value)
+      return result
     }
     set {
       let key = "integerEnum"
       willChangeValue(forKey: key)
       defer { didChangeValue(forKey: key) }
 
-      setPrimitiveValue(newValue?.rawValue, forKey: key)
+      setPrimitiveValue(newValue.rawValue, forKey: key)
     }
   }
   internal var optionalBoolean: Bool? {

--- a/Tests/Fixtures/Generated/CoreData/swift4/defaults-generateObjcName.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift4/defaults-generateObjcName.swift
@@ -88,23 +88,24 @@ internal class MainEntity: NSManagedObject {
   @NSManaged internal var int16: Int16
   @NSManaged internal var int32: Int32
   @NSManaged internal var int64: Int64
-  internal var integerEnum: IntegerEnum? {
+  internal var integerEnum: IntegerEnum {
     get {
       let key = "integerEnum"
       willAccessValue(forKey: key)
       defer { didAccessValue(forKey: key) }
 
-      guard let value = primitiveValue(forKey: key) as? IntegerEnum.RawValue else {
-        return nil
+      guard let value = primitiveValue(forKey: key) as? IntegerEnum.RawValue,
+        let result = IntegerEnum(rawValue: value) else {
+        fatalError("Could not convert value for key '\(key)' to type 'IntegerEnum'")
       }
-      return IntegerEnum(rawValue: value)
+      return result
     }
     set {
       let key = "integerEnum"
       willChangeValue(forKey: key)
       defer { didChangeValue(forKey: key) }
 
-      setPrimitiveValue(newValue?.rawValue, forKey: key)
+      setPrimitiveValue(newValue.rawValue, forKey: key)
     }
   }
   internal var optionalBoolean: Bool? {

--- a/Tests/Fixtures/Generated/CoreData/swift4/defaults-importCoreLocation.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift4/defaults-importCoreLocation.swift
@@ -86,23 +86,24 @@ internal class MainEntity: NSManagedObject {
   @NSManaged internal var int16: Int16
   @NSManaged internal var int32: Int32
   @NSManaged internal var int64: Int64
-  internal var integerEnum: IntegerEnum? {
+  internal var integerEnum: IntegerEnum {
     get {
       let key = "integerEnum"
       willAccessValue(forKey: key)
       defer { didAccessValue(forKey: key) }
 
-      guard let value = primitiveValue(forKey: key) as? IntegerEnum.RawValue else {
-        return nil
+      guard let value = primitiveValue(forKey: key) as? IntegerEnum.RawValue,
+        let result = IntegerEnum(rawValue: value) else {
+        fatalError("Could not convert value for key '\(key)' to type 'IntegerEnum'")
       }
-      return IntegerEnum(rawValue: value)
+      return result
     }
     set {
       let key = "integerEnum"
       willChangeValue(forKey: key)
       defer { didChangeValue(forKey: key) }
 
-      setPrimitiveValue(newValue?.rawValue, forKey: key)
+      setPrimitiveValue(newValue.rawValue, forKey: key)
     }
   }
   internal var optionalBoolean: Bool? {

--- a/Tests/Fixtures/Generated/CoreData/swift4/defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift4/defaults-publicAccess.swift
@@ -85,23 +85,24 @@ public class MainEntity: NSManagedObject {
   @NSManaged public var int16: Int16
   @NSManaged public var int32: Int32
   @NSManaged public var int64: Int64
-  public var integerEnum: IntegerEnum? {
+  public var integerEnum: IntegerEnum {
     get {
       let key = "integerEnum"
       willAccessValue(forKey: key)
       defer { didAccessValue(forKey: key) }
 
-      guard let value = primitiveValue(forKey: key) as? IntegerEnum.RawValue else {
-        return nil
+      guard let value = primitiveValue(forKey: key) as? IntegerEnum.RawValue,
+        let result = IntegerEnum(rawValue: value) else {
+        fatalError("Could not convert value for key '\(key)' to type 'IntegerEnum'")
       }
-      return IntegerEnum(rawValue: value)
+      return result
     }
     set {
       let key = "integerEnum"
       willChangeValue(forKey: key)
       defer { didChangeValue(forKey: key) }
 
-      setPrimitiveValue(newValue?.rawValue, forKey: key)
+      setPrimitiveValue(newValue.rawValue, forKey: key)
     }
   }
   public var optionalBoolean: Bool? {

--- a/Tests/Fixtures/Generated/CoreData/swift4/defaults.swift
+++ b/Tests/Fixtures/Generated/CoreData/swift4/defaults.swift
@@ -85,23 +85,24 @@ internal class MainEntity: NSManagedObject {
   @NSManaged internal var int16: Int16
   @NSManaged internal var int32: Int32
   @NSManaged internal var int64: Int64
-  internal var integerEnum: IntegerEnum? {
+  internal var integerEnum: IntegerEnum {
     get {
       let key = "integerEnum"
       willAccessValue(forKey: key)
       defer { didAccessValue(forKey: key) }
 
-      guard let value = primitiveValue(forKey: key) as? IntegerEnum.RawValue else {
-        return nil
+      guard let value = primitiveValue(forKey: key) as? IntegerEnum.RawValue,
+        let result = IntegerEnum(rawValue: value) else {
+        fatalError("Could not convert value for key '\(key)' to type 'IntegerEnum'")
       }
-      return IntegerEnum(rawValue: value)
+      return result
     }
     set {
       let key = "integerEnum"
       willChangeValue(forKey: key)
       defer { didChangeValue(forKey: key) }
 
-      setPrimitiveValue(newValue?.rawValue, forKey: key)
+      setPrimitiveValue(newValue.rawValue, forKey: key)
     }
   }
   internal var optionalBoolean: Bool? {

--- a/Tests/Fixtures/Resources/CoreData/Model.xcdatamodeld/Model 2.xcdatamodel/contents
+++ b/Tests/Fixtures/Resources/CoreData/Model.xcdatamodeld/Model 2.xcdatamodel/contents
@@ -27,6 +27,7 @@
         <attribute name="integerEnum" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES" syncable="YES">
             <userInfo>
                 <entry key="RawType" value="IntegerEnum"/>
+                <entry key="unwrapOptional" value="true"/>
             </userInfo>
         </attribute>
         <attribute name="optionalBoolean" optional="YES" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>

--- a/Tests/Fixtures/Resources/CoreData/Model.xcdatamodeld/Model 2.xcdatamodel/contents
+++ b/Tests/Fixtures/Resources/CoreData/Model.xcdatamodeld/Model 2.xcdatamodel/contents
@@ -26,7 +26,7 @@
         <attribute name="int64" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="integerEnum" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES" syncable="YES">
             <userInfo>
-                <entry key="enumType" value="IntegerEnum"/>
+                <entry key="RawType" value="IntegerEnum"/>
             </userInfo>
         </attribute>
         <attribute name="optionalBoolean" optional="YES" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
@@ -39,7 +39,7 @@
         <attribute name="string" attributeType="String" syncable="YES"/>
         <attribute name="stringEnum" optional="YES" attributeType="String" syncable="YES">
             <userInfo>
-                <entry key="enumType" value="StringEnum"/>
+                <entry key="RawType" value="StringEnum"/>
             </userInfo>
         </attribute>
         <attribute name="transformable" optional="YES" attributeType="Transformable" syncable="YES"/>

--- a/Tests/Fixtures/StencilContexts/CoreData/defaults.yaml
+++ b/Tests/Fixtures/StencilContexts/CoreData/defaults.yaml
@@ -181,6 +181,7 @@ models:
         typeName: "Int16"
         userInfo:
           RawType: "IntegerEnum"
+          unwrapOptional: true
         usesScalarValueType: true
       - customClassName: ""
         isIndexed: false

--- a/Tests/Fixtures/StencilContexts/CoreData/defaults.yaml
+++ b/Tests/Fixtures/StencilContexts/CoreData/defaults.yaml
@@ -180,7 +180,7 @@ models:
         type: "Integer 16"
         typeName: "Int16"
         userInfo:
-          enumType: "IntegerEnum"
+          RawType: "IntegerEnum"
         usesScalarValueType: true
       - customClassName: ""
         isIndexed: false
@@ -271,7 +271,7 @@ models:
         type: "String"
         typeName: "String"
         userInfo:
-          enumType: "StringEnum"
+          RawType: "StringEnum"
         usesScalarValueType: false
       - customClassName: ""
         isIndexed: false

--- a/templates/coredata/swift3.stencil
+++ b/templates/coredata/swift3.stencil
@@ -48,17 +48,18 @@ import {{ import }}
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection
   {% for attribute in entity.attributes %}
-  {% if attribute.userInfo.enumType %}
-  {{ accessModifier }} var {{ attribute.name }}: {{ attribute.userInfo.enumType }}? {
+  {% if attribute.userInfo.RawType %}
+  {% set rawType attribute.userInfo.RawType %}
+  {{ accessModifier }} var {{ attribute.name }}: {{ rawType }}? {
     get {
       let key = "{{ attribute.name }}"
       willAccessValue(forKey: key)
       defer { didAccessValue(forKey: key) }
 
-      guard let value = primitiveValue(forKey: key) as? {{ attribute.userInfo.enumType }}.RawValue else {
+      guard let value = primitiveValue(forKey: key) as? {{ rawType }}.RawValue else {
         return nil
       }
-      return {{ attribute.userInfo.enumType }}(rawValue: value)
+      return {{ rawType }}(rawValue: value)
     }
     set {
       let key = "{{ attribute.name }}"

--- a/templates/coredata/swift3.stencil
+++ b/templates/coredata/swift3.stencil
@@ -50,23 +50,32 @@ import {{ import }}
   {% for attribute in entity.attributes %}
   {% if attribute.userInfo.RawType %}
   {% set rawType attribute.userInfo.RawType %}
-  {{ accessModifier }} var {{ attribute.name }}: {{ rawType }}? {
+  {% set unwrapOptional attribute.userInfo.unwrapOptional %}
+  {{ accessModifier }} var {{ attribute.name }}: {{ rawType }}{% if not unwrapOptional %}?{% endif %} {
     get {
       let key = "{{ attribute.name }}"
       willAccessValue(forKey: key)
       defer { didAccessValue(forKey: key) }
 
+      {% if unwrapOptional %}
+      guard let value = primitiveValue(forKey: key) as? {{ rawType }}.RawValue,
+        let result = {{ rawType }}(rawValue: value) else {
+        fatalError("Could not convert value for key '\(key)' to type '{{ rawType }}'")
+      }
+      return result
+      {% else %}
       guard let value = primitiveValue(forKey: key) as? {{ rawType }}.RawValue else {
         return nil
       }
       return {{ rawType }}(rawValue: value)
+      {% endif %}
     }
     set {
       let key = "{{ attribute.name }}"
       willChangeValue(forKey: key)
       defer { didChangeValue(forKey: key) }
 
-      setPrimitiveValue(newValue?.rawValue, forKey: key)
+      setPrimitiveValue(newValue{% if not unwrapOptional %}?{% endif %}.rawValue, forKey: key)
     }
   }
   {% elif attribute.usesScalarValueType and attribute.isOptional %}

--- a/templates/coredata/swift4.stencil
+++ b/templates/coredata/swift4.stencil
@@ -48,17 +48,18 @@ import {{ import }}
 
   // swiftlint:disable discouraged_optional_boolean discouraged_optional_collection
   {% for attribute in entity.attributes %}
-  {% if attribute.userInfo.enumType %}
-  {{ accessModifier }} var {{ attribute.name }}: {{ attribute.userInfo.enumType }}? {
+  {% if attribute.userInfo.RawType %}
+  {% set rawType attribute.userInfo.RawType %}
+  {{ accessModifier }} var {{ attribute.name }}: {{ rawType }}? {
     get {
       let key = "{{ attribute.name }}"
       willAccessValue(forKey: key)
       defer { didAccessValue(forKey: key) }
 
-      guard let value = primitiveValue(forKey: key) as? {{ attribute.userInfo.enumType }}.RawValue else {
+      guard let value = primitiveValue(forKey: key) as? {{ rawType }}.RawValue else {
         return nil
       }
-      return {{ attribute.userInfo.enumType }}(rawValue: value)
+      return {{ rawType }}(rawValue: value)
     }
     set {
       let key = "{{ attribute.name }}"

--- a/templates/coredata/swift4.stencil
+++ b/templates/coredata/swift4.stencil
@@ -50,23 +50,32 @@ import {{ import }}
   {% for attribute in entity.attributes %}
   {% if attribute.userInfo.RawType %}
   {% set rawType attribute.userInfo.RawType %}
-  {{ accessModifier }} var {{ attribute.name }}: {{ rawType }}? {
+  {% set unwrapOptional attribute.userInfo.unwrapOptional %}
+  {{ accessModifier }} var {{ attribute.name }}: {{ rawType }}{% if not unwrapOptional %}?{% endif %} {
     get {
       let key = "{{ attribute.name }}"
       willAccessValue(forKey: key)
       defer { didAccessValue(forKey: key) }
 
+      {% if unwrapOptional %}
+      guard let value = primitiveValue(forKey: key) as? {{ rawType }}.RawValue,
+        let result = {{ rawType }}(rawValue: value) else {
+        fatalError("Could not convert value for key '\(key)' to type '{{ rawType }}'")
+      }
+      return result
+      {% else %}
       guard let value = primitiveValue(forKey: key) as? {{ rawType }}.RawValue else {
         return nil
       }
       return {{ rawType }}(rawValue: value)
+      {% endif %}
     }
     set {
       let key = "{{ attribute.name }}"
       willChangeValue(forKey: key)
       defer { didChangeValue(forKey: key) }
 
-      setPrimitiveValue(newValue?.rawValue, forKey: key)
+      setPrimitiveValue(newValue{% if not unwrapOptional %}?{% endif %}.rawValue, forKey: key)
     }
   }
   {% elif attribute.usesScalarValueType and attribute.isOptional %}


### PR DESCRIPTION
Fixes #609.

This renames the (unreleased) `enumType` to the more generic name `rawType`. It also adds an additional user info key `unwrapOptional`, for avoiding optional `RawRepresentable` attributes (using a `guard` & `fatalError`).

