### PR TITLE
Better CLI error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,9 @@
 
 ### Bug Fixes
 
+* SwiftGen now properly shows a better help message and the command usage when running an incomplete command, instead of complaining about a config file.  
+  [@AliSoftware](https://github.com/AliSoftware)
+  [#706](https://github.com/SwiftGen/SwiftGen/pull/706)
 * XCAssets: improved the performance for color assets by caching the resolved colors.  
   [David Jennes](https://github.com/djbe)
   [#578](https://github.com/SwiftGen/SwiftGen/issue/578)

--- a/Sources/SwiftGen/Commander/ConfigCommands.swift
+++ b/Sources/SwiftGen/Commander/ConfigCommands.swift
@@ -125,11 +125,15 @@ enum ConfigCLI {
       logMessage(
         .error,
         """
-        It seems like there was an error running SwiftGen. Please verify that your configuration file is valid by \
-        running:
+        It seems like there was an error running SwiftGen.
+
+        - Verify that your configuration file exists at the correct path, or create a new one using:
+        > swiftgen config init
+
+        - Verify that your configuration file is valid by running:
         > swiftgen config lint
 
-        If you have any other questions or issues, we have extensive documentation and an issue tracker on GitHub:
+        - If you have any other questions or issues, we have extensive documentation and an issue tracker on GitHub:
         > https://github.com/SwiftGen/SwiftGen
         """
       )

--- a/Sources/SwiftGen/Commander/ConfigCommands.swift
+++ b/Sources/SwiftGen/Commander/ConfigCommands.swift
@@ -122,21 +122,7 @@ enum ConfigCLI {
       }
     } catch let error as Config.Error {
       logMessage(.error, error)
-      logMessage(
-        .error,
-        """
-        It seems like there was an error running SwiftGen.
-
-        - Verify that your configuration file exists at the correct path, or create a new one using:
-        > swiftgen config init
-
-        - Verify that your configuration file is valid by running:
-        > swiftgen config lint
-
-        - If you have any other questions or issues, we have extensive documentation and an issue tracker on GitHub:
-        > https://github.com/SwiftGen/SwiftGen
-        """
-      )
+      logMessage(.error, configRunErrorMessageWithSuggestions)
     }
   }
 
@@ -166,3 +152,19 @@ enum ConfigCLI {
     NSWorkspace.shared.open(docURL)
   }
 }
+
+// MARK: Private
+
+private let configRunErrorMessageWithSuggestions =
+  """
+  It seems like there was an error running SwiftGen.
+
+  - Verify that your configuration file exists at the correct path, or create a new one using:
+  > swiftgen config init
+
+  - Verify that your configuration file is valid by running:
+  > swiftgen config lint
+
+  - If you have any other questions or issues, we have extensive documentation and an issue tracker on GitHub:
+  > https://github.com/SwiftGen/SwiftGen
+  """

--- a/Sources/SwiftGen/main.swift
+++ b/Sources/SwiftGen/main.swift
@@ -16,11 +16,15 @@ import SwiftGenKit
 // swiftlint:disable:next closure_body_length
 let main = Group {
   $0.noCommand = { path, group, parser in
-    if parser.hasOption("help") {
-      logMessage(.info, "Note: If you invoke swiftgen with no subcommand, it will default to `swiftgen config run`\n")
-      throw GroupError.noCommand(path, group)
-    } else {
+    if path == nil && !parser.hasOption("help") {
+      // `swiftgen` invoked with no subcommand AND no `--help` flag ==> run `swiftgen config run`
       try ConfigCLI.run.run(parser)
+    } else {
+      // invoked with either an incomplete subcommand (e.g. `swiftgen config`) OR with `--help` flag ==> show help
+      if path == nil { // no subcommand, so just `swiftgen --help`
+        logMessage(.info, "Note: If you invoke swiftgen with no subcommand, it will default to `swiftgen config run`\n")
+      }
+      throw GroupError.noCommand(path, group)
     }
   }
   $0.group("config", "manage and run configuration files") {


### PR DESCRIPTION
* [x] I've started my branch from the `develop` branch (gitflow)
  * [x] And I've selected `develop` as the "base" branch for this Pull Request I'm about to create
* [x] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself  
      _(or added `#trivial` to the PR title if I think it doesn't warrant a mention in the CHANGELOG)_
  * [x] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
  * [x] Add a period and 2 spaces at the end of your short entry description
  * [x] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

⚠️  This PR is built on top of #705

This PR ensures that the user will get the proper help message in the terminal when typing an incomplete command.

* In the previous implementation, calling any incomplete command (more specifically calling a command with a subgroup but not up to a leaf subcommand, like `swiftgen template` or `swiftgen config` instead of `swiftgen template list` or `swiftgen config init`) would result in SwiftGen trying to execute `ConfigCLI.run.run(parser)` (so do as if the user typed `swiftgen config run`) and result in an "Failed to file config file" error
* Now that default execution of `swiftgen config run` only happens when we invoke `swiftgen` with no subcommand, not even a subgroup, and if we don't have the `--help` flag present. So only when running the bare `swiftgen` command.
* Otherwise, like if we run an incomplete group without subcommand `swiftgen template`, it will properly print the help message like if we ran `swiftgen template --help`