### PR TITLE
Colors: slow type inference in `init`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@
 * Strings: we now correctly generate the type `Any` (instead of `String`) for `%@` placeholders.  
   [David Jennes](https://github.com/djbe)
   [620](https://github.com/SwiftGen/SwiftGen/issues/620)
+* Colors: Reduce initializer type inference for improved compilation performance.  
+  [Markus Faßbender](https://github.com/dermaaarkus)
+  [#663](https://github.com/SwiftGen/SwiftGen/issues/663)
 
 ### Internal Changes
 

--- a/Tests/Fixtures/Generated/Colors/swift3/defaults-customName.swift
+++ b/Tests/Fixtures/Generated/Colors/swift3/defaults-customName.swift
@@ -36,18 +36,18 @@ internal struct XCTColors {
 
 // MARK: - Implementation Details
 
-// swiftlint:disable operator_usage_whitespace
+// swiftlint:disable operator_usage_whitespace colon
 internal extension XCTColor {
   convenience init(rgbaValue: UInt32) {
-    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
-    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
-    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
-    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
+    let red:   CGFloat = CGFloat((rgbaValue >> UInt32(24)) & UInt32(0xff)) / CGFloat(255.0)
+    let green: CGFloat = CGFloat((rgbaValue >> UInt32(16)) & UInt32(0xff)) / CGFloat(255.0)
+    let blue:  CGFloat = CGFloat((rgbaValue >> UInt32( 8)) & UInt32(0xff)) / CGFloat(255.0)
+    let alpha: CGFloat = CGFloat((rgbaValue              ) & UInt32(0xff)) / CGFloat(255.0)
 
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
-// swiftlint:enable operator_usage_whitespace
+// swiftlint:enable operator_usage_whitespace colon
 
 internal extension XCTColor {
   convenience init(named color: XCTColors) {

--- a/Tests/Fixtures/Generated/Colors/swift3/defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Colors/swift3/defaults-publicAccess.swift
@@ -36,18 +36,18 @@ public struct ColorName {
 
 // MARK: - Implementation Details
 
-// swiftlint:disable operator_usage_whitespace
+// swiftlint:disable operator_usage_whitespace colon
 internal extension Color {
   convenience init(rgbaValue: UInt32) {
-    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
-    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
-    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
-    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
+    let red:   CGFloat = CGFloat((rgbaValue >> UInt32(24)) & UInt32(0xff)) / CGFloat(255.0)
+    let green: CGFloat = CGFloat((rgbaValue >> UInt32(16)) & UInt32(0xff)) / CGFloat(255.0)
+    let blue:  CGFloat = CGFloat((rgbaValue >> UInt32( 8)) & UInt32(0xff)) / CGFloat(255.0)
+    let alpha: CGFloat = CGFloat((rgbaValue              ) & UInt32(0xff)) / CGFloat(255.0)
 
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
-// swiftlint:enable operator_usage_whitespace
+// swiftlint:enable operator_usage_whitespace colon
 
 public extension Color {
   convenience init(named color: ColorName) {

--- a/Tests/Fixtures/Generated/Colors/swift3/defaults.swift
+++ b/Tests/Fixtures/Generated/Colors/swift3/defaults.swift
@@ -36,18 +36,18 @@ internal struct ColorName {
 
 // MARK: - Implementation Details
 
-// swiftlint:disable operator_usage_whitespace
+// swiftlint:disable operator_usage_whitespace colon
 internal extension Color {
   convenience init(rgbaValue: UInt32) {
-    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
-    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
-    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
-    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
+    let red:   CGFloat = CGFloat((rgbaValue >> UInt32(24)) & UInt32(0xff)) / CGFloat(255.0)
+    let green: CGFloat = CGFloat((rgbaValue >> UInt32(16)) & UInt32(0xff)) / CGFloat(255.0)
+    let blue:  CGFloat = CGFloat((rgbaValue >> UInt32( 8)) & UInt32(0xff)) / CGFloat(255.0)
+    let alpha: CGFloat = CGFloat((rgbaValue              ) & UInt32(0xff)) / CGFloat(255.0)
 
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
-// swiftlint:enable operator_usage_whitespace
+// swiftlint:enable operator_usage_whitespace colon
 
 internal extension Color {
   convenience init(named color: ColorName) {

--- a/Tests/Fixtures/Generated/Colors/swift3/multiple.swift
+++ b/Tests/Fixtures/Generated/Colors/swift3/multiple.swift
@@ -61,18 +61,18 @@ internal struct ColorName {
 
 // MARK: - Implementation Details
 
-// swiftlint:disable operator_usage_whitespace
+// swiftlint:disable operator_usage_whitespace colon
 internal extension Color {
   convenience init(rgbaValue: UInt32) {
-    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
-    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
-    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
-    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
+    let red:   CGFloat = CGFloat((rgbaValue >> UInt32(24)) & UInt32(0xff)) / CGFloat(255.0)
+    let green: CGFloat = CGFloat((rgbaValue >> UInt32(16)) & UInt32(0xff)) / CGFloat(255.0)
+    let blue:  CGFloat = CGFloat((rgbaValue >> UInt32( 8)) & UInt32(0xff)) / CGFloat(255.0)
+    let alpha: CGFloat = CGFloat((rgbaValue              ) & UInt32(0xff)) / CGFloat(255.0)
 
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
-// swiftlint:enable operator_usage_whitespace
+// swiftlint:enable operator_usage_whitespace colon
 
 internal extension Color {
   convenience init(named color: ColorName) {

--- a/Tests/Fixtures/Generated/Colors/swift4/defaults-customName.swift
+++ b/Tests/Fixtures/Generated/Colors/swift4/defaults-customName.swift
@@ -36,18 +36,18 @@ internal struct XCTColors {
 
 // MARK: - Implementation Details
 
-// swiftlint:disable operator_usage_whitespace
+// swiftlint:disable operator_usage_whitespace colon
 internal extension XCTColor {
   convenience init(rgbaValue: UInt32) {
-    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
-    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
-    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
-    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
+    let red:   CGFloat = CGFloat((rgbaValue >> UInt32(24)) & UInt32(0xff)) / CGFloat(255.0)
+    let green: CGFloat = CGFloat((rgbaValue >> UInt32(16)) & UInt32(0xff)) / CGFloat(255.0)
+    let blue:  CGFloat = CGFloat((rgbaValue >> UInt32( 8)) & UInt32(0xff)) / CGFloat(255.0)
+    let alpha: CGFloat = CGFloat((rgbaValue              ) & UInt32(0xff)) / CGFloat(255.0)
 
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
-// swiftlint:enable operator_usage_whitespace
+// swiftlint:enable operator_usage_whitespace colon
 
 internal extension XCTColor {
   convenience init(named color: XCTColors) {

--- a/Tests/Fixtures/Generated/Colors/swift4/defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Colors/swift4/defaults-publicAccess.swift
@@ -36,18 +36,18 @@ public struct ColorName {
 
 // MARK: - Implementation Details
 
-// swiftlint:disable operator_usage_whitespace
+// swiftlint:disable operator_usage_whitespace colon
 internal extension Color {
   convenience init(rgbaValue: UInt32) {
-    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
-    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
-    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
-    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
+    let red:   CGFloat = CGFloat((rgbaValue >> UInt32(24)) & UInt32(0xff)) / CGFloat(255.0)
+    let green: CGFloat = CGFloat((rgbaValue >> UInt32(16)) & UInt32(0xff)) / CGFloat(255.0)
+    let blue:  CGFloat = CGFloat((rgbaValue >> UInt32( 8)) & UInt32(0xff)) / CGFloat(255.0)
+    let alpha: CGFloat = CGFloat((rgbaValue              ) & UInt32(0xff)) / CGFloat(255.0)
 
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
-// swiftlint:enable operator_usage_whitespace
+// swiftlint:enable operator_usage_whitespace colon
 
 public extension Color {
   convenience init(named color: ColorName) {

--- a/Tests/Fixtures/Generated/Colors/swift4/defaults.swift
+++ b/Tests/Fixtures/Generated/Colors/swift4/defaults.swift
@@ -36,18 +36,18 @@ internal struct ColorName {
 
 // MARK: - Implementation Details
 
-// swiftlint:disable operator_usage_whitespace
+// swiftlint:disable operator_usage_whitespace colon
 internal extension Color {
   convenience init(rgbaValue: UInt32) {
-    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
-    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
-    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
-    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
+    let red:   CGFloat = CGFloat((rgbaValue >> UInt32(24)) & UInt32(0xff)) / CGFloat(255.0)
+    let green: CGFloat = CGFloat((rgbaValue >> UInt32(16)) & UInt32(0xff)) / CGFloat(255.0)
+    let blue:  CGFloat = CGFloat((rgbaValue >> UInt32( 8)) & UInt32(0xff)) / CGFloat(255.0)
+    let alpha: CGFloat = CGFloat((rgbaValue              ) & UInt32(0xff)) / CGFloat(255.0)
 
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
-// swiftlint:enable operator_usage_whitespace
+// swiftlint:enable operator_usage_whitespace colon
 
 internal extension Color {
   convenience init(named color: ColorName) {

--- a/Tests/Fixtures/Generated/Colors/swift4/multiple.swift
+++ b/Tests/Fixtures/Generated/Colors/swift4/multiple.swift
@@ -61,18 +61,18 @@ internal struct ColorName {
 
 // MARK: - Implementation Details
 
-// swiftlint:disable operator_usage_whitespace
+// swiftlint:disable operator_usage_whitespace colon
 internal extension Color {
   convenience init(rgbaValue: UInt32) {
-    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
-    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
-    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
-    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
+    let red:   CGFloat = CGFloat((rgbaValue >> UInt32(24)) & UInt32(0xff)) / CGFloat(255.0)
+    let green: CGFloat = CGFloat((rgbaValue >> UInt32(16)) & UInt32(0xff)) / CGFloat(255.0)
+    let blue:  CGFloat = CGFloat((rgbaValue >> UInt32( 8)) & UInt32(0xff)) / CGFloat(255.0)
+    let alpha: CGFloat = CGFloat((rgbaValue              ) & UInt32(0xff)) / CGFloat(255.0)
 
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
-// swiftlint:enable operator_usage_whitespace
+// swiftlint:enable operator_usage_whitespace colon
 
 internal extension Color {
   convenience init(named color: ColorName) {

--- a/Tests/Fixtures/Generated/Colors/swift5/defaults-customName.swift
+++ b/Tests/Fixtures/Generated/Colors/swift5/defaults-customName.swift
@@ -36,18 +36,18 @@ internal struct XCTColors {
 
 // MARK: - Implementation Details
 
-// swiftlint:disable operator_usage_whitespace
+// swiftlint:disable operator_usage_whitespace colon
 internal extension XCTColor {
   convenience init(rgbaValue: UInt32) {
-    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
-    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
-    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
-    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
+    let red:   CGFloat = CGFloat((rgbaValue >> UInt32(24)) & UInt32(0xff)) / CGFloat(255.0)
+    let green: CGFloat = CGFloat((rgbaValue >> UInt32(16)) & UInt32(0xff)) / CGFloat(255.0)
+    let blue:  CGFloat = CGFloat((rgbaValue >> UInt32( 8)) & UInt32(0xff)) / CGFloat(255.0)
+    let alpha: CGFloat = CGFloat((rgbaValue              ) & UInt32(0xff)) / CGFloat(255.0)
 
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
-// swiftlint:enable operator_usage_whitespace
+// swiftlint:enable operator_usage_whitespace colon
 
 internal extension XCTColor {
   convenience init(named color: XCTColors) {

--- a/Tests/Fixtures/Generated/Colors/swift5/defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Colors/swift5/defaults-publicAccess.swift
@@ -36,18 +36,18 @@ public struct ColorName {
 
 // MARK: - Implementation Details
 
-// swiftlint:disable operator_usage_whitespace
+// swiftlint:disable operator_usage_whitespace colon
 internal extension Color {
   convenience init(rgbaValue: UInt32) {
-    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
-    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
-    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
-    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
+    let red:   CGFloat = CGFloat((rgbaValue >> UInt32(24)) & UInt32(0xff)) / CGFloat(255.0)
+    let green: CGFloat = CGFloat((rgbaValue >> UInt32(16)) & UInt32(0xff)) / CGFloat(255.0)
+    let blue:  CGFloat = CGFloat((rgbaValue >> UInt32( 8)) & UInt32(0xff)) / CGFloat(255.0)
+    let alpha: CGFloat = CGFloat((rgbaValue              ) & UInt32(0xff)) / CGFloat(255.0)
 
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
-// swiftlint:enable operator_usage_whitespace
+// swiftlint:enable operator_usage_whitespace colon
 
 public extension Color {
   convenience init(named color: ColorName) {

--- a/Tests/Fixtures/Generated/Colors/swift5/defaults.swift
+++ b/Tests/Fixtures/Generated/Colors/swift5/defaults.swift
@@ -36,18 +36,18 @@ internal struct ColorName {
 
 // MARK: - Implementation Details
 
-// swiftlint:disable operator_usage_whitespace
+// swiftlint:disable operator_usage_whitespace colon
 internal extension Color {
   convenience init(rgbaValue: UInt32) {
-    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
-    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
-    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
-    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
+    let red:   CGFloat = CGFloat((rgbaValue >> UInt32(24)) & UInt32(0xff)) / CGFloat(255.0)
+    let green: CGFloat = CGFloat((rgbaValue >> UInt32(16)) & UInt32(0xff)) / CGFloat(255.0)
+    let blue:  CGFloat = CGFloat((rgbaValue >> UInt32( 8)) & UInt32(0xff)) / CGFloat(255.0)
+    let alpha: CGFloat = CGFloat((rgbaValue              ) & UInt32(0xff)) / CGFloat(255.0)
 
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
-// swiftlint:enable operator_usage_whitespace
+// swiftlint:enable operator_usage_whitespace colon
 
 internal extension Color {
   convenience init(named color: ColorName) {

--- a/Tests/Fixtures/Generated/Colors/swift5/multiple.swift
+++ b/Tests/Fixtures/Generated/Colors/swift5/multiple.swift
@@ -61,18 +61,18 @@ internal struct ColorName {
 
 // MARK: - Implementation Details
 
-// swiftlint:disable operator_usage_whitespace
+// swiftlint:disable operator_usage_whitespace colon
 internal extension Color {
   convenience init(rgbaValue: UInt32) {
-    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
-    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
-    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
-    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
+    let red:   CGFloat = CGFloat((rgbaValue >> UInt32(24)) & UInt32(0xff)) / CGFloat(255.0)
+    let green: CGFloat = CGFloat((rgbaValue >> UInt32(16)) & UInt32(0xff)) / CGFloat(255.0)
+    let blue:  CGFloat = CGFloat((rgbaValue >> UInt32( 8)) & UInt32(0xff)) / CGFloat(255.0)
+    let alpha: CGFloat = CGFloat((rgbaValue              ) & UInt32(0xff)) / CGFloat(255.0)
 
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
-// swiftlint:enable operator_usage_whitespace
+// swiftlint:enable operator_usage_whitespace colon
 
 internal extension Color {
   convenience init(named color: ColorName) {

--- a/templates/colors/swift3.stencil
+++ b/templates/colors/swift3.stencil
@@ -45,18 +45,18 @@
 
 // MARK: - Implementation Details
 
-// swiftlint:disable operator_usage_whitespace
+// swiftlint:disable operator_usage_whitespace colon
 internal extension {{colorAlias}} {
   convenience init(rgbaValue: UInt32) {
-    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
-    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
-    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
-    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
+    let red:   CGFloat = CGFloat((rgbaValue >> UInt32(24)) & UInt32(0xff)) / CGFloat(255.0)
+    let green: CGFloat = CGFloat((rgbaValue >> UInt32(16)) & UInt32(0xff)) / CGFloat(255.0)
+    let blue:  CGFloat = CGFloat((rgbaValue >> UInt32( 8)) & UInt32(0xff)) / CGFloat(255.0)
+    let alpha: CGFloat = CGFloat((rgbaValue              ) & UInt32(0xff)) / CGFloat(255.0)
 
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
-// swiftlint:enable operator_usage_whitespace
+// swiftlint:enable operator_usage_whitespace colon
 
 {{accessModifier}} extension {{colorAlias}} {
   convenience init(named color: {{enumName}}) {

--- a/templates/colors/swift4.stencil
+++ b/templates/colors/swift4.stencil
@@ -45,18 +45,18 @@
 
 // MARK: - Implementation Details
 
-// swiftlint:disable operator_usage_whitespace
+// swiftlint:disable operator_usage_whitespace colon
 internal extension {{colorAlias}} {
   convenience init(rgbaValue: UInt32) {
-    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
-    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
-    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
-    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
+    let red:   CGFloat = CGFloat((rgbaValue >> UInt32(24)) & UInt32(0xff)) / CGFloat(255.0)
+    let green: CGFloat = CGFloat((rgbaValue >> UInt32(16)) & UInt32(0xff)) / CGFloat(255.0)
+    let blue:  CGFloat = CGFloat((rgbaValue >> UInt32( 8)) & UInt32(0xff)) / CGFloat(255.0)
+    let alpha: CGFloat = CGFloat((rgbaValue              ) & UInt32(0xff)) / CGFloat(255.0)
 
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
-// swiftlint:enable operator_usage_whitespace
+// swiftlint:enable operator_usage_whitespace colon
 
 {{accessModifier}} extension {{colorAlias}} {
   convenience init(named color: {{enumName}}) {

--- a/templates/colors/swift5.stencil
+++ b/templates/colors/swift5.stencil
@@ -45,18 +45,18 @@
 
 // MARK: - Implementation Details
 
-// swiftlint:disable operator_usage_whitespace
+// swiftlint:disable operator_usage_whitespace colon
 internal extension {{colorAlias}} {
   convenience init(rgbaValue: UInt32) {
-    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
-    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
-    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
-    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
+    let red:   CGFloat = CGFloat((rgbaValue >> UInt32(24)) & UInt32(0xff)) / CGFloat(255.0)
+    let green: CGFloat = CGFloat((rgbaValue >> UInt32(16)) & UInt32(0xff)) / CGFloat(255.0)
+    let blue:  CGFloat = CGFloat((rgbaValue >> UInt32( 8)) & UInt32(0xff)) / CGFloat(255.0)
+    let alpha: CGFloat = CGFloat((rgbaValue              ) & UInt32(0xff)) / CGFloat(255.0)
 
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
-// swiftlint:enable operator_usage_whitespace
+// swiftlint:enable operator_usage_whitespace colon
 
 {{accessModifier}} extension {{colorAlias}} {
   convenience init(named color: {{enumName}}) {


### PR DESCRIPTION
I've implemented the suggested solution of my issue #663 
