### PR TITLE
Unify some template changes + add forceFileNameEnum to all eligible templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,9 +52,11 @@
   [David Jennes](https://github.com/djbe)
   [#595](https://github.com/SwiftGen/SwiftGen/issue/595)
   [#600](https://github.com/SwiftGen/SwiftGen/pull/600)
-* Strings: new template option to force having the table name used in generated code even if there's only a single strings file.  
+* Most templates now accept a parameter to force having the file name used as namespace (`enum <FileName>`) in generated code _even if_ there's only one single input file.  
   [Viktoras Laukevičius](https://github.com/viktorasl)
   [#669](https://github.com/SwiftGen/SwiftGen/issue/669)
+  [@AliSoftware](https://github.com/AliSoftware)
+  [#693](https://github.com/SwiftGen/SwiftGen/pull/693)
 
 ### Bug Fixes
 

--- a/Documentation/templates/colors/literals-swift4.md
+++ b/Documentation/templates/colors/literals-swift4.md
@@ -21,6 +21,7 @@ You can customize some elements of this template by overriding the following par
 | -------------- | ------------- | ----------- |
 | `enumName` | `ColorName` | Allows you to change the name of the generated `enum` containing all colors. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
+| `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
 
 Note: if you use `enumName: UIColor` (or `NSColor` on macOS) then the color constants will be generated as an extension of the `UIColor` (iOS) / `NSColor` (macOS) type directly without creating a separate `enum` type for namespacing those color constants.
 

--- a/Documentation/templates/colors/literals-swift5.md
+++ b/Documentation/templates/colors/literals-swift5.md
@@ -21,6 +21,7 @@ You can customize some elements of this template by overriding the following par
 | -------------- | ------------- | ----------- |
 | `enumName` | `ColorName` | Allows you to change the name of the generated `enum` containing all colors. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
+| `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
 
 Note: if you use `enumName: UIColor` (or `NSColor` on macOS) then the color constants will be generated as an extension of the `UIColor` (iOS) / `NSColor` (macOS) type directly without creating a separate `enum` type for namespacing those color constants.
 

--- a/Documentation/templates/colors/swift4.md
+++ b/Documentation/templates/colors/swift4.md
@@ -21,6 +21,7 @@ You can customize some elements of this template by overriding the following par
 | `enumName` | `ColorName` | Allows you to change the name of the generated `enum` containing all colors. |
 | `colorAliasName` | `Color` | Allows you to change the name of the generated `typealias` for the platform specific color type. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
+| `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
 
 ## Generated Code
 

--- a/Documentation/templates/colors/swift5.md
+++ b/Documentation/templates/colors/swift5.md
@@ -21,6 +21,7 @@ You can customize some elements of this template by overriding the following par
 | `enumName` | `ColorName` | Allows you to change the name of the generated `enum` containing all colors. |
 | `colorAliasName` | `Color` | Allows you to change the name of the generated `typealias` for the platform specific color type. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
+| `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
 
 ## Generated Code
 

--- a/Documentation/templates/json/inline-swift4.md
+++ b/Documentation/templates/json/inline-swift4.md
@@ -21,6 +21,7 @@ You can customize some elements of this template by overriding the following par
 | `enumName` | `JSONFiles` | Allows you to change the name of the generated `enum` containing all files. |
 | `preservePath` | N/A | Setting this parameter will disable the basename filter applied to all file paths. Use this if you added your data folder as a "folder reference" in your Xcode project, making that folder hierarchy preserved once copied in the build app bundle. The path will be relative to the folder you provided to SwiftGen. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
+| `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
 
 ## Generated Code
 

--- a/Documentation/templates/json/inline-swift5.md
+++ b/Documentation/templates/json/inline-swift5.md
@@ -21,6 +21,7 @@ You can customize some elements of this template by overriding the following par
 | `enumName` | `JSONFiles` | Allows you to change the name of the generated `enum` containing all files. |
 | `preservePath` | N/A | Setting this parameter will disable the basename filter applied to all file paths. Use this if you added your data folder as a "folder reference" in your Xcode project, making that folder hierarchy preserved once copied in the build app bundle. The path will be relative to the folder you provided to SwiftGen. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
+| `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
 
 ## Generated Code
 

--- a/Documentation/templates/json/runtime-swift4.md
+++ b/Documentation/templates/json/runtime-swift4.md
@@ -22,6 +22,7 @@ You can customize some elements of this template by overriding the following par
 | `enumName` | `JSONFiles` | Allows you to change the name of the generated `enum` containing all files. |
 | `preservePath` | N/A | Setting this parameter will disable the basename filter applied to all file paths. Use this if you added your data folder as a "folder reference" in your Xcode project, making that folder hierarchy preserved once copied in the build app bundle. The path will be relative to the folder you provided to SwiftGen. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
+| `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
 
 ## Generated Code
 

--- a/Documentation/templates/json/runtime-swift5.md
+++ b/Documentation/templates/json/runtime-swift5.md
@@ -22,6 +22,7 @@ You can customize some elements of this template by overriding the following par
 | `enumName` | `JSONFiles` | Allows you to change the name of the generated `enum` containing all files. |
 | `preservePath` | N/A | Setting this parameter will disable the basename filter applied to all file paths. Use this if you added your data folder as a "folder reference" in your Xcode project, making that folder hierarchy preserved once copied in the build app bundle. The path will be relative to the folder you provided to SwiftGen. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
+| `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
 
 ## Generated Code
 

--- a/Documentation/templates/plist/inline-swift4.md
+++ b/Documentation/templates/plist/inline-swift4.md
@@ -21,6 +21,7 @@ You can customize some elements of this template by overriding the following par
 | `enumName` | `PlistFiles` | Allows you to change the name of the generated `enum` containing all files. |
 | `preservePath` | N/A | Setting this parameter will disable the basename filter applied to all file paths. Use this if you added your data folder as a "folder reference" in your Xcode project, making that folder hierarchy preserved once copied in the build app bundle. The path will be relative to the folder you provided to SwiftGen. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
+| `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
 
 ## Generated Code
 

--- a/Documentation/templates/plist/inline-swift5.md
+++ b/Documentation/templates/plist/inline-swift5.md
@@ -21,6 +21,7 @@ You can customize some elements of this template by overriding the following par
 | `enumName` | `PlistFiles` | Allows you to change the name of the generated `enum` containing all files. |
 | `preservePath` | N/A | Setting this parameter will disable the basename filter applied to all file paths. Use this if you added your data folder as a "folder reference" in your Xcode project, making that folder hierarchy preserved once copied in the build app bundle. The path will be relative to the folder you provided to SwiftGen. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
+| `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
 
 ## Generated Code
 

--- a/Documentation/templates/plist/runtime-swift4.md
+++ b/Documentation/templates/plist/runtime-swift4.md
@@ -22,6 +22,7 @@ You can customize some elements of this template by overriding the following par
 | `enumName` | `PlistFiles` | Allows you to change the name of the generated `enum` containing all files. |
 | `preservePath` | N/A | Setting this parameter will disable the basename filter applied to all file paths. Use this if you added your data folder as a "folder reference" in your Xcode project, making that folder hierarchy preserved once copied in the build app bundle. The path will be relative to the folder you provided to SwiftGen. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
+| `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
 
 ## Generated Code
 

--- a/Documentation/templates/plist/runtime-swift5.md
+++ b/Documentation/templates/plist/runtime-swift5.md
@@ -22,6 +22,7 @@ You can customize some elements of this template by overriding the following par
 | `enumName` | `PlistFiles` | Allows you to change the name of the generated `enum` containing all files. |
 | `preservePath` | N/A | Setting this parameter will disable the basename filter applied to all file paths. Use this if you added your data folder as a "folder reference" in your Xcode project, making that folder hierarchy preserved once copied in the build app bundle. The path will be relative to the folder you provided to SwiftGen. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
+| `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
 
 ## Generated Code
 

--- a/Documentation/templates/strings/flat-swift4.md
+++ b/Documentation/templates/strings/flat-swift4.md
@@ -22,7 +22,7 @@ You can customize some elements of this template by overriding the following par
 | `noComments` | N/A | Setting this parameter will disable the comments describing the translation of a key. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
 | `localizeFunction` | `NSLocalizedString` | Allows you to set your own custom localization function. Your custom function must have the same signature as the one provided by `Foundation`, i.e. `yourFunctionName(_:tableName:bundle:comment:)` |
-| `forceFileNameEnum` | N/A | Setting this parameter will generate `enum` for file even if only single is provided. |
+| `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
 
 ## Generated Code
 

--- a/Documentation/templates/strings/flat-swift5.md
+++ b/Documentation/templates/strings/flat-swift5.md
@@ -22,7 +22,7 @@ You can customize some elements of this template by overriding the following par
 | `noComments` | N/A | Setting this parameter will disable the comments describing the translation of a key. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
 | `localizeFunction` | `NSLocalizedString` | Allows you to set your own custom localization function. Your custom function must have the same signature as the one provided by `Foundation`, i.e. `yourFunctionName(_:tableName:bundle:comment:)` |
-| `forceFileNameEnum` | N/A | Setting this parameter will generate `enum` for file even if only single is provided. |
+| `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
 
 ## Generated Code
 

--- a/Documentation/templates/strings/structured-swift4.md
+++ b/Documentation/templates/strings/structured-swift4.md
@@ -28,7 +28,7 @@ You can customize some elements of this template by overriding the following par
 | `noComments` | N/A | Setting this parameter will disable the comments describing the translation of a key. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
 | `localizeFunction` | `NSLocalizedString` | Allows you to set your own custom localization function. Your custom function must have the same signature as the one provided by `Foundation`, i.e. `yourFunctionName(_:tableName:bundle:comment:)` |
-| `forceFileNameEnum` | N/A | Setting this parameter will generate `enum` for file even if only single is provided. |
+| `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
 
 ## Generated Code
 

--- a/Documentation/templates/strings/structured-swift5.md
+++ b/Documentation/templates/strings/structured-swift5.md
@@ -28,7 +28,7 @@ You can customize some elements of this template by overriding the following par
 | `noComments` | N/A | Setting this parameter will disable the comments describing the translation of a key. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
 | `localizeFunction` | `NSLocalizedString` | Allows you to set your own custom localization function. Your custom function must have the same signature as the one provided by `Foundation`, i.e. `yourFunctionName(_:tableName:bundle:comment:)` |
-| `forceFileNameEnum` | N/A | Setting this parameter will generate `enum` for file even if only single is provided. |
+| `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
 
 ## Generated Code
 

--- a/Documentation/templates/xcassets/swift4.md
+++ b/Documentation/templates/xcassets/swift4.md
@@ -31,6 +31,7 @@ You can customize some elements of this template by overriding the following par
 | `forceProvidesNamespaces` | N/A | If set, generates namespaces even for non namespacing asset folders (i.e. "Provides Namespace" is unchecked) |
 | `colorAliasName` | `AssetColorTypeAlias` | **Deprecated** Allows you to change the name of the generated `typealias` for the platform specific color type. |
 | `imageAliasName` | `AssetImageTypeAlias` | **Deprecated** Allows you to change the name of the generated `typealias` for the platform specific image type. |
+| `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
 
 ## Generated Code
 

--- a/Documentation/templates/xcassets/swift5.md
+++ b/Documentation/templates/xcassets/swift5.md
@@ -31,6 +31,7 @@ You can customize some elements of this template by overriding the following par
 | `forceProvidesNamespaces` | N/A | If set, generates namespaces even for non namespacing asset folders (i.e. "Provides Namespace" is unchecked) |
 | `colorAliasName` | `AssetColorTypeAlias` | **Deprecated** Allows you to change the name of the generated `typealias` for the platform specific color type. |
 | `imageAliasName` | `AssetImageTypeAlias` | **Deprecated** Allows you to change the name of the generated `typealias` for the platform specific image type. |
+| `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
 
 ## Generated Code
 

--- a/Documentation/templates/yaml/inline-swift4.md
+++ b/Documentation/templates/yaml/inline-swift4.md
@@ -22,6 +22,7 @@ You can customize some elements of this template by overriding the following par
 | `enumName` | `YAMLFiles` | Allows you to change the name of the generated `enum` containing all files. |
 | `preservePath` | N/A | Setting this parameter will disable the basename filter applied to all file paths. Use this if you added your data folder as a "folder reference" in your Xcode project, making that folder hierarchy preserved once copied in the build app bundle. The path will be relative to the folder you provided to SwiftGen. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
+| `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
 
 ## Generated Code
 

--- a/Documentation/templates/yaml/inline-swift5.md
+++ b/Documentation/templates/yaml/inline-swift5.md
@@ -22,6 +22,7 @@ You can customize some elements of this template by overriding the following par
 | `enumName` | `YAMLFiles` | Allows you to change the name of the generated `enum` containing all files. |
 | `preservePath` | N/A | Setting this parameter will disable the basename filter applied to all file paths. Use this if you added your data folder as a "folder reference" in your Xcode project, making that folder hierarchy preserved once copied in the build app bundle. The path will be relative to the folder you provided to SwiftGen. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
+| `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
 
 ## Generated Code
 

--- a/Tests/Fixtures/Generated/Colors/literals-swift4/defaults-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/Colors/literals-swift4/defaults-forceFileNameEnum.swift
@@ -1,0 +1,30 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+#if os(OSX)
+  import AppKit
+  internal enum ColorName { }
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit
+  internal enum ColorName { }
+#endif
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - Colors
+
+// swiftlint:disable identifier_name line_length type_body_length
+internal extension ColorName {
+  enum Colors {
+    /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)
+    internal static let articleBody = #colorLiteral(red: 0.2, green: 0.5882353, blue: 0.4, alpha: 1.0)
+    /// 0xff66ccff (r: 255, g: 102, b: 204, a: 255)
+    internal static let articleFootnote = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
+    /// 0x33fe66ff (r: 51, g: 254, b: 102, a: 255)
+    internal static let articleTitle = #colorLiteral(red: 0.2, green: 0.99607843, blue: 0.4, alpha: 1.0)
+    /// 0xffffffcc (r: 255, g: 255, b: 255, a: 204)
+    internal static let `private` = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
+  }
+}
+// swiftlint:enable identifier_name line_length type_body_length

--- a/Tests/Fixtures/Generated/Colors/literals-swift5/defaults-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/Colors/literals-swift5/defaults-forceFileNameEnum.swift
@@ -1,0 +1,30 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+#if os(OSX)
+  import AppKit
+  internal enum ColorName { }
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit
+  internal enum ColorName { }
+#endif
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - Colors
+
+// swiftlint:disable identifier_name line_length type_body_length
+internal extension ColorName {
+  enum Colors {
+    /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)
+    internal static let articleBody = #colorLiteral(red: 0.2, green: 0.5882353, blue: 0.4, alpha: 1.0)
+    /// 0xff66ccff (r: 255, g: 102, b: 204, a: 255)
+    internal static let articleFootnote = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
+    /// 0x33fe66ff (r: 51, g: 254, b: 102, a: 255)
+    internal static let articleTitle = #colorLiteral(red: 0.2, green: 0.99607843, blue: 0.4, alpha: 1.0)
+    /// 0xffffffcc (r: 255, g: 255, b: 255, a: 204)
+    internal static let `private` = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 0.8)
+  }
+}
+// swiftlint:enable identifier_name line_length type_body_length

--- a/Tests/Fixtures/Generated/Colors/swift4/defaults-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/Colors/swift4/defaults-forceFileNameEnum.swift
@@ -1,0 +1,57 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+#if os(OSX)
+  import AppKit.NSColor
+  internal typealias Color = NSColor
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIColor
+  internal typealias Color = UIColor
+#endif
+
+// swiftlint:disable superfluous_disable_command file_length implicit_return
+
+// MARK: - Colors
+
+// swiftlint:disable identifier_name line_length type_body_length
+internal struct ColorName {
+  internal let rgbaValue: UInt32
+  internal var color: Color { return Color(named: self) }
+
+  internal enum Colors {
+    /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#339666"></span>
+    /// Alpha: 100% <br/> (0x339666ff)
+    internal static let articleBody = ColorName(rgbaValue: 0x339666ff)
+    /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#ff66cc"></span>
+    /// Alpha: 100% <br/> (0xff66ccff)
+    internal static let articleFootnote = ColorName(rgbaValue: 0xff66ccff)
+    /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#33fe66"></span>
+    /// Alpha: 100% <br/> (0x33fe66ff)
+    internal static let articleTitle = ColorName(rgbaValue: 0x33fe66ff)
+    /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#ffffff"></span>
+    /// Alpha: 80% <br/> (0xffffffcc)
+    internal static let `private` = ColorName(rgbaValue: 0xffffffcc)
+  }
+}
+// swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+// swiftlint:disable operator_usage_whitespace colon
+internal extension Color {
+  convenience init(rgbaValue: UInt32) {
+    let red:   CGFloat = CGFloat((rgbaValue >> UInt32(24)) & UInt32(0xff)) / CGFloat(255.0)
+    let green: CGFloat = CGFloat((rgbaValue >> UInt32(16)) & UInt32(0xff)) / CGFloat(255.0)
+    let blue:  CGFloat = CGFloat((rgbaValue >> UInt32( 8)) & UInt32(0xff)) / CGFloat(255.0)
+    let alpha: CGFloat = CGFloat((rgbaValue              ) & UInt32(0xff)) / CGFloat(255.0)
+
+    self.init(red: red, green: green, blue: blue, alpha: alpha)
+  }
+}
+// swiftlint:enable operator_usage_whitespace colon
+
+internal extension Color {
+  convenience init(named color: ColorName) {
+    self.init(rgbaValue: color.rgbaValue)
+  }
+}

--- a/Tests/Fixtures/Generated/Colors/swift5/defaults-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/Colors/swift5/defaults-forceFileNameEnum.swift
@@ -1,0 +1,57 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+#if os(OSX)
+  import AppKit.NSColor
+  internal typealias Color = NSColor
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIColor
+  internal typealias Color = UIColor
+#endif
+
+// swiftlint:disable superfluous_disable_command file_length implicit_return
+
+// MARK: - Colors
+
+// swiftlint:disable identifier_name line_length type_body_length
+internal struct ColorName {
+  internal let rgbaValue: UInt32
+  internal var color: Color { return Color(named: self) }
+
+  internal enum Colors {
+    /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#339666"></span>
+    /// Alpha: 100% <br/> (0x339666ff)
+    internal static let articleBody = ColorName(rgbaValue: 0x339666ff)
+    /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#ff66cc"></span>
+    /// Alpha: 100% <br/> (0xff66ccff)
+    internal static let articleFootnote = ColorName(rgbaValue: 0xff66ccff)
+    /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#33fe66"></span>
+    /// Alpha: 100% <br/> (0x33fe66ff)
+    internal static let articleTitle = ColorName(rgbaValue: 0x33fe66ff)
+    /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#ffffff"></span>
+    /// Alpha: 80% <br/> (0xffffffcc)
+    internal static let `private` = ColorName(rgbaValue: 0xffffffcc)
+  }
+}
+// swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+// swiftlint:disable operator_usage_whitespace colon
+internal extension Color {
+  convenience init(rgbaValue: UInt32) {
+    let red:   CGFloat = CGFloat((rgbaValue >> UInt32(24)) & UInt32(0xff)) / CGFloat(255.0)
+    let green: CGFloat = CGFloat((rgbaValue >> UInt32(16)) & UInt32(0xff)) / CGFloat(255.0)
+    let blue:  CGFloat = CGFloat((rgbaValue >> UInt32( 8)) & UInt32(0xff)) / CGFloat(255.0)
+    let alpha: CGFloat = CGFloat((rgbaValue              ) & UInt32(0xff)) / CGFloat(255.0)
+
+    self.init(red: red, green: green, blue: blue, alpha: alpha)
+  }
+}
+// swiftlint:enable operator_usage_whitespace colon
+
+internal extension Color {
+  convenience init(named color: ColorName) {
+    self.init(rgbaValue: color.rgbaValue)
+  }
+}

--- a/Tests/Fixtures/Generated/Fonts/swift4/defaults-customName.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift4/defaults-customName.swift
@@ -9,7 +9,9 @@
   internal typealias Font = UIFont
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length implicit_return
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+// swiftlint:disable implicit_return
 
 // MARK: - Fonts
 

--- a/Tests/Fixtures/Generated/Fonts/swift4/defaults-preservePath.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift4/defaults-preservePath.swift
@@ -9,7 +9,9 @@
   internal typealias Font = UIFont
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length implicit_return
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+// swiftlint:disable implicit_return
 
 // MARK: - Fonts
 

--- a/Tests/Fixtures/Generated/Fonts/swift4/defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift4/defaults-publicAccess.swift
@@ -9,7 +9,9 @@
   public typealias Font = UIFont
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length implicit_return
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+// swiftlint:disable implicit_return
 
 // MARK: - Fonts
 

--- a/Tests/Fixtures/Generated/Fonts/swift4/defaults.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift4/defaults.swift
@@ -9,7 +9,9 @@
   internal typealias Font = UIFont
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length implicit_return
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+// swiftlint:disable implicit_return
 
 // MARK: - Fonts
 

--- a/Tests/Fixtures/Generated/JSON/inline-swift4/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/JSON/inline-swift4/all-forceFileNameEnum.swift
@@ -1,0 +1,40 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+import Foundation
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - JSON Files
+
+// swiftlint:disable identifier_name line_length number_separator type_body_length
+internal enum JSONFiles {
+  internal enum Configuration {
+    internal static let apiVersion: String = "2"
+    internal static let country: Any? = nil
+    internal static let environment: String = "staging"
+    internal static let options: [String: Any] = ["screen-order": ["1", "2", "3"]]
+  }
+  internal enum Documents {
+    internal enum Document1 {
+      internal static let items: [String] = ["Mark McGwire", "Sammy Sosa", "Ken Griffey"]
+    }
+    internal enum Document2 {
+      internal static let items: [String] = ["Chicago Cubs", "St Louis Cardinals"]
+    }
+  }
+  internal enum GroceryList {
+    internal static let items: [String] = ["Eggs", "Bread", "Milk"]
+  }
+  internal enum Mapping {
+    internal static let car: Any? = nil
+    internal static let foo: [String: Any] = ["bar": "banana", "baz": "orange"]
+    internal static let hello: String = "world"
+    internal static let weight: Double = 33.3
+  }
+  internal enum Version {
+    internal static let value: String = "1.2.3.beta.4"
+  }
+}
+// swiftlint:enable identifier_name line_length number_separator type_body_length

--- a/Tests/Fixtures/Generated/JSON/inline-swift5/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/JSON/inline-swift5/all-forceFileNameEnum.swift
@@ -1,0 +1,40 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+import Foundation
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - JSON Files
+
+// swiftlint:disable identifier_name line_length number_separator type_body_length
+internal enum JSONFiles {
+  internal enum Configuration {
+    internal static let apiVersion: String = "2"
+    internal static let country: Any? = nil
+    internal static let environment: String = "staging"
+    internal static let options: [String: Any] = ["screen-order": ["1", "2", "3"]]
+  }
+  internal enum Documents {
+    internal enum Document1 {
+      internal static let items: [String] = ["Mark McGwire", "Sammy Sosa", "Ken Griffey"]
+    }
+    internal enum Document2 {
+      internal static let items: [String] = ["Chicago Cubs", "St Louis Cardinals"]
+    }
+  }
+  internal enum GroceryList {
+    internal static let items: [String] = ["Eggs", "Bread", "Milk"]
+  }
+  internal enum Mapping {
+    internal static let car: Any? = nil
+    internal static let foo: [String: Any] = ["bar": "banana", "baz": "orange"]
+    internal static let hello: String = "world"
+    internal static let weight: Double = 33.3
+  }
+  internal enum Version {
+    internal static let value: String = "1.2.3.beta.4"
+  }
+}
+// swiftlint:enable identifier_name line_length number_separator type_body_length

--- a/Tests/Fixtures/Generated/JSON/runtime-swift4/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift4/all-forceFileNameEnum.swift
@@ -1,0 +1,77 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+import Foundation
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - JSON Files
+
+// swiftlint:disable identifier_name line_length type_body_length
+internal enum JSONFiles {
+  internal enum Configuration {
+    private static let _document = JSONDocument(path: "configuration.json")
+    internal static let apiVersion: String = _document["api-version"]
+    internal static let country: Any? = _document["country"]
+    internal static let environment: String = _document["environment"]
+    internal static let options: [String: Any] = _document["options"]
+  }
+  internal enum Documents {
+    internal enum Document1 {
+      internal static let items: [String] = objectFromJSON(at: "documents.yaml")
+    }
+    internal enum Document2 {
+      internal static let items: [String] = objectFromJSON(at: "documents.yaml")
+    }
+  }
+  internal enum GroceryList {
+    internal static let items: [String] = objectFromJSON(at: "grocery-list.yaml")
+  }
+  internal enum Mapping {
+    private static let _document = JSONDocument(path: "mapping.yaml")
+    internal static let car: Any? = _document["car"]
+    internal static let foo: [String: Any] = _document["foo"]
+    internal static let hello: String = _document["hello"]
+    internal static let weight: Double = _document["weight"]
+  }
+  internal enum Version {
+    internal static let value: String = objectFromJSON(at: "version.yaml")
+  }
+}
+// swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+private func objectFromJSON<T>(at path: String) -> T {
+  let bundle = BundleToken.bundle
+  guard let url = bundle.url(forResource: path, withExtension: nil),
+    let json = try? JSONSerialization.jsonObject(with: Data(contentsOf: url), options: []),
+    let result = json as? T else {
+    fatalError("Unable to load JSON at path: \(path)")
+  }
+  return result
+}
+
+private struct JSONDocument {
+  let data: [String: Any]
+
+  init(path: String) {
+    self.data = objectFromJSON(at: path)
+  }
+
+  subscript<T>(key: String) -> T {
+    guard let result = data[key] as? T else {
+      fatalError("Property '\(key)' is not of type \(T.self)")
+    }
+    return result
+  }
+}
+
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    Bundle(for: BundleToken.self)
+  }()
+}
+// swiftlint:enable convenience_type

--- a/Tests/Fixtures/Generated/JSON/runtime-swift5/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift5/all-forceFileNameEnum.swift
@@ -1,0 +1,77 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+import Foundation
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - JSON Files
+
+// swiftlint:disable identifier_name line_length type_body_length
+internal enum JSONFiles {
+  internal enum Configuration {
+    private static let _document = JSONDocument(path: "configuration.json")
+    internal static let apiVersion: String = _document["api-version"]
+    internal static let country: Any? = _document["country"]
+    internal static let environment: String = _document["environment"]
+    internal static let options: [String: Any] = _document["options"]
+  }
+  internal enum Documents {
+    internal enum Document1 {
+      internal static let items: [String] = objectFromJSON(at: "documents.yaml")
+    }
+    internal enum Document2 {
+      internal static let items: [String] = objectFromJSON(at: "documents.yaml")
+    }
+  }
+  internal enum GroceryList {
+    internal static let items: [String] = objectFromJSON(at: "grocery-list.yaml")
+  }
+  internal enum Mapping {
+    private static let _document = JSONDocument(path: "mapping.yaml")
+    internal static let car: Any? = _document["car"]
+    internal static let foo: [String: Any] = _document["foo"]
+    internal static let hello: String = _document["hello"]
+    internal static let weight: Double = _document["weight"]
+  }
+  internal enum Version {
+    internal static let value: String = objectFromJSON(at: "version.yaml")
+  }
+}
+// swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+private func objectFromJSON<T>(at path: String) -> T {
+  let bundle = BundleToken.bundle
+  guard let url = bundle.url(forResource: path, withExtension: nil),
+    let json = try? JSONSerialization.jsonObject(with: Data(contentsOf: url), options: []),
+    let result = json as? T else {
+    fatalError("Unable to load JSON at path: \(path)")
+  }
+  return result
+}
+
+private struct JSONDocument {
+  let data: [String: Any]
+
+  init(path: String) {
+    self.data = objectFromJSON(at: path)
+  }
+
+  subscript<T>(key: String) -> T {
+    guard let result = data[key] as? T else {
+      fatalError("Property '\(key)' is not of type \(T.self)")
+    }
+    return result
+  }
+}
+
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    Bundle(for: BundleToken.self)
+  }()
+}
+// swiftlint:enable convenience_type

