### PR TITLE
Renamed "master" branch to "stable" #trivial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -548,7 +548,7 @@ Read the [SwiftGen 5.0 Migration Guide](Documentation/MigrationGuide.md#swiftgen
 * Removed deprecated template context variables, and restructured many others. Please check the [SwiftGenKit migration guide](Documentation/SwiftGenKit%20Contexts/MigrationGuide.md#swiftgenkit-20-swiftgen-50) for more information.  
   [David Jennes](https://github.com/djbe)
   [SwiftGen/SwiftGenKit#5](https://github.com/SwiftGen/SwiftGenKit/issues/5)
-* Some filters have been removed in favour of Stencil's built in versions, and other filters have been updated to accept parameters. Please consult the [StencilSwiftKit migration guide](https://github.com/SwiftGen/StencilSwiftKit/blob/master/Documentation/MigrationGuide.md#stencilswiftkit-20-swiftgen-50) for more information.  
+* Some filters have been removed in favour of Stencil's built in versions, and other filters have been updated to accept parameters. Please consult the [StencilSwiftKit migration guide](https://github.com/SwiftGen/StencilSwiftKit/blob/stable/Documentation/MigrationGuide.md#stencilswiftkit-20-swiftgen-50) for more information.  
   [David Jennes](https://github.com/djbe)
   [SwiftGen/StencilSwiftKit#5](https://github.com/SwiftGen/StencilSwiftKit/issues/5)
   [SwiftGen/StencilSwiftKit#6](https://github.com/SwiftGen/StencilSwiftKit/issues/6)

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -26,7 +26,7 @@ Use this file to track all dependencies required by this project.
 ### StencilSwiftKit
 
 - Additional tags/filters for Stencil, developed and maintained by the SwiftGen project.
-- License: [MIT](https://github.com/SwiftGen/StencilSwiftKit/blob/master/LICENCE)
+- License: [MIT](https://github.com/SwiftGen/StencilSwiftKit/blob/stable/LICENCE)
 
 ### SwiftLint
 

--- a/Documentation/MigrationGuide.md
+++ b/Documentation/MigrationGuide.md
@@ -7,7 +7,7 @@ All the migration guides for SwiftGen are spread out over a few files, depending
 | SwiftGen Migration Guide (this file) | All users of SwiftGen | Changes in configuration, CLI parameters and global changes overview |
 | [Templates Migration Guide](templates/MigrationGuide.md) | Users of SwiftGen's bundled templates (`templateName` option) | Some templates may have been renamed, removed or merged, or their functionality may have changed |
 | [SwiftGenKit Migration Guide](SwiftGenKit%20Contexts/MigrationGuide.md) | Template writers | Changes in names of variables provided by SwiftGenKit to your templates |
-| [StencilSwiftKit Migration Guide](https://github.com/SwiftGen/StencilSwiftKit/blob/master/Documentation/MigrationGuide.md) | Template writers | Changes in extra filters and tags for use in templates |
+| [StencilSwiftKit Migration Guide](https://github.com/SwiftGen/StencilSwiftKit/blob/stable/Documentation/MigrationGuide.md) | Template writers | Changes in extra filters and tags for use in templates |
 
 ----
 
@@ -216,7 +216,7 @@ These are just a few of the changes to the structure of the variables passed by 
 
 ### Some SwiftGen-specific Stencil filters evolved
 
-Also, a few dedicated Stencil filters provided by SwiftGen (via StencilSwiftKit) have been renamed. Especially the `join` and `snakeToCamelCase` filters now take a parameter. See [StencilSwiftKit's own Migration Guide](https://github.com/SwiftGen/StencilSwiftKit/blob/master/Documentation/MigrationGuide.md#stencilswiftkit-20-swiftgen-50) for more info.
+Also, a few dedicated Stencil filters provided by SwiftGen (via StencilSwiftKit) have been renamed. Especially the `join` and `snakeToCamelCase` filters now take a parameter. See [StencilSwiftKit's own Migration Guide](https://github.com/SwiftGen/StencilSwiftKit/blob/stable/Documentation/MigrationGuide.md#stencilswiftkit-20-swiftgen-50) for more info.
 
 </details>
 

--- a/Documentation/templates/MigrationGuide.md
+++ b/Documentation/templates/MigrationGuide.md
@@ -59,7 +59,7 @@ The templates have been split up into separate templates for each specific funct
 
 All templates now have `swiftlint:disable all` at the top, so `swiftlint` users no longer need to ignore the generated files, although this is still highly recommended.
 
-SwiftGen 6.0 uses the latest [Stencil](https://github.com/stencilproject/Stencil/blob/master/CHANGELOG.md#0131) and [StencilSwiftKit](https://github.com/SwiftGen/StencilSwiftKit/blob/master/CHANGELOG.md#270) libraries, so there are plenty of new features for template writers, such as variable subscripting, an `indent` filter, better error reporting, ...
+SwiftGen 6.0 uses the latest [Stencil](https://github.com/stencilproject/Stencil/blob/master/CHANGELOG.md#0131) and [StencilSwiftKit](https://github.com/SwiftGen/StencilSwiftKit/blob/stable/CHANGELOG.md#270) libraries, so there are plenty of new features for template writers, such as variable subscripting, an `indent` filter, better error reporting, ...
 
 ### Fonts
 


### PR DESCRIPTION
* [x] I've started my branch from the `develop` branch (gitflow)
  * [x] And I've selected `develop` as the "base" branch for this Pull Request I'm about to create
* [x] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself  
      _(or **added `#trivial` to the PR title** if I think it doesn't warrant a mention in the CHANGELOG)_
  * [ ] ~~Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)~~
  * [ ] ~~Add a period and 2 spaces at the end of your short entry description~~
  * [ ] ~~Add links to your GitHub profile to credit yourself and to the related PR and issue after your description~~

---

This PR updates the links to StencilSwiftKit's `master` branch to use `stable` instead (see https://github.com/SwiftGen/StencilSwiftKit/pull/126)

I have also:
 - Updated the default branch and protected branch name in SwiftGen repo's GitHub settings
 - Updated all open PRs targeting `master` to now target `stable` (they were [3 of those](https://github.com/SwiftGen/SwiftGen/pulls?q=is%3Apr+is%3Aopen+base%3Astable+), which should have targeted `develop` instead in the first place anyway, but some of those were old and before our Danger rule about it)
 - Deleted the `master` branch from origin now that `stable` is pointing to the same sha1

#blacklivesmatter