### PR TITLE
Added doc for using env vars in config file #trivial

### DIFF
--- a/Documentation/ConfigFile.md
+++ b/Documentation/ConfigFile.md
@@ -8,6 +8,8 @@ Simply create a YAML file named `swiftgen.yml` at the root of your repository wi
 
 ## Configuration File Format
 
+### Global Structure
+
 The configuration file is a YAML file structured like this (example):
 
 ```yaml
@@ -37,6 +39,8 @@ xcassets:
 ℹ️ All _relative_ paths specified in the configuration file (`input_dir`, `output_dir`, `inputs`, `templatePath`, `output`) are relative to the location of the _configuration file_ itself.
 
 > 💡 We advise against using _absolute_ paths — starting with `/` — in the configuration file, so that they won't rely on where the project was cloned on your machine.
+
+### Keys details
 
 Here's a quick description of all the possible _root_ keys. All of them are optional.
 
@@ -87,6 +91,20 @@ Similarly to when you invoke each subcommand of SwiftGen manually:
 * `inputs` and `outputs` are mandatory.
 * You must specify either `templateName` or `templatePath`, but not both, nor neither.
 * `params` is optional.
+
+### Environment Variables
+
+You can use environment variables in your config file, by using the `${VARNAME}` syntax. Those environment variables will be expanded when SwiftGen parses the config file.
+
+If you're running `swiftgen` as part of a Script Build Phase in Xcode, this especially allows you to inject values coming from Xcode's build settings (as Xcode expose those as env vars) into your config file. For example:
+
+```yaml
+strings:
+  inputs: ${PROJECT_DIR}/${TARGET_NAME}/Resources/
+  outputs:
+    templateName: swift4
+    output: ${PROJECT_DIR}/${TARGET_NAME}/Constants/Strings-${TARGET_NAME}.swift
+```
 
 ## Advanced options for running the config file
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ SwiftGen is a tool to auto-generate Swift code for resources of your projects, t
   </td><td>
     <ul>
         <li><a href="#installation">Installation</a>
-        <li><a href="#usage">Usage</a>
+        <li><a href="#configuration-file">Configuration File</a>
         <li><a href="#choosing-your-template">Choosing your template</a>
         <li><a href="#additional-documentation">Additional documentation</a>
     </ul>
@@ -164,13 +164,13 @@ Or add the path to the `bin` folder to your `$PATH` and invoke `swiftgen` direct
 ---
 </details>
 
-## Usage
+## Configuration File
 
 > ❗️ If you're migrating from older SwiftGen versions, don't forget to [read the Migration Guide](Documentation/MigrationGuide.md).
 
 SwiftGen is provided as a single command-line tool which uses a configuration file to run various actions (subcommands).
 
-Each action described in the configuration file (`strings`, `fonts`, `ib`, …) typically corresponds to a type of input resources to parse (strings files, IB files, Font files, JSON files, …), allowing you to generate constants for each types of those input files.
+Each action described in the [configuration file](Documentation/ConfigFile.md) (`strings`, `fonts`, `ib`, …) typically corresponds to a type of input resources to parse (strings files, IB files, Font files, JSON files, …), allowing you to generate constants for each types of those input files.
 
 To use SwiftGen, simply create a `swiftgen.yml` YAML file to list all the subcommands to invoke, and for each subcommand, the list of arguments to pass to it. For example:
 
@@ -192,7 +192,7 @@ xcassets:
 
 Then you just have to invoke `swiftgen config run`, or even just `swiftgen` for short, and it will execute what's described in the configuration file
 
-To learn more about the configuration file — its more detailed syntax and possibilities, how to pass custom parameters, using `swiftgen config lint` to validate it, how to use alternate config files, and other tips — [see the dedicated documentation](Documentation/ConfigFile.md).
+[The dedicated documentation](Documentation/ConfigFile.md) explains the syntax and possibilities in details – like how to pass custom parameters, use `swiftgen config lint` to validate it, how to use alternate config files, and other tips.
 
 There are also additional subcommands you can invoke from the command line to manage and configure SwiftGen:
 


### PR DESCRIPTION
* [x] I've started my branch from the `develop` branch (gitflow)
  * [x] And I've selected `develop` as the "base" branch for this Pull Request I'm about to create
* [x] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself  
      _(or added `#trivial` to the PR title if I think it doesn't warrant a mention in the CHANGELOG)_
  * [ ] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
  * [ ] Add a period and 2 spaces at the end of your short entry description
  * [ ] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

I realized we didn't document the fact that the config file now supports the ENV vars in config file, so I added it.
Also reworded some small parts to make the doc more obvious/discoverable