--- a/Tests/Fixtures/Generated/Plist/inline-swift4/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/Plist/inline-swift4/all-forceFileNameEnum.swift
@@ -1,0 +1,52 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+import Foundation
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - Plist Files
+
+// swiftlint:disable identifier_name line_length number_separator type_body_length
+internal enum PlistFiles {
+  internal enum Info {
+    internal static let cfBundleDevelopmentRegion: String = "en"
+    internal static let cfBundleDisplayName: String = "${PRODUCT_NAME}"
+    internal static let cfBundleExecutable: String = "${EXECUTABLE_NAME}"
+    internal static let cfBundleIdentifier: String = "$(PRODUCT_BUNDLE_IDENTIFIER)"
+    internal static let cfBundleInfoDictionaryVersion: String = "6.0"
+    internal static let cfBundleName: String = "${PRODUCT_NAME}"
+    internal static let cfBundlePackageType: String = "APPL"
+    internal static let cfBundleShortVersionString: String = "1.2.0"
+    internal static let cfBundleSignature: String = "????"
+    internal static let cfBundleVersion: String = "0"
+    internal static let fabric: [String: Any] = ["APIKey": "512345678900aaafffff", "Kits": [["KitInfo": [:], "KitName": "Crashlytics"]]]
+    internal static let itsAppUsesNonExemptEncryption: Bool = false
+    internal static let lsRequiresIPhoneOS: Bool = true
+    internal static let nsAppTransportSecurity: [String: Any] = [:]
+    internal static let nsCameraUsageDescription: String = "24 Vision needs access to your camera for uploading photos for caes, or for your profile picture."
+    internal static let nsPhotoLibraryUsageDescription: String = "24 Vision needs access to your photo library for uploading photos for caes, or for your profile picture."
+    internal static let uiBackgroundModes: [String] = ["remote-notification"]
+    internal static let uiLaunchStoryboardName: String = "LaunchScreen"
+    internal static let uiMainStoryboardFile: String = "Start"
+    internal static let uiRequiredDeviceCapabilities: [String] = ["armv7"]
+    internal static let uiRequiresFullScreen: Bool = true
+    internal static let uiStatusBarStyle: String = "UIStatusBarStyleDefault"
+    internal static let uiSupportedInterfaceOrientations: [String] = ["UIInterfaceOrientationPortrait", "UIInterfaceOrientationPortraitUpsideDown", "UIInterfaceOrientationLandscapeRight", "UIInterfaceOrientationLandscapeLeft"]
+    internal static let uiSupportedInterfaceOrientationsIpad: [String] = ["UIInterfaceOrientationLandscapeLeft", "UIInterfaceOrientationLandscapeRight", "UIInterfaceOrientationPortraitUpsideDown", "UIInterfaceOrientationPortrait"]
+    internal static let userAmbiguousInteger: Bool = true
+    internal static let userBoolean: Bool = false
+    internal static let userDate: Date = Date(timeIntervalSinceReferenceDate: 547184366)
+    internal static let userFloat: Double = 3.14
+    internal static let userInteger: Int = 5
+  }
+  internal enum Configuration {
+    internal static let environment: String = "development"
+    internal static let options: [String: Any] = ["Animation Style": "Party Mode"]
+  }
+  internal enum ShoppingList {
+    internal static let items: [String] = ["Eggs", "Bread", "Milk"]
+  }
+}
+// swiftlint:enable identifier_name line_length number_separator type_body_length

--- a/Tests/Fixtures/Generated/Plist/inline-swift5/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/Plist/inline-swift5/all-forceFileNameEnum.swift
@@ -1,0 +1,52 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+import Foundation
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - Plist Files
+
+// swiftlint:disable identifier_name line_length number_separator type_body_length
+internal enum PlistFiles {
+  internal enum Info {
+    internal static let cfBundleDevelopmentRegion: String = "en"
+    internal static let cfBundleDisplayName: String = "${PRODUCT_NAME}"
+    internal static let cfBundleExecutable: String = "${EXECUTABLE_NAME}"
+    internal static let cfBundleIdentifier: String = "$(PRODUCT_BUNDLE_IDENTIFIER)"
+    internal static let cfBundleInfoDictionaryVersion: String = "6.0"
+    internal static let cfBundleName: String = "${PRODUCT_NAME}"
+    internal static let cfBundlePackageType: String = "APPL"
+    internal static let cfBundleShortVersionString: String = "1.2.0"
+    internal static let cfBundleSignature: String = "????"
+    internal static let cfBundleVersion: String = "0"
+    internal static let fabric: [String: Any] = ["APIKey": "512345678900aaafffff", "Kits": [["KitInfo": [:], "KitName": "Crashlytics"]]]
+    internal static let itsAppUsesNonExemptEncryption: Bool = false
+    internal static let lsRequiresIPhoneOS: Bool = true
+    internal static let nsAppTransportSecurity: [String: Any] = [:]
+    internal static let nsCameraUsageDescription: String = "24 Vision needs access to your camera for uploading photos for caes, or for your profile picture."
+    internal static let nsPhotoLibraryUsageDescription: String = "24 Vision needs access to your photo library for uploading photos for caes, or for your profile picture."
+    internal static let uiBackgroundModes: [String] = ["remote-notification"]
+    internal static let uiLaunchStoryboardName: String = "LaunchScreen"
+    internal static let uiMainStoryboardFile: String = "Start"
+    internal static let uiRequiredDeviceCapabilities: [String] = ["armv7"]
+    internal static let uiRequiresFullScreen: Bool = true
+    internal static let uiStatusBarStyle: String = "UIStatusBarStyleDefault"
+    internal static let uiSupportedInterfaceOrientations: [String] = ["UIInterfaceOrientationPortrait", "UIInterfaceOrientationPortraitUpsideDown", "UIInterfaceOrientationLandscapeRight", "UIInterfaceOrientationLandscapeLeft"]
+    internal static let uiSupportedInterfaceOrientationsIpad: [String] = ["UIInterfaceOrientationLandscapeLeft", "UIInterfaceOrientationLandscapeRight", "UIInterfaceOrientationPortraitUpsideDown", "UIInterfaceOrientationPortrait"]
+    internal static let userAmbiguousInteger: Bool = true
+    internal static let userBoolean: Bool = false
+    internal static let userDate: Date = Date(timeIntervalSinceReferenceDate: 547184366)
+    internal static let userFloat: Double = 3.14
+    internal static let userInteger: Int = 5
+  }
+  internal enum Configuration {
+    internal static let environment: String = "development"
+    internal static let options: [String: Any] = ["Animation Style": "Party Mode"]
+  }
+  internal enum ShoppingList {
+    internal static let items: [String] = ["Eggs", "Bread", "Milk"]
+  }
+}
+// swiftlint:enable identifier_name line_length number_separator type_body_length

--- a/Tests/Fixtures/Generated/Plist/runtime-swift4/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift4/all-forceFileNameEnum.swift
@@ -1,0 +1,93 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+import Foundation
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - Plist Files
+
+// swiftlint:disable identifier_name line_length type_body_length
+internal enum PlistFiles {
+  internal enum Info {
+    private static let _document = PlistDocument(path: "Info.plist")
+    internal static let cfBundleDevelopmentRegion: String = _document["CFBundleDevelopmentRegion"]
+    internal static let cfBundleDisplayName: String = _document["CFBundleDisplayName"]
+    internal static let cfBundleExecutable: String = _document["CFBundleExecutable"]
+    internal static let cfBundleIdentifier: String = _document["CFBundleIdentifier"]
+    internal static let cfBundleInfoDictionaryVersion: String = _document["CFBundleInfoDictionaryVersion"]
+    internal static let cfBundleName: String = _document["CFBundleName"]
+    internal static let cfBundlePackageType: String = _document["CFBundlePackageType"]
+    internal static let cfBundleShortVersionString: String = _document["CFBundleShortVersionString"]
+    internal static let cfBundleSignature: String = _document["CFBundleSignature"]
+    internal static let cfBundleVersion: String = _document["CFBundleVersion"]
+    internal static let fabric: [String: Any] = _document["Fabric"]
+    internal static let itsAppUsesNonExemptEncryption: Bool = _document["ITSAppUsesNonExemptEncryption"]
+    internal static let lsRequiresIPhoneOS: Bool = _document["LSRequiresIPhoneOS"]
+    internal static let nsAppTransportSecurity: [String: Any] = _document["NSAppTransportSecurity"]
+    internal static let nsCameraUsageDescription: String = _document["NSCameraUsageDescription"]
+    internal static let nsPhotoLibraryUsageDescription: String = _document["NSPhotoLibraryUsageDescription"]
+    internal static let uiBackgroundModes: [String] = _document["UIBackgroundModes"]
+    internal static let uiLaunchStoryboardName: String = _document["UILaunchStoryboardName"]
+    internal static let uiMainStoryboardFile: String = _document["UIMainStoryboardFile"]
+    internal static let uiRequiredDeviceCapabilities: [String] = _document["UIRequiredDeviceCapabilities"]
+    internal static let uiRequiresFullScreen: Bool = _document["UIRequiresFullScreen"]
+    internal static let uiStatusBarStyle: String = _document["UIStatusBarStyle"]
+    internal static let uiSupportedInterfaceOrientations: [String] = _document["UISupportedInterfaceOrientations"]
+    internal static let uiSupportedInterfaceOrientationsIpad: [String] = _document["UISupportedInterfaceOrientations~ipad"]
+    internal static let userAmbiguousInteger: Bool = _document["User Ambiguous Integer"]
+    internal static let userBoolean: Bool = _document["User Boolean"]
+    internal static let userDate: Date = _document["User Date"]
+    internal static let userFloat: Double = _document["User Float"]
+    internal static let userInteger: Int = _document["User Integer"]
+  }
+  internal enum Configuration {
+    private static let _document = PlistDocument(path: "configuration.plist")
+    internal static let environment: String = _document["Environment"]
+    internal static let options: [String: Any] = _document["Options"]
+  }
+  internal enum ShoppingList {
+    internal static let items: [String] = arrayFromPlist(at: "shopping-list.plist")
+  }
+}
+// swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+private func arrayFromPlist<T>(at path: String) -> [T] {
+  let bundle = BundleToken.bundle
+  guard let url = bundle.url(forResource: path, withExtension: nil),
+    let data = NSArray(contentsOf: url) as? [T] else {
+    fatalError("Unable to load PLIST at path: \(path)")
+  }
+  return data
+}
+
+private struct PlistDocument {
+  let data: [String: Any]
+
+  init(path: String) {
+    let bundle = BundleToken.bundle
+    guard let url = bundle.url(forResource: path, withExtension: nil),
+      let data = NSDictionary(contentsOf: url) as? [String: Any] else {
+        fatalError("Unable to load PLIST at path: \(path)")
+    }
+    self.data = data
+  }
+
+  subscript<T>(key: String) -> T {
+    guard let result = data[key] as? T else {
+      fatalError("Property '\(key)' is not of type \(T.self)")
+    }
+    return result
+  }
+}
+
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    Bundle(for: BundleToken.self)
+  }()
+}
+// swiftlint:enable convenience_type

