### PR TITLE
Better CocoaPods script build phase #trivial

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ Given that you can specify an exact version for `SwiftGen` in your `Podfile`, th
 You can then invoke SwiftGen in your Script Build Phase using:
 
 ```sh
-if [[ -f "$PODS_ROOT"/SwiftGen/bin/swiftgen ]]; then
-  "$PODS_ROOT"/SwiftGen/bin/swiftgen …
+if [[ -f "${PODS_ROOT}/SwiftGen/bin/swiftgen" ]]; then
+  "${PODS_ROOT}/SwiftGen/bin/swiftgen" …
 else
-  echo "warning: SwiftGen is not installed. Run pod install --repo-update to install it."
+  echo "warning: SwiftGen is not installed. Run 'pod install --repo-update' to install it."
 fi
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,11 @@ Given that you can specify an exact version for `SwiftGen` in your `Podfile`, th
 You can then invoke SwiftGen in your Script Build Phase using:
 
 ```sh
-"${PODS_ROOT}/SwiftGen/bin/swiftgen" …
+if [[ -f "$PODS_ROOT"/SwiftGen/bin/swiftgen ]]; then
+  "$PODS_ROOT"/SwiftGen/bin/swiftgen …
+else
+  echo "warning: SwiftGen is not installed. Run pod install --repo-update to install it."
+fi
 ```
 
 > Similarly, be sure to use `Pods/SwiftGen/bin/swiftgen` instead of just `swiftgen` where we mention commands with `swiftgen` in the rest of the documentation.


### PR DESCRIPTION
I've added a script to the README that warns users to run `pod update` if SwiftGen is not installed. I also quoted the $PODS_ROOT variable to deal with spaces in paths.