--- a/Tests/Fixtures/Generated/Plist/runtime-swift5/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift5/all-forceFileNameEnum.swift
@@ -1,0 +1,93 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+import Foundation
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - Plist Files
+
+// swiftlint:disable identifier_name line_length type_body_length
+internal enum PlistFiles {
+  internal enum Info {
+    private static let _document = PlistDocument(path: "Info.plist")
+    internal static let cfBundleDevelopmentRegion: String = _document["CFBundleDevelopmentRegion"]
+    internal static let cfBundleDisplayName: String = _document["CFBundleDisplayName"]
+    internal static let cfBundleExecutable: String = _document["CFBundleExecutable"]
+    internal static let cfBundleIdentifier: String = _document["CFBundleIdentifier"]
+    internal static let cfBundleInfoDictionaryVersion: String = _document["CFBundleInfoDictionaryVersion"]
+    internal static let cfBundleName: String = _document["CFBundleName"]
+    internal static let cfBundlePackageType: String = _document["CFBundlePackageType"]
+    internal static let cfBundleShortVersionString: String = _document["CFBundleShortVersionString"]
+    internal static let cfBundleSignature: String = _document["CFBundleSignature"]
+    internal static let cfBundleVersion: String = _document["CFBundleVersion"]
+    internal static let fabric: [String: Any] = _document["Fabric"]
+    internal static let itsAppUsesNonExemptEncryption: Bool = _document["ITSAppUsesNonExemptEncryption"]
+    internal static let lsRequiresIPhoneOS: Bool = _document["LSRequiresIPhoneOS"]
+    internal static let nsAppTransportSecurity: [String: Any] = _document["NSAppTransportSecurity"]
+    internal static let nsCameraUsageDescription: String = _document["NSCameraUsageDescription"]
+    internal static let nsPhotoLibraryUsageDescription: String = _document["NSPhotoLibraryUsageDescription"]
+    internal static let uiBackgroundModes: [String] = _document["UIBackgroundModes"]
+    internal static let uiLaunchStoryboardName: String = _document["UILaunchStoryboardName"]
+    internal static let uiMainStoryboardFile: String = _document["UIMainStoryboardFile"]
+    internal static let uiRequiredDeviceCapabilities: [String] = _document["UIRequiredDeviceCapabilities"]
+    internal static let uiRequiresFullScreen: Bool = _document["UIRequiresFullScreen"]
+    internal static let uiStatusBarStyle: String = _document["UIStatusBarStyle"]
+    internal static let uiSupportedInterfaceOrientations: [String] = _document["UISupportedInterfaceOrientations"]
+    internal static let uiSupportedInterfaceOrientationsIpad: [String] = _document["UISupportedInterfaceOrientations~ipad"]
+    internal static let userAmbiguousInteger: Bool = _document["User Ambiguous Integer"]
+    internal static let userBoolean: Bool = _document["User Boolean"]
+    internal static let userDate: Date = _document["User Date"]
+    internal static let userFloat: Double = _document["User Float"]
+    internal static let userInteger: Int = _document["User Integer"]
+  }
+  internal enum Configuration {
+    private static let _document = PlistDocument(path: "configuration.plist")
+    internal static let environment: String = _document["Environment"]
+    internal static let options: [String: Any] = _document["Options"]
+  }
+  internal enum ShoppingList {
+    internal static let items: [String] = arrayFromPlist(at: "shopping-list.plist")
+  }
+}
+// swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+private func arrayFromPlist<T>(at path: String) -> [T] {
+  let bundle = BundleToken.bundle
+  guard let url = bundle.url(forResource: path, withExtension: nil),
+    let data = NSArray(contentsOf: url) as? [T] else {
+    fatalError("Unable to load PLIST at path: \(path)")
+  }
+  return data
+}
+
+private struct PlistDocument {
+  let data: [String: Any]
+
+  init(path: String) {
+    let bundle = BundleToken.bundle
+    guard let url = bundle.url(forResource: path, withExtension: nil),
+      let data = NSDictionary(contentsOf: url) as? [String: Any] else {
+        fatalError("Unable to load PLIST at path: \(path)")
+    }
+    self.data = data
+  }
+
+  subscript<T>(key: String) -> T {
+    guard let result = data[key] as? T else {
+      fatalError("Property '\(key)' is not of type \(T.self)")
+    }
+    return result
+  }
+}
+
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    Bundle(for: BundleToken.self)
+  }()
+}
+// swiftlint:enable convenience_type

--- a/Tests/Fixtures/Generated/XCAssets/swift4/all-allValues.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift4/all-allValues.swift
@@ -243,7 +243,9 @@ internal struct ImageAsset {
     #elseif os(watchOS)
     let image = Image(named: name)
     #endif
-    guard let result = image else { fatalError("Unable to load image named \(name).") }
+    guard let result = image else {
+      fatalError("Unable to load image named \(name).")
+    }
     return result
   }
 }

--- a/Tests/Fixtures/Generated/XCAssets/swift4/all-customName.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift4/all-customName.swift
@@ -175,7 +175,9 @@ internal struct XCTImageAsset {
     #elseif os(watchOS)
     let image = Image(named: name)
     #endif
-    guard let result = image else { fatalError("Unable to load image named \(name).") }
+    guard let result = image else {
+      fatalError("Unable to load image named \(name).")
+    }
     return result
   }
 }

--- a/Tests/Fixtures/Generated/XCAssets/swift4/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift4/all-forceFileNameEnum.swift
@@ -175,7 +175,9 @@ internal struct ImageAsset {
     #elseif os(watchOS)
     let image = Image(named: name)
     #endif
-    guard let result = image else { fatalError("Unable to load image named \(name).") }
+    guard let result = image else {
+      fatalError("Unable to load image named \(name).")
+    }
     return result
   }
 }

--- a/Tests/Fixtures/Generated/XCAssets/swift4/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift4/all-forceFileNameEnum.swift
@@ -1,0 +1,204 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+#if os(macOS)
+  import AppKit
+#elseif os(iOS)
+  import ARKit
+  import UIKit
+#elseif os(tvOS) || os(watchOS)
+  import UIKit
+#endif
+
+// Deprecated typealiases
+@available(*, deprecated, renamed: "ColorAsset.Color", message: "This typealias will be removed in SwiftGen 7.0")
+internal typealias AssetColorTypeAlias = ColorAsset.Color
+@available(*, deprecated, renamed: "ImageAsset.Image", message: "This typealias will be removed in SwiftGen 7.0")
+internal typealias AssetImageTypeAlias = ImageAsset.Image
+
+// swiftlint:disable superfluous_disable_command file_length implicit_return
+
+// MARK: - Asset Catalogs
+
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
+internal enum Asset {
+  internal enum Files {
+    internal static let data = DataAsset(name: "Data")
+    internal enum Json {
+      internal static let data = DataAsset(name: "Json/Data")
+    }
+    internal static let readme = DataAsset(name: "README")
+  }
+  internal enum Food {
+    internal enum Exotic {
+      internal static let banana = ImageAsset(name: "Exotic/Banana")
+      internal static let mango = ImageAsset(name: "Exotic/Mango")
+    }
+    internal enum Round {
+      internal static let apricot = ImageAsset(name: "Round/Apricot")
+      internal static let apple = ImageAsset(name: "Round/Apple")
+      internal enum Double {
+        internal static let cherry = ImageAsset(name: "Round/Double/Cherry")
+      }
+      internal static let tomato = ImageAsset(name: "Round/Tomato")
+    }
+    internal static let `private` = ImageAsset(name: "private")
+  }
+  internal enum Other {
+  }
+  internal enum Styles {
+    internal enum _24Vision {
+      internal static let background = ColorAsset(name: "24Vision/Background")
+      internal static let primary = ColorAsset(name: "24Vision/Primary")
+    }
+    internal static let orange = ImageAsset(name: "Orange")
+    internal enum Vengo {
+      internal static let primary = ColorAsset(name: "Vengo/Primary")
+      internal static let tint = ColorAsset(name: "Vengo/Tint")
+    }
+  }
+  internal enum Targets {
+    internal static let bottles = ARResourceGroupAsset(name: "Bottles")
+    internal static let paintings = ARResourceGroupAsset(name: "Paintings")
+    internal static let posters = ARResourceGroupAsset(name: "Posters")
+  }
+}
+// swiftlint:enable identifier_name line_length nesting type_body_length type_name
+
+// MARK: - Implementation Details
+
+internal struct ARResourceGroupAsset {
+  internal fileprivate(set) var name: String
+
+  #if os(iOS)
+  @available(iOS 11.3, *)
+  internal var referenceImages: Set<ARReferenceImage> {
+    return ARReferenceImage.referenceImages(in: self)
+  }
+
+  @available(iOS 12.0, *)
+  internal var referenceObjects: Set<ARReferenceObject> {
+    return ARReferenceObject.referenceObjects(in: self)
+  }
+  #endif
+}
+
+#if os(iOS)
+@available(iOS 11.3, *)
+internal extension ARReferenceImage {
+  static func referenceImages(in asset: ARResourceGroupAsset) -> Set<ARReferenceImage> {
+    let bundle = BundleToken.bundle
+    return referenceImages(inGroupNamed: asset.name, bundle: bundle) ?? Set()
+  }
+}
+
+@available(iOS 12.0, *)
+internal extension ARReferenceObject {
+  static func referenceObjects(in asset: ARResourceGroupAsset) -> Set<ARReferenceObject> {
+    let bundle = BundleToken.bundle
+    return referenceObjects(inGroupNamed: asset.name, bundle: bundle) ?? Set()
+  }
+}
+#endif
+
+internal final class ColorAsset {
+  internal fileprivate(set) var name: String
+
+  #if os(macOS)
+  internal typealias Color = NSColor
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  internal typealias Color = UIColor
+  #endif
+
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
+  internal private(set) lazy var color: Color = Color(asset: self)
+
+  fileprivate init(name: String) {
+    self.name = name
+  }
+}
+
+internal extension ColorAsset.Color {
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
+  convenience init!(asset: ColorAsset) {
+    let bundle = BundleToken.bundle
+    #if os(iOS) || os(tvOS)
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    #elseif os(macOS)
+    self.init(named: NSColor.Name(asset.name), bundle: bundle)
+    #elseif os(watchOS)
+    self.init(named: asset.name)
+    #endif
+  }
+}
+
+internal struct DataAsset {
+  internal fileprivate(set) var name: String
+
+  #if os(iOS) || os(tvOS) || os(macOS)
+  @available(iOS 9.0, macOS 10.11, *)
+  internal var data: NSDataAsset {
+    return NSDataAsset(asset: self)
+  }
+  #endif
+}
+
+#if os(iOS) || os(tvOS) || os(macOS)
+@available(iOS 9.0, macOS 10.11, *)
+internal extension NSDataAsset {
+  convenience init!(asset: DataAsset) {
+    let bundle = BundleToken.bundle
+    #if os(iOS) || os(tvOS)
+    self.init(name: asset.name, bundle: bundle)
+    #elseif os(macOS)
+    self.init(name: NSDataAsset.Name(asset.name), bundle: bundle)
+    #endif
+  }
+}
+#endif
+
+internal struct ImageAsset {
+  internal fileprivate(set) var name: String
+
+  #if os(macOS)
+  internal typealias Image = NSImage
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  internal typealias Image = UIImage
+  #endif
+
+  internal var image: Image {
+    let bundle = BundleToken.bundle
+    #if os(iOS) || os(tvOS)
+    let image = Image(named: name, in: bundle, compatibleWith: nil)
+    #elseif os(macOS)
+    let image = bundle.image(forResource: NSImage.Name(name))
+    #elseif os(watchOS)
+    let image = Image(named: name)
+    #endif
+    guard let result = image else { fatalError("Unable to load image named \(name).") }
+    return result
+  }
+}
+
+internal extension ImageAsset.Image {
+  @available(macOS, deprecated,
+    message: "This initializer is unsafe on macOS, please use the ImageAsset.image property")
+  convenience init!(asset: ImageAsset) {
+    #if os(iOS) || os(tvOS)
+    let bundle = BundleToken.bundle
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    #elseif os(macOS)
+    self.init(named: NSImage.Name(asset.name))
+    #elseif os(watchOS)
+    self.init(named: asset.name)
+    #endif
+  }
+}
+
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    Bundle(for: BundleToken.self)
+  }()
+}
+// swiftlint:enable convenience_type

--- a/Tests/Fixtures/Generated/XCAssets/swift4/all-forceNamespaces.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift4/all-forceNamespaces.swift
@@ -177,7 +177,9 @@ internal struct ImageAsset {
     #elseif os(watchOS)
     let image = Image(named: name)
     #endif
-    guard let result = image else { fatalError("Unable to load image named \(name).") }
+    guard let result = image else {
+      fatalError("Unable to load image named \(name).")
+    }
     return result
   }
 }

--- a/Tests/Fixtures/Generated/XCAssets/swift4/all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift4/all-publicAccess.swift
@@ -175,7 +175,9 @@ public struct ImageAsset {
     #elseif os(watchOS)
     let image = Image(named: name)
     #endif
-    guard let result = image else { fatalError("Unable to load image named \(name).") }
+    guard let result = image else {
+      fatalError("Unable to load image named \(name).")
+    }
     return result
   }
 }

--- a/Tests/Fixtures/Generated/XCAssets/swift4/all.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift4/all.swift
@@ -175,7 +175,9 @@ internal struct ImageAsset {
     #elseif os(watchOS)
     let image = Image(named: name)
     #endif
-    guard let result = image else { fatalError("Unable to load image named \(name).") }
+    guard let result = image else {
+      fatalError("Unable to load image named \(name).")
+    }
     return result
   }
 }

--- a/Tests/Fixtures/Generated/XCAssets/swift4/food.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift4/food.swift
@@ -55,7 +55,9 @@ internal struct ImageAsset {
     #elseif os(watchOS)
     let image = Image(named: name)
     #endif
-    guard let result = image else { fatalError("Unable to load image named \(name).") }
+    guard let result = image else {
+      fatalError("Unable to load image named \(name).")
+    }
     return result
   }
 }

--- a/Tests/Fixtures/Generated/XCAssets/swift5/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift5/all-forceFileNameEnum.swift
@@ -1,0 +1,214 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+#if os(macOS)
+  import AppKit
+#elseif os(iOS)
+  import ARKit
+  import UIKit
+#elseif os(tvOS) || os(watchOS)
+  import UIKit
+#endif
+
+// Deprecated typealiases
+@available(*, deprecated, renamed: "ColorAsset.Color", message: "This typealias will be removed in SwiftGen 7.0")
+internal typealias AssetColorTypeAlias = ColorAsset.Color
+@available(*, deprecated, renamed: "ImageAsset.Image", message: "This typealias will be removed in SwiftGen 7.0")
+internal typealias AssetImageTypeAlias = ImageAsset.Image
+
+// swiftlint:disable superfluous_disable_command file_length implicit_return
+
+// MARK: - Asset Catalogs
+
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
+internal enum Asset {
+  internal enum Files {
+    internal static let data = DataAsset(name: "Data")
+    internal enum Json {
+      internal static let data = DataAsset(name: "Json/Data")
+    }
+    internal static let readme = DataAsset(name: "README")
+  }
+  internal enum Food {
+    internal enum Exotic {
+      internal static let banana = ImageAsset(name: "Exotic/Banana")
+      internal static let mango = ImageAsset(name: "Exotic/Mango")
+    }
+    internal enum Round {
+      internal static let apricot = ImageAsset(name: "Round/Apricot")
+      internal static let apple = ImageAsset(name: "Round/Apple")
+      internal enum Double {
+        internal static let cherry = ImageAsset(name: "Round/Double/Cherry")
+      }
+      internal static let tomato = ImageAsset(name: "Round/Tomato")
+    }
+    internal static let `private` = ImageAsset(name: "private")
+  }
+  internal enum Other {
+  }
+  internal enum Styles {
+    internal enum _24Vision {
+      internal static let background = ColorAsset(name: "24Vision/Background")
+      internal static let primary = ColorAsset(name: "24Vision/Primary")
+    }
+    internal static let orange = ImageAsset(name: "Orange")
+    internal enum Vengo {
+      internal static let primary = ColorAsset(name: "Vengo/Primary")
+      internal static let tint = ColorAsset(name: "Vengo/Tint")
+    }
+  }
+  internal enum Targets {
+    internal static let bottles = ARResourceGroupAsset(name: "Bottles")
+    internal static let paintings = ARResourceGroupAsset(name: "Paintings")
+    internal static let posters = ARResourceGroupAsset(name: "Posters")
+  }
+}
+// swiftlint:enable identifier_name line_length nesting type_body_length type_name
+
+// MARK: - Implementation Details
+
+internal struct ARResourceGroupAsset {
+  internal fileprivate(set) var name: String
+
+  #if os(iOS)
+  @available(iOS 11.3, *)
+  internal var referenceImages: Set<ARReferenceImage> {
+    return ARReferenceImage.referenceImages(in: self)
+  }
+
+  @available(iOS 12.0, *)
+  internal var referenceObjects: Set<ARReferenceObject> {
+    return ARReferenceObject.referenceObjects(in: self)
+  }
+  #endif
+}
+
+#if os(iOS)
+@available(iOS 11.3, *)
+internal extension ARReferenceImage {
+  static func referenceImages(in asset: ARResourceGroupAsset) -> Set<ARReferenceImage> {
+    let bundle = BundleToken.bundle
+    return referenceImages(inGroupNamed: asset.name, bundle: bundle) ?? Set()
+  }
+}
+
+@available(iOS 12.0, *)
+internal extension ARReferenceObject {
+  static func referenceObjects(in asset: ARResourceGroupAsset) -> Set<ARReferenceObject> {
+    let bundle = BundleToken.bundle
+    return referenceObjects(inGroupNamed: asset.name, bundle: bundle) ?? Set()
+  }
+}
+#endif
+
+internal final class ColorAsset {
+  internal fileprivate(set) var name: String
+
+  #if os(macOS)
+  internal typealias Color = NSColor
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  internal typealias Color = UIColor
+  #endif
+
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
+  internal private(set) lazy var color: Color = {
+    guard let color = Color(asset: self) else {
+      fatalError("Unable to load color asset named \(name).")
+    }
+    return color
+  }()
+
+  fileprivate init(name: String) {
+    self.name = name
+  }
+}
+
+internal extension ColorAsset.Color {
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
+  convenience init?(asset: ColorAsset) {
+    let bundle = BundleToken.bundle
+    #if os(iOS) || os(tvOS)
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    #elseif os(macOS)
+    self.init(named: NSColor.Name(asset.name), bundle: bundle)
+    #elseif os(watchOS)
+    self.init(named: asset.name)
+    #endif
+  }
+}
+
+internal struct DataAsset {
+  internal fileprivate(set) var name: String
+
+  #if os(iOS) || os(tvOS) || os(macOS)
+  @available(iOS 9.0, macOS 10.11, *)
+  internal var data: NSDataAsset {
+    guard let data = NSDataAsset(asset: self) else {
+      fatalError("Unable to load data asset named \(name).")
+    }
+    return data
+  }
+  #endif
+}
+
+#if os(iOS) || os(tvOS) || os(macOS)
+@available(iOS 9.0, macOS 10.11, *)
+internal extension NSDataAsset {
+  convenience init?(asset: DataAsset) {
+    let bundle = BundleToken.bundle
+    #if os(iOS) || os(tvOS)
+    self.init(name: asset.name, bundle: bundle)
+    #elseif os(macOS)
+    self.init(name: NSDataAsset.Name(asset.name), bundle: bundle)
+    #endif
+  }
+}
+#endif
+
+internal struct ImageAsset {
+  internal fileprivate(set) var name: String
+
+  #if os(macOS)
+  internal typealias Image = NSImage
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  internal typealias Image = UIImage
+  #endif
+
+  internal var image: Image {
+    let bundle = BundleToken.bundle
+    #if os(iOS) || os(tvOS)
+    let image = Image(named: name, in: bundle, compatibleWith: nil)
+    #elseif os(macOS)
+    let image = bundle.image(forResource: NSImage.Name(name))
+    #elseif os(watchOS)
+    let image = Image(named: name)
+    #endif
+    guard let result = image else {
+      fatalError("Unable to load image asset named \(name).")
+    }
+    return result
+  }
+}
+
+internal extension ImageAsset.Image {
+  @available(macOS, deprecated,
+    message: "This initializer is unsafe on macOS, please use the ImageAsset.image property")
+  convenience init?(asset: ImageAsset) {
+    #if os(iOS) || os(tvOS)
+    let bundle = BundleToken.bundle
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    #elseif os(macOS)
+    self.init(named: NSImage.Name(asset.name))
+    #elseif os(watchOS)
+    self.init(named: asset.name)
+    #endif
+  }
+}
+
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    Bundle(for: BundleToken.self)
+  }()
+}
+// swiftlint:enable convenience_type

--- a/Tests/Fixtures/Generated/YAML/inline-swift4/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/YAML/inline-swift4/all-forceFileNameEnum.swift
@@ -1,0 +1,40 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+import Foundation
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - YAML Files
+
+// swiftlint:disable identifier_name line_length number_separator type_body_length
+internal enum YAMLFiles {
+  internal enum Configuration {
+    internal static let apiVersion: String = "2"
+    internal static let country: Any? = nil
+    internal static let environment: String = "staging"
+    internal static let options: [String: Any] = ["screen-order": ["1", "2", "3"]]
+  }
+  internal enum Documents {
+    internal enum Document1 {
+      internal static let items: [String] = ["Mark McGwire", "Sammy Sosa", "Ken Griffey"]
+    }
+    internal enum Document2 {
+      internal static let items: [String] = ["Chicago Cubs", "St Louis Cardinals"]
+    }
+  }
+  internal enum GroceryList {
+    internal static let items: [String] = ["Eggs", "Bread", "Milk"]
+  }
+  internal enum Mapping {
+    internal static let car: Any? = nil
+    internal static let foo: [String: Any] = ["bar": "banana", "baz": "orange"]
+    internal static let hello: String = "world"
+    internal static let weight: Double = 33.3
+  }
+  internal enum Version {
+    internal static let value: String = "1.2.3.beta.4"
+  }
+}
+// swiftlint:enable identifier_name line_length number_separator type_body_length

--- a/Tests/Fixtures/Generated/YAML/inline-swift5/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/YAML/inline-swift5/all-forceFileNameEnum.swift
@@ -1,0 +1,40 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+import Foundation
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - YAML Files
+
+// swiftlint:disable identifier_name line_length number_separator type_body_length
+internal enum YAMLFiles {
+  internal enum Configuration {
+    internal static let apiVersion: String = "2"
+    internal static let country: Any? = nil
+    internal static let environment: String = "staging"
+    internal static let options: [String: Any] = ["screen-order": ["1", "2", "3"]]
+  }
+  internal enum Documents {
+    internal enum Document1 {
+      internal static let items: [String] = ["Mark McGwire", "Sammy Sosa", "Ken Griffey"]
+    }
+    internal enum Document2 {
+      internal static let items: [String] = ["Chicago Cubs", "St Louis Cardinals"]
+    }
+  }
+  internal enum GroceryList {
+    internal static let items: [String] = ["Eggs", "Bread", "Milk"]
+  }
+  internal enum Mapping {
+    internal static let car: Any? = nil
+    internal static let foo: [String: Any] = ["bar": "banana", "baz": "orange"]
+    internal static let hello: String = "world"
+    internal static let weight: Double = 33.3
+  }
+  internal enum Version {
+    internal static let value: String = "1.2.3.beta.4"
+  }
+}
+// swiftlint:enable identifier_name line_length number_separator type_body_length

--- a/Tests/TemplatesTests/ColorsTests.swift
+++ b/Tests/TemplatesTests/ColorsTests.swift
@@ -33,6 +33,10 @@ class ColorsTests: XCTestCase {
         (
           context: try StencilContext.enrich(context: context, parameters: ["publicAccess"]),
           suffix: "-publicAccess"
+        ),
+        (
+          context: try StencilContext.enrich(context: context, parameters: ["forceFileNameEnum"]),
+          suffix: "-forceFileNameEnum"
         )
       ]
     }

--- a/Tests/TemplatesTests/JsonTests.swift
+++ b/Tests/TemplatesTests/JsonTests.swift
@@ -28,6 +28,10 @@ class JsonTests: XCTestCase {
       (
         context: try StencilContext.enrich(context: context, parameters: ["publicAccess"]),
         suffix: "-publicAccess"
+      ),
+      (
+        context: try StencilContext.enrich(context: context, parameters: ["forceFileNameEnum"]),
+        suffix: "-forceFileNameEnum"
       )
     ]
   }
@@ -74,6 +78,10 @@ class JsonTests: XCTestCase {
       (
         context: try StencilContext.enrich(context: context, parameters: ["publicAccess"]),
         suffix: "-publicAccess"
+      ),
+      (
+        context: try StencilContext.enrich(context: context, parameters: ["forceFileNameEnum"]),
+        suffix: "-forceFileNameEnum"
       )
     ]
   }

--- a/Tests/TemplatesTests/PlistTests.swift
+++ b/Tests/TemplatesTests/PlistTests.swift
@@ -28,6 +28,10 @@ class PlistTests: XCTestCase {
       (
         context: try StencilContext.enrich(context: context, parameters: ["publicAccess"]),
         suffix: "-publicAccess"
+      ),
+      (
+        context: try StencilContext.enrich(context: context, parameters: ["forceFileNameEnum"]),
+        suffix: "-forceFileNameEnum"
       )
     ]
   }
@@ -70,6 +74,10 @@ class PlistTests: XCTestCase {
       (
         context: try StencilContext.enrich(context: context, parameters: ["publicAccess"]),
         suffix: "-publicAccess"
+      ),
+      (
+        context: try StencilContext.enrich(context: context, parameters: ["forceFileNameEnum"]),
+        suffix: "-forceFileNameEnum"
       )
     ]
   }

--- a/Tests/TemplatesTests/XCAssetsTests.swift
+++ b/Tests/TemplatesTests/XCAssetsTests.swift
@@ -49,6 +49,10 @@ class XCAssetsTests: XCTestCase {
       (
         context: try StencilContext.enrich(context: context, parameters: ["forceProvidesNamespaces"]),
         suffix: "-forceNamespaces"
+      ),
+      (
+        context: try StencilContext.enrich(context: context, parameters: ["forceFileNameEnum"]),
+        suffix: "-forceFileNameEnum"
       )
     ]
   }

--- a/Tests/TemplatesTests/YamlTests.swift
+++ b/Tests/TemplatesTests/YamlTests.swift
@@ -28,6 +28,10 @@ class YamlTests: XCTestCase {
       (
         context: try StencilContext.enrich(context: context, parameters: ["publicAccess"]),
         suffix: "-publicAccess"
+      ),
+      (
+        context: try StencilContext.enrich(context: context, parameters: ["forceFileNameEnum"]),
+        suffix: "-forceFileNameEnum"
       )
     ]
   }

--- a/templates/colors/literals-swift4.stencil
+++ b/templates/colors/literals-swift4.stencil
@@ -26,7 +26,7 @@
   {{accessPrefix}}static let {{color.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = #colorLiteral(red: {% call h2f color.red %}, green: {% call h2f color.green %}, blue: {% call h2f color.blue %}, alpha: {% call h2f color.alpha %})
   {% endfor %}
 {% endmacro %}
-  {% if palettes.count > 1 %}
+  {% if palettes.count > 1 or param.forceFileNameEnum %}
   {% set accessPrefix %}{{accessModifier}} {% endset %}
   {% for palette in palettes %}
   enum {{palette.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {

--- a/templates/colors/literals-swift5.stencil
+++ b/templates/colors/literals-swift5.stencil
@@ -26,7 +26,7 @@
   {{accessPrefix}}static let {{color.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = #colorLiteral(red: {% call h2f color.red %}, green: {% call h2f color.green %}, blue: {% call h2f color.blue %}, alpha: {% call h2f color.alpha %})
   {% endfor %}
 {% endmacro %}
-  {% if palettes.count > 1 %}
+  {% if palettes.count > 1 or param.forceFileNameEnum %}
   {% set accessPrefix %}{{accessModifier}} {% endset %}
   {% for palette in palettes %}
   enum {{palette.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {

--- a/templates/colors/swift4.stencil
+++ b/templates/colors/swift4.stencil
@@ -30,7 +30,7 @@
   {{accessModifier}} static let {{color.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}(rgbaValue: {% call rgbaValue color %})
   {% endfor %}
 {% endmacro %}
-  {% if palettes.count > 1 %}
+  {% if palettes.count > 1 or param.forceFileNameEnum %}
   {% for palette in palettes %}
   {{accessModifier}} enum {{palette.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
     {% filter indent:2 %}{% call enumBlock palette.colors %}{% endfilter %}

--- a/templates/colors/swift5.stencil
+++ b/templates/colors/swift5.stencil
@@ -30,7 +30,7 @@
   {{accessModifier}} static let {{color.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}(rgbaValue: {% call rgbaValue color %})
   {% endfor %}
 {% endmacro %}
-  {% if palettes.count > 1 %}
+  {% if palettes.count > 1 or param.forceFileNameEnum %}
   {% for palette in palettes %}
   {{accessModifier}} enum {{palette.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
     {% filter indent:2 %}{% call enumBlock palette.colors %}{% endfilter %}

--- a/templates/fonts/swift4.stencil
+++ b/templates/fonts/swift4.stencil
@@ -11,7 +11,9 @@
   {{accessModifier}} typealias Font = UIFont
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length implicit_return
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+// swiftlint:disable implicit_return
 
 // MARK: - Fonts
 

--- a/templates/json/inline-swift4.stencil
+++ b/templates/json/inline-swift4.stencil
@@ -74,7 +74,7 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length number_separator type_body_length
 {{accessModifier}} enum {{param.enumName|default:"JSONFiles"}} {
-  {% if files.count > 1 %}
+  {% if files.count > 1 or param.forceFileNameEnum %}
   {% for file in files %}
   {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
     {% filter indent:2 %}{% call fileBlock file %}{% endfilter %}

--- a/templates/json/inline-swift4.stencil
+++ b/templates/json/inline-swift4.stencil
@@ -58,12 +58,12 @@ import Foundation
   {% elif metadata.type == "Array" and metadata.element.items %}
     [{% for itemMetadata in metadata.element.items %}
       {% call valueBlock value[forloop.counter0] itemMetadata %}
-      {% if not forloop.last %}, {% endif %}
+      {{ ", " if not forloop.last }}
     {% endfor %}]
   {% elif metadata.type == "Dictionary" %}
     [{% for key,value in value %}
       "{{key}}": {% call valueBlock value metadata.properties[key] %}
-      {% if not forloop.last %}, {% endif %}
+      {{ ", " if not forloop.last }}
     {% empty %}
       :
     {% endfor %}]

--- a/templates/json/inline-swift5.stencil
+++ b/templates/json/inline-swift5.stencil
@@ -74,7 +74,7 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length number_separator type_body_length
 {{accessModifier}} enum {{param.enumName|default:"JSONFiles"}} {
-  {% if files.count > 1 %}
+  {% if files.count > 1 or param.forceFileNameEnum %}
   {% for file in files %}
   {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
     {% filter indent:2 %}{% call fileBlock file %}{% endfilter %}

--- a/templates/json/inline-swift5.stencil
+++ b/templates/json/inline-swift5.stencil
@@ -58,12 +58,12 @@ import Foundation
   {% elif metadata.type == "Array" and metadata.element.items %}
     [{% for itemMetadata in metadata.element.items %}
       {% call valueBlock value[forloop.counter0] itemMetadata %}
-      {% if not forloop.last %}, {% endif %}
+      {{ ", " if not forloop.last }}
     {% endfor %}]
   {% elif metadata.type == "Dictionary" %}
     [{% for key,value in value %}
       "{{key}}": {% call valueBlock value metadata.properties[key] %}
-      {% if not forloop.last %}, {% endif %}
+      {{ ", " if not forloop.last }}
     {% empty %}
       :
     {% endfor %}]

--- a/templates/json/runtime-swift4.stencil
+++ b/templates/json/runtime-swift4.stencil
@@ -62,7 +62,7 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length type_body_length
 {{accessModifier}} enum {{param.enumName|default:"JSONFiles"}} {
-  {% if files.count > 1 %}
+  {% if files.count > 1 or param.forceFileNameEnum %}
   {% for file in files %}
   {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
     {% filter indent:2 %}{% call fileBlock file %}{% endfilter %}

--- a/templates/json/runtime-swift5.stencil
+++ b/templates/json/runtime-swift5.stencil
@@ -62,7 +62,7 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length type_body_length
 {{accessModifier}} enum {{param.enumName|default:"JSONFiles"}} {
-  {% if files.count > 1 %}
+  {% if files.count > 1 or param.forceFileNameEnum %}
   {% for file in files %}
   {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
     {% filter indent:2 %}{% call fileBlock file %}{% endfilter %}

--- a/templates/plist/inline-swift4.stencil
+++ b/templates/plist/inline-swift4.stencil
@@ -58,12 +58,12 @@ import Foundation
   {% elif metadata.type == "Array" and metadata.element.items %}
     [{% for itemMetadata in metadata.element.items %}
       {% call valueBlock value[forloop.counter0] itemMetadata %}
-      {% if not forloop.last %}, {% endif %}
+      {{ ", " if not forloop.last }}
     {% endfor %}]
   {% elif metadata.type == "Dictionary" %}
     [{% for key,value in value %}
       "{{key}}": {% call valueBlock value metadata.properties[key] %}
-      {% if not forloop.last %}, {% endif %}
+      {{ ", " if not forloop.last }}
     {% empty %}
       :
     {% endfor %}]

--- a/templates/plist/inline-swift4.stencil
+++ b/templates/plist/inline-swift4.stencil
@@ -74,7 +74,7 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length number_separator type_body_length
 {{accessModifier}} enum {{param.enumName|default:"PlistFiles"}} {
-  {% if files.count > 1 %}
+  {% if files.count > 1 or param.forceFileNameEnum %}
   {% for file in files %}
   {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
     {% filter indent:2 %}{% call fileBlock file %}{% endfilter %}

--- a/templates/plist/inline-swift5.stencil
+++ b/templates/plist/inline-swift5.stencil
@@ -58,12 +58,12 @@ import Foundation
   {% elif metadata.type == "Array" and metadata.element.items %}
     [{% for itemMetadata in metadata.element.items %}
       {% call valueBlock value[forloop.counter0] itemMetadata %}
-      {% if not forloop.last %}, {% endif %}
+      {{ ", " if not forloop.last }}
     {% endfor %}]
   {% elif metadata.type == "Dictionary" %}
     [{% for key,value in value %}
       "{{key}}": {% call valueBlock value metadata.properties[key] %}
-      {% if not forloop.last %}, {% endif %}
+      {{ ", " if not forloop.last }}
     {% empty %}
       :
     {% endfor %}]

--- a/templates/plist/inline-swift5.stencil
+++ b/templates/plist/inline-swift5.stencil
@@ -74,7 +74,7 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length number_separator type_body_length
 {{accessModifier}} enum {{param.enumName|default:"PlistFiles"}} {
-  {% if files.count > 1 %}
+  {% if files.count > 1 or param.forceFileNameEnum %}
   {% for file in files %}
   {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
     {% filter indent:2 %}{% call fileBlock file %}{% endfilter %}

--- a/templates/plist/runtime-swift4.stencil
+++ b/templates/plist/runtime-swift4.stencil
@@ -60,7 +60,7 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length type_body_length
 {{accessModifier}} enum {{param.enumName|default:"PlistFiles"}} {
-  {% if files.count > 1 %}
+  {% if files.count > 1 or param.forceFileNameEnum %}
   {% for file in files %}
   {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
     {% filter indent:2 %}{% call fileBlock file %}{% endfilter %}

--- a/templates/plist/runtime-swift5.stencil
+++ b/templates/plist/runtime-swift5.stencil
@@ -60,7 +60,7 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length type_body_length
 {{accessModifier}} enum {{param.enumName|default:"PlistFiles"}} {
-  {% if files.count > 1 %}
+  {% if files.count > 1 or param.forceFileNameEnum %}
   {% for file in files %}
   {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
     {% filter indent:2 %}{% call fileBlock file %}{% endfilter %}

--- a/templates/strings/objc-h.stencil
+++ b/templates/strings/objc-h.stencil
@@ -7,12 +7,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 {% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
   {% for type in types %}
-    ({% call paramTranslate type %})p{{ forloop.counter }}{% if not forloop.last %} :{% endif %}
+    ({% call paramTranslate type %})p{{ forloop.counter }}{{ " :" if not forloop.last }}
   {% endfor %}
 {% endfilter %}{% endmacro %}
 {% macro argumentsBlock types %}{% filter removeNewlines:"leading" %}
   {% for type in types %}
-    p{{forloop.counter}}{% if not forloop.last %}, {% endif %}
+    p{{forloop.counter}}{{ ", " if not forloop.last }}
   {% endfor %}
 {% endfilter %}{% endmacro %}
 {% macro paramTranslate swiftType %}

--- a/templates/strings/objc-m.stencil
+++ b/templates/strings/objc-m.stencil
@@ -28,12 +28,12 @@ static NSString* tr(NSString *tableName, NSString *key, ...) {
 
 {% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
   {% for type in types %}
-    ({% call paramTranslate type %})p{{ forloop.counter }}{% if not forloop.last %} :{% endif %}
+    ({% call paramTranslate type %})p{{ forloop.counter }}{{ " :" if not forloop.last }}
   {% endfor %}
 {% endfilter %}{% endmacro %}
 {% macro argumentsBlock types %}{% filter removeNewlines:"leading" %}
   {% for type in types %}
-    p{{forloop.counter}}{% if not forloop.last %}, {% endif %}
+    p{{forloop.counter}}{{ ", " if not forloop.last }}
   {% endfor %}
 {% endfilter %}{% endmacro %}
 {% macro paramTranslate swiftType %}

--- a/templates/xcassets/swift4.stencil
+++ b/templates/xcassets/swift4.stencil
@@ -224,7 +224,9 @@
     #elseif os(watchOS)
     let image = Image(named: name)
     #endif
-    guard let result = image else { fatalError("Unable to load image named \(name).") }
+    guard let result = image else {
+      fatalError("Unable to load image named \(name).")
+    }
     return result
   }
 }

--- a/templates/xcassets/swift4.stencil
+++ b/templates/xcassets/swift4.stencil
@@ -95,7 +95,7 @@
 {% endmacro %}
 // swiftlint:disable identifier_name line_length nesting type_body_length type_name
 {{accessModifier}} enum {{enumName}} {
-  {% if catalogs.count > 1 %}
+  {% if catalogs.count > 1 or param.forceFileNameEnum %}
   {% for catalog in catalogs %}
   {{accessModifier}} enum {{catalog.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
     {% filter indent:2 %}{% call enumBlock catalog.assets %}{% endfilter %}

--- a/templates/xcassets/swift5.stencil
+++ b/templates/xcassets/swift5.stencil
@@ -95,7 +95,7 @@
 {% endmacro %}
 // swiftlint:disable identifier_name line_length nesting type_body_length type_name
 {{accessModifier}} enum {{enumName}} {
-  {% if catalogs.count > 1 %}
+  {% if catalogs.count > 1 or param.forceFileNameEnum %}
   {% for catalog in catalogs %}
   {{accessModifier}} enum {{catalog.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
     {% filter indent:2 %}{% call enumBlock catalog.assets %}{% endfilter %}

--- a/templates/yaml/inline-swift4.stencil
+++ b/templates/yaml/inline-swift4.stencil
@@ -74,7 +74,7 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length number_separator type_body_length
 {{accessModifier}} enum {{param.enumName|default:"YAMLFiles"}} {
-  {% if files.count > 1 %}
+  {% if files.count > 1 or param.forceFileNameEnum %}
   {% for file in files %}
   {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
     {% filter indent:2 %}{% call fileBlock file %}{% endfilter %}

--- a/templates/yaml/inline-swift4.stencil
+++ b/templates/yaml/inline-swift4.stencil
@@ -58,12 +58,12 @@ import Foundation
   {% elif metadata.type == "Array" and metadata.element.items %}
     [{% for itemMetadata in metadata.element.items %}
       {% call valueBlock value[forloop.counter0] itemMetadata %}
-      {% if not forloop.last %}, {% endif %}
+      {{ ", " if not forloop.last }}
     {% endfor %}]
   {% elif metadata.type == "Dictionary" %}
     [{% for key,value in value %}
       "{{key}}": {% call valueBlock value metadata.properties[key] %}
-      {% if not forloop.last %}, {% endif %}
+      {{ ", " if not forloop.last }}
     {% empty %}
       :
     {% endfor %}]

--- a/templates/yaml/inline-swift5.stencil
+++ b/templates/yaml/inline-swift5.stencil
@@ -74,7 +74,7 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length number_separator type_body_length
 {{accessModifier}} enum {{param.enumName|default:"YAMLFiles"}} {
-  {% if files.count > 1 %}
+  {% if files.count > 1 or param.forceFileNameEnum %}
   {% for file in files %}
   {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
     {% filter indent:2 %}{% call fileBlock file %}{% endfilter %}

--- a/templates/yaml/inline-swift5.stencil
+++ b/templates/yaml/inline-swift5.stencil
@@ -58,12 +58,12 @@ import Foundation
   {% elif metadata.type == "Array" and metadata.element.items %}
     [{% for itemMetadata in metadata.element.items %}
       {% call valueBlock value[forloop.counter0] itemMetadata %}
-      {% if not forloop.last %}, {% endif %}
+      {{ ", " if not forloop.last }}
     {% endfor %}]
   {% elif metadata.type == "Dictionary" %}
     [{% for key,value in value %}
       "{{key}}": {% call valueBlock value metadata.properties[key] %}
-      {% if not forloop.last %}, {% endif %}
+      {{ ", " if not forloop.last }}
     {% empty %}
       :
     {% endfor %}]


### PR DESCRIPTION
* [x] I've started my branch from the `develop` branch (gitflow)
  * [x] And I've selected `develop` as the "base" branch for this Pull Request I'm about to create
* [x] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself  
      _(or added `#trivial` to the PR title if I think it doesn't warrant a mention in the CHANGELOG)_
  * [x] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
  * [x] Add a period and 2 spaces at the end of your short entry description
  * [x] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

This PR:
- [x] Apply the changes done on strings templates by https://github.com/SwiftGen/SwiftGen/pull/669 to all other templates too
- [x] Unify the use of `{{ "x" if y }}` over `{% if y %}x{% endif %}` in all templates. The shorter syntax was used in recent changes in some templates but were not used everywhere, and since it's more readable better be consistent and prefer use it everywhere over the longer version
- [x] Unify tweaks between some swift4 vs swift5 templates to keep the diff between those to the minimum possible (right now the main remaining diff is the use of `init!` in `*swift4.stencil` vs `init?`+`guard let else fatalError(…)` in `*swift5.stencil` in internal types)