### PR TITLE
Fonts: parameters to change typealias name & struct name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,21 @@
 
 _None_
 
+### Deprecations
+
+* Fonts: the generated `Font` typealias (to `UIFont`/`NSFont`) is deprecated and will be removed in the next major release.  
+  [David Jennes](https://github.com/djbe)
+  [#728](https://github.com/SwiftGen/SwiftGen/pull/728)
+
 ### New Features
 
-_None_
+* Fonts: the templates now support a new `fontTypeName` template parameter that you can use to change the name of the `struct` representing a font to something else.  
+  [David Jennes](https://github.com/djbe)
+  [#728](https://github.com/SwiftGen/SwiftGen/pull/728)
+* Fonts: the templates now support a new `fontAliasName` that you can use to change the `typealias`'s name from `Font` to something else. For example: this is useful when working with SwiftUI which already defines a `Font` type. Note that as this `typealias` is deprecated (see deprecations above), this template parameter will also be removed in the next major release.  
+  [David Jennes](https://github.com/djbe)
+  [#647](https://github.com/SwiftGen/SwiftGen/issues/647)
+  [#728](https://github.com/SwiftGen/SwiftGen/pull/728)
 
 ### Bug Fixes
 

--- a/Documentation/templates/fonts/swift4.md
+++ b/Documentation/templates/fonts/swift4.md
@@ -18,8 +18,10 @@ You can customize some elements of this template by overriding the following par
 | Parameter Name | Default Value | Description |
 | -------------- | ------------- | ----------- |
 | `enumName` | `FontFamily` | Allows you to change the name of the generated `enum` containing all font families. |
+| `fontTypeName` | `FontConvertible` | Allows you to change the name of the struct type representing a font. |
 | `preservePath` | N/A | Setting this parameter will disable the basename filter applied to all font paths. Use this if you added your font folder as a "folder reference" in your Xcode project, making that folder hierarchy preserved once copied in the build app bundle. The path will be relative to the folder you provided to SwiftGen. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
+| `fontAliasName` | `Font` | **Deprecated** Allows you to change the name of the `typealias` representing a font. Useful when working with SwiftUI, which defines it's own `Font` type. |
 
 ## Generated Code
 

--- a/Documentation/templates/fonts/swift5.md
+++ b/Documentation/templates/fonts/swift5.md
@@ -18,8 +18,10 @@ You can customize some elements of this template by overriding the following par
 | Parameter Name | Default Value | Description |
 | -------------- | ------------- | ----------- |
 | `enumName` | `FontFamily` | Allows you to change the name of the generated `enum` containing all font families. |
+| `fontTypeName` | `FontConvertible` | Allows you to change the name of the struct type representing a font. |
 | `preservePath` | N/A | Setting this parameter will disable the basename filter applied to all font paths. Use this if you added your font folder as a "folder reference" in your Xcode project, making that folder hierarchy preserved once copied in the build app bundle. The path will be relative to the folder you provided to SwiftGen. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
+| `fontAliasName` | `Font` | **Deprecated** Allows you to change the name of the `typealias` representing a font. Useful when working with SwiftUI, which defines it's own `Font` type. |
 
 ## Generated Code
 

--- a/Tests/Fixtures/Generated/Fonts/swift4/defaults-customName.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift4/defaults-customName.swift
@@ -2,12 +2,14 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 #if os(OSX)
-  import AppKit.NSFont
-  internal typealias Font = NSFont
+import AppKit.NSFont
 #elseif os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIFont
-  internal typealias Font = UIFont
+import UIKit.UIFont
 #endif
+
+// Deprecated typealiases
+@available(*, deprecated, renamed: "MyFontConvertible.Font", message: "This typealias will be removed in SwiftGen 7.0")
+internal typealias MyFont = MyFontConvertible.Font
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
@@ -18,42 +20,42 @@
 // swiftlint:disable identifier_name line_length type_body_length
 internal enum CustomFamily {
   internal enum SFNSDisplay {
-    internal static let black = FontConvertible(name: ".SFNSDisplay-Black", family: ".SF NS Display", path: "SFNSDisplay-Black.otf")
-    internal static let bold = FontConvertible(name: ".SFNSDisplay-Bold", family: ".SF NS Display", path: "SFNSDisplay-Bold.otf")
-    internal static let heavy = FontConvertible(name: ".SFNSDisplay-Heavy", family: ".SF NS Display", path: "SFNSDisplay-Heavy.otf")
-    internal static let regular = FontConvertible(name: ".SFNSDisplay-Regular", family: ".SF NS Display", path: "SFNSDisplay-Regular.otf")
-    internal static let all: [FontConvertible] = [black, bold, heavy, regular]
+    internal static let black = MyFontConvertible(name: ".SFNSDisplay-Black", family: ".SF NS Display", path: "SFNSDisplay-Black.otf")
+    internal static let bold = MyFontConvertible(name: ".SFNSDisplay-Bold", family: ".SF NS Display", path: "SFNSDisplay-Bold.otf")
+    internal static let heavy = MyFontConvertible(name: ".SFNSDisplay-Heavy", family: ".SF NS Display", path: "SFNSDisplay-Heavy.otf")
+    internal static let regular = MyFontConvertible(name: ".SFNSDisplay-Regular", family: ".SF NS Display", path: "SFNSDisplay-Regular.otf")
+    internal static let all: [MyFontConvertible] = [black, bold, heavy, regular]
   }
   internal enum SFNSText {
-    internal static let bold = FontConvertible(name: ".SFNSText-Bold", family: ".SF NS Text", path: "SFNSText-Bold.otf")
-    internal static let heavy = FontConvertible(name: ".SFNSText-Heavy", family: ".SF NS Text", path: "SFNSText-Heavy.otf")
-    internal static let regular = FontConvertible(name: ".SFNSText-Regular", family: ".SF NS Text", path: "SFNSText-Regular.otf")
-    internal static let all: [FontConvertible] = [bold, heavy, regular]
+    internal static let bold = MyFontConvertible(name: ".SFNSText-Bold", family: ".SF NS Text", path: "SFNSText-Bold.otf")
+    internal static let heavy = MyFontConvertible(name: ".SFNSText-Heavy", family: ".SF NS Text", path: "SFNSText-Heavy.otf")
+    internal static let regular = MyFontConvertible(name: ".SFNSText-Regular", family: ".SF NS Text", path: "SFNSText-Regular.otf")
+    internal static let all: [MyFontConvertible] = [bold, heavy, regular]
   }
   internal enum Avenir {
-    internal static let black = FontConvertible(name: "Avenir-Black", family: "Avenir", path: "Avenir.ttc")
-    internal static let blackOblique = FontConvertible(name: "Avenir-BlackOblique", family: "Avenir", path: "Avenir.ttc")
-    internal static let book = FontConvertible(name: "Avenir-Book", family: "Avenir", path: "Avenir.ttc")
-    internal static let bookOblique = FontConvertible(name: "Avenir-BookOblique", family: "Avenir", path: "Avenir.ttc")
-    internal static let heavy = FontConvertible(name: "Avenir-Heavy", family: "Avenir", path: "Avenir.ttc")
-    internal static let heavyOblique = FontConvertible(name: "Avenir-HeavyOblique", family: "Avenir", path: "Avenir.ttc")
-    internal static let light = FontConvertible(name: "Avenir-Light", family: "Avenir", path: "Avenir.ttc")
-    internal static let lightOblique = FontConvertible(name: "Avenir-LightOblique", family: "Avenir", path: "Avenir.ttc")
-    internal static let medium = FontConvertible(name: "Avenir-Medium", family: "Avenir", path: "Avenir.ttc")
-    internal static let mediumOblique = FontConvertible(name: "Avenir-MediumOblique", family: "Avenir", path: "Avenir.ttc")
-    internal static let oblique = FontConvertible(name: "Avenir-Oblique", family: "Avenir", path: "Avenir.ttc")
-    internal static let roman = FontConvertible(name: "Avenir-Roman", family: "Avenir", path: "Avenir.ttc")
-    internal static let all: [FontConvertible] = [black, blackOblique, book, bookOblique, heavy, heavyOblique, light, lightOblique, medium, mediumOblique, oblique, roman]
+    internal static let black = MyFontConvertible(name: "Avenir-Black", family: "Avenir", path: "Avenir.ttc")
+    internal static let blackOblique = MyFontConvertible(name: "Avenir-BlackOblique", family: "Avenir", path: "Avenir.ttc")
+    internal static let book = MyFontConvertible(name: "Avenir-Book", family: "Avenir", path: "Avenir.ttc")
+    internal static let bookOblique = MyFontConvertible(name: "Avenir-BookOblique", family: "Avenir", path: "Avenir.ttc")
+    internal static let heavy = MyFontConvertible(name: "Avenir-Heavy", family: "Avenir", path: "Avenir.ttc")
+    internal static let heavyOblique = MyFontConvertible(name: "Avenir-HeavyOblique", family: "Avenir", path: "Avenir.ttc")
+    internal static let light = MyFontConvertible(name: "Avenir-Light", family: "Avenir", path: "Avenir.ttc")
+    internal static let lightOblique = MyFontConvertible(name: "Avenir-LightOblique", family: "Avenir", path: "Avenir.ttc")
+    internal static let medium = MyFontConvertible(name: "Avenir-Medium", family: "Avenir", path: "Avenir.ttc")
+    internal static let mediumOblique = MyFontConvertible(name: "Avenir-MediumOblique", family: "Avenir", path: "Avenir.ttc")
+    internal static let oblique = MyFontConvertible(name: "Avenir-Oblique", family: "Avenir", path: "Avenir.ttc")
+    internal static let roman = MyFontConvertible(name: "Avenir-Roman", family: "Avenir", path: "Avenir.ttc")
+    internal static let all: [MyFontConvertible] = [black, blackOblique, book, bookOblique, heavy, heavyOblique, light, lightOblique, medium, mediumOblique, oblique, roman]
   }
   internal enum ZapfDingbats {
-    internal static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
-    internal static let all: [FontConvertible] = [regular]
+    internal static let regular = MyFontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
+    internal static let all: [MyFontConvertible] = [regular]
   }
   internal enum Public {
-    internal static let `internal` = FontConvertible(name: "private", family: "public", path: "class.ttf")
-    internal static let all: [FontConvertible] = [`internal`]
+    internal static let `internal` = MyFontConvertible(name: "private", family: "public", path: "class.ttf")
+    internal static let all: [MyFontConvertible] = [`internal`]
   }
-  internal static let allCustomFonts: [FontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, ZapfDingbats.all, Public.all].flatMap { $0 }
+  internal static let allCustomFonts: [MyFontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, ZapfDingbats.all, Public.all].flatMap { $0 }
   internal static func registerAllCustomFonts() {
     allCustomFonts.forEach { $0.register() }
   }
@@ -62,10 +64,16 @@ internal enum CustomFamily {
 
 // MARK: - Implementation Details
 
-internal struct FontConvertible {
+internal struct MyFontConvertible {
   internal let name: String
   internal let family: String
   internal let path: String
+
+  #if os(OSX)
+  internal typealias Font = NSFont
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  internal typealias Font = UIFont
+  #endif
 
   internal func font(size: CGFloat) -> Font! {
     return Font(font: self, size: size)
@@ -83,8 +91,8 @@ internal struct FontConvertible {
   }
 }
 
-internal extension Font {
-  convenience init!(font: FontConvertible, size: CGFloat) {
+internal extension MyFontConvertible.Font {
+  convenience init?(font: MyFontConvertible, size: CGFloat) {
     #if os(iOS) || os(tvOS) || os(watchOS)
     if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
       font.register()

--- a/Tests/Fixtures/Generated/Fonts/swift4/defaults-customName.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift4/defaults-customName.swift
@@ -2,9 +2,9 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 #if os(OSX)
-import AppKit.NSFont
+  import AppKit.NSFont
 #elseif os(iOS) || os(tvOS) || os(watchOS)
-import UIKit.UIFont
+  import UIKit.UIFont
 #endif
 
 // Deprecated typealiases

--- a/Tests/Fixtures/Generated/Fonts/swift4/defaults-preservePath.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift4/defaults-preservePath.swift
@@ -2,9 +2,9 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 #if os(OSX)
-import AppKit.NSFont
+  import AppKit.NSFont
 #elseif os(iOS) || os(tvOS) || os(watchOS)
-import UIKit.UIFont
+  import UIKit.UIFont
 #endif
 
 // Deprecated typealiases

--- a/Tests/Fixtures/Generated/Fonts/swift4/defaults-preservePath.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift4/defaults-preservePath.swift
@@ -2,12 +2,14 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 #if os(OSX)
-  import AppKit.NSFont
-  internal typealias Font = NSFont
+import AppKit.NSFont
 #elseif os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIFont
-  internal typealias Font = UIFont
+import UIKit.UIFont
 #endif
+
+// Deprecated typealiases
+@available(*, deprecated, renamed: "FontConvertible.Font", message: "This typealias will be removed in SwiftGen 7.0")
+internal typealias Font = FontConvertible.Font
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
@@ -67,6 +69,12 @@ internal struct FontConvertible {
   internal let family: String
   internal let path: String
 
+  #if os(OSX)
+  internal typealias Font = NSFont
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  internal typealias Font = UIFont
+  #endif
+
   internal func font(size: CGFloat) -> Font! {
     return Font(font: self, size: size)
   }
@@ -83,8 +91,8 @@ internal struct FontConvertible {
   }
 }
 
-internal extension Font {
-  convenience init!(font: FontConvertible, size: CGFloat) {
+internal extension FontConvertible.Font {
+  convenience init?(font: FontConvertible, size: CGFloat) {
     #if os(iOS) || os(tvOS) || os(watchOS)
     if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
       font.register()

--- a/Tests/Fixtures/Generated/Fonts/swift4/defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift4/defaults-publicAccess.swift
@@ -2,9 +2,9 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 #if os(OSX)
-import AppKit.NSFont
+  import AppKit.NSFont
 #elseif os(iOS) || os(tvOS) || os(watchOS)
-import UIKit.UIFont
+  import UIKit.UIFont
 #endif
 
 // Deprecated typealiases

--- a/Tests/Fixtures/Generated/Fonts/swift4/defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift4/defaults-publicAccess.swift
@@ -2,12 +2,14 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 #if os(OSX)
-  import AppKit.NSFont
-  public typealias Font = NSFont
+import AppKit.NSFont
 #elseif os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIFont
-  public typealias Font = UIFont
+import UIKit.UIFont
 #endif
+
+// Deprecated typealiases
+@available(*, deprecated, renamed: "FontConvertible.Font", message: "This typealias will be removed in SwiftGen 7.0")
+public typealias Font = FontConvertible.Font
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
@@ -67,6 +69,12 @@ public struct FontConvertible {
   public let family: String
   public let path: String
 
+  #if os(OSX)
+  public typealias Font = NSFont
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  public typealias Font = UIFont
+  #endif
+
   public func font(size: CGFloat) -> Font! {
     return Font(font: self, size: size)
   }
@@ -83,8 +91,8 @@ public struct FontConvertible {
   }
 }
 
-public extension Font {
-  convenience init!(font: FontConvertible, size: CGFloat) {
+public extension FontConvertible.Font {
+  convenience init?(font: FontConvertible, size: CGFloat) {
     #if os(iOS) || os(tvOS) || os(watchOS)
     if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
       font.register()

--- a/Tests/Fixtures/Generated/Fonts/swift4/defaults.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift4/defaults.swift
@@ -2,9 +2,9 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 #if os(OSX)
-import AppKit.NSFont
+  import AppKit.NSFont
 #elseif os(iOS) || os(tvOS) || os(watchOS)
-import UIKit.UIFont
+  import UIKit.UIFont
 #endif
 
 // Deprecated typealiases

--- a/Tests/Fixtures/Generated/Fonts/swift4/defaults.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift4/defaults.swift
@@ -2,12 +2,14 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 #if os(OSX)
-  import AppKit.NSFont
-  internal typealias Font = NSFont
+import AppKit.NSFont
 #elseif os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIFont
-  internal typealias Font = UIFont
+import UIKit.UIFont
 #endif
+
+// Deprecated typealiases
+@available(*, deprecated, renamed: "FontConvertible.Font", message: "This typealias will be removed in SwiftGen 7.0")
+internal typealias Font = FontConvertible.Font
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
@@ -67,6 +69,12 @@ internal struct FontConvertible {
   internal let family: String
   internal let path: String
 
+  #if os(OSX)
+  internal typealias Font = NSFont
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  internal typealias Font = UIFont
+  #endif
+
   internal func font(size: CGFloat) -> Font! {
     return Font(font: self, size: size)
   }
@@ -83,8 +91,8 @@ internal struct FontConvertible {
   }
 }
 
-internal extension Font {
-  convenience init!(font: FontConvertible, size: CGFloat) {
+internal extension FontConvertible.Font {
+  convenience init?(font: FontConvertible, size: CGFloat) {
     #if os(iOS) || os(tvOS) || os(watchOS)
     if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
       font.register()

--- a/Tests/Fixtures/Generated/Fonts/swift5/defaults-customName.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift5/defaults-customName.swift
@@ -2,12 +2,14 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 #if os(OSX)
-  import AppKit.NSFont
-  internal typealias Font = NSFont
+import AppKit.NSFont
 #elseif os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIFont
-  internal typealias Font = UIFont
+import UIKit.UIFont
 #endif
+
+// Deprecated typealiases
+@available(*, deprecated, renamed: "MyFontConvertible.Font", message: "This typealias will be removed in SwiftGen 7.0")
+internal typealias MyFont = MyFontConvertible.Font
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
@@ -17,42 +19,42 @@
 // swiftlint:disable identifier_name line_length type_body_length
 internal enum CustomFamily {
   internal enum SFNSDisplay {
-    internal static let black = FontConvertible(name: ".SFNSDisplay-Black", family: ".SF NS Display", path: "SFNSDisplay-Black.otf")
-    internal static let bold = FontConvertible(name: ".SFNSDisplay-Bold", family: ".SF NS Display", path: "SFNSDisplay-Bold.otf")
-    internal static let heavy = FontConvertible(name: ".SFNSDisplay-Heavy", family: ".SF NS Display", path: "SFNSDisplay-Heavy.otf")
-    internal static let regular = FontConvertible(name: ".SFNSDisplay-Regular", family: ".SF NS Display", path: "SFNSDisplay-Regular.otf")
-    internal static let all: [FontConvertible] = [black, bold, heavy, regular]
+    internal static let black = MyFontConvertible(name: ".SFNSDisplay-Black", family: ".SF NS Display", path: "SFNSDisplay-Black.otf")
+    internal static let bold = MyFontConvertible(name: ".SFNSDisplay-Bold", family: ".SF NS Display", path: "SFNSDisplay-Bold.otf")
+    internal static let heavy = MyFontConvertible(name: ".SFNSDisplay-Heavy", family: ".SF NS Display", path: "SFNSDisplay-Heavy.otf")
+    internal static let regular = MyFontConvertible(name: ".SFNSDisplay-Regular", family: ".SF NS Display", path: "SFNSDisplay-Regular.otf")
+    internal static let all: [MyFontConvertible] = [black, bold, heavy, regular]
   }
   internal enum SFNSText {
-    internal static let bold = FontConvertible(name: ".SFNSText-Bold", family: ".SF NS Text", path: "SFNSText-Bold.otf")
-    internal static let heavy = FontConvertible(name: ".SFNSText-Heavy", family: ".SF NS Text", path: "SFNSText-Heavy.otf")
-    internal static let regular = FontConvertible(name: ".SFNSText-Regular", family: ".SF NS Text", path: "SFNSText-Regular.otf")
-    internal static let all: [FontConvertible] = [bold, heavy, regular]
+    internal static let bold = MyFontConvertible(name: ".SFNSText-Bold", family: ".SF NS Text", path: "SFNSText-Bold.otf")
+    internal static let heavy = MyFontConvertible(name: ".SFNSText-Heavy", family: ".SF NS Text", path: "SFNSText-Heavy.otf")
+    internal static let regular = MyFontConvertible(name: ".SFNSText-Regular", family: ".SF NS Text", path: "SFNSText-Regular.otf")
+    internal static let all: [MyFontConvertible] = [bold, heavy, regular]
   }
   internal enum Avenir {
-    internal static let black = FontConvertible(name: "Avenir-Black", family: "Avenir", path: "Avenir.ttc")
-    internal static let blackOblique = FontConvertible(name: "Avenir-BlackOblique", family: "Avenir", path: "Avenir.ttc")
-    internal static let book = FontConvertible(name: "Avenir-Book", family: "Avenir", path: "Avenir.ttc")
-    internal static let bookOblique = FontConvertible(name: "Avenir-BookOblique", family: "Avenir", path: "Avenir.ttc")
-    internal static let heavy = FontConvertible(name: "Avenir-Heavy", family: "Avenir", path: "Avenir.ttc")
-    internal static let heavyOblique = FontConvertible(name: "Avenir-HeavyOblique", family: "Avenir", path: "Avenir.ttc")
-    internal static let light = FontConvertible(name: "Avenir-Light", family: "Avenir", path: "Avenir.ttc")
-    internal static let lightOblique = FontConvertible(name: "Avenir-LightOblique", family: "Avenir", path: "Avenir.ttc")
-    internal static let medium = FontConvertible(name: "Avenir-Medium", family: "Avenir", path: "Avenir.ttc")
-    internal static let mediumOblique = FontConvertible(name: "Avenir-MediumOblique", family: "Avenir", path: "Avenir.ttc")
-    internal static let oblique = FontConvertible(name: "Avenir-Oblique", family: "Avenir", path: "Avenir.ttc")
-    internal static let roman = FontConvertible(name: "Avenir-Roman", family: "Avenir", path: "Avenir.ttc")
-    internal static let all: [FontConvertible] = [black, blackOblique, book, bookOblique, heavy, heavyOblique, light, lightOblique, medium, mediumOblique, oblique, roman]
+    internal static let black = MyFontConvertible(name: "Avenir-Black", family: "Avenir", path: "Avenir.ttc")
+    internal static let blackOblique = MyFontConvertible(name: "Avenir-BlackOblique", family: "Avenir", path: "Avenir.ttc")
+    internal static let book = MyFontConvertible(name: "Avenir-Book", family: "Avenir", path: "Avenir.ttc")
+    internal static let bookOblique = MyFontConvertible(name: "Avenir-BookOblique", family: "Avenir", path: "Avenir.ttc")
+    internal static let heavy = MyFontConvertible(name: "Avenir-Heavy", family: "Avenir", path: "Avenir.ttc")
+    internal static let heavyOblique = MyFontConvertible(name: "Avenir-HeavyOblique", family: "Avenir", path: "Avenir.ttc")
+    internal static let light = MyFontConvertible(name: "Avenir-Light", family: "Avenir", path: "Avenir.ttc")
+    internal static let lightOblique = MyFontConvertible(name: "Avenir-LightOblique", family: "Avenir", path: "Avenir.ttc")
+    internal static let medium = MyFontConvertible(name: "Avenir-Medium", family: "Avenir", path: "Avenir.ttc")
+    internal static let mediumOblique = MyFontConvertible(name: "Avenir-MediumOblique", family: "Avenir", path: "Avenir.ttc")
+    internal static let oblique = MyFontConvertible(name: "Avenir-Oblique", family: "Avenir", path: "Avenir.ttc")
+    internal static let roman = MyFontConvertible(name: "Avenir-Roman", family: "Avenir", path: "Avenir.ttc")
+    internal static let all: [MyFontConvertible] = [black, blackOblique, book, bookOblique, heavy, heavyOblique, light, lightOblique, medium, mediumOblique, oblique, roman]
   }
   internal enum ZapfDingbats {
-    internal static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
-    internal static let all: [FontConvertible] = [regular]
+    internal static let regular = MyFontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
+    internal static let all: [MyFontConvertible] = [regular]
   }
   internal enum Public {
-    internal static let `internal` = FontConvertible(name: "private", family: "public", path: "class.ttf")
-    internal static let all: [FontConvertible] = [`internal`]
+    internal static let `internal` = MyFontConvertible(name: "private", family: "public", path: "class.ttf")
+    internal static let all: [MyFontConvertible] = [`internal`]
   }
-  internal static let allCustomFonts: [FontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, ZapfDingbats.all, Public.all].flatMap { $0 }
+  internal static let allCustomFonts: [MyFontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, ZapfDingbats.all, Public.all].flatMap { $0 }
   internal static func registerAllCustomFonts() {
     allCustomFonts.forEach { $0.register() }
   }
@@ -61,10 +63,16 @@ internal enum CustomFamily {
 
 // MARK: - Implementation Details
 
-internal struct FontConvertible {
+internal struct MyFontConvertible {
   internal let name: String
   internal let family: String
   internal let path: String
+
+  #if os(OSX)
+  internal typealias Font = NSFont
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  internal typealias Font = UIFont
+  #endif
 
   internal func font(size: CGFloat) -> Font {
     guard let font = Font(font: self, size: size) else {
@@ -85,8 +93,8 @@ internal struct FontConvertible {
   }
 }
 
-internal extension Font {
-  convenience init?(font: FontConvertible, size: CGFloat) {
+internal extension MyFontConvertible.Font {
+  convenience init?(font: MyFontConvertible, size: CGFloat) {
     #if os(iOS) || os(tvOS) || os(watchOS)
     if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
       font.register()

--- a/Tests/Fixtures/Generated/Fonts/swift5/defaults-customName.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift5/defaults-customName.swift
@@ -2,9 +2,9 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 #if os(OSX)
-import AppKit.NSFont
+  import AppKit.NSFont
 #elseif os(iOS) || os(tvOS) || os(watchOS)
-import UIKit.UIFont
+  import UIKit.UIFont
 #endif
 
 // Deprecated typealiases

--- a/Tests/Fixtures/Generated/Fonts/swift5/defaults-preservePath.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift5/defaults-preservePath.swift
@@ -2,12 +2,14 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 #if os(OSX)
-  import AppKit.NSFont
-  internal typealias Font = NSFont
+import AppKit.NSFont
 #elseif os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIFont
-  internal typealias Font = UIFont
+import UIKit.UIFont
 #endif
+
+// Deprecated typealiases
+@available(*, deprecated, renamed: "FontConvertible.Font", message: "This typealias will be removed in SwiftGen 7.0")
+internal typealias Font = FontConvertible.Font
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
@@ -66,6 +68,12 @@ internal struct FontConvertible {
   internal let family: String
   internal let path: String
 
+  #if os(OSX)
+  internal typealias Font = NSFont
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  internal typealias Font = UIFont
+  #endif
+
   internal func font(size: CGFloat) -> Font {
     guard let font = Font(font: self, size: size) else {
       fatalError("Unabble to initialize font '\(name)' (\(family))")
@@ -85,7 +93,7 @@ internal struct FontConvertible {
   }
 }
 
-internal extension Font {
+internal extension FontConvertible.Font {
   convenience init?(font: FontConvertible, size: CGFloat) {
     #if os(iOS) || os(tvOS) || os(watchOS)
     if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {

--- a/Tests/Fixtures/Generated/Fonts/swift5/defaults-preservePath.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift5/defaults-preservePath.swift
@@ -2,9 +2,9 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 #if os(OSX)
-import AppKit.NSFont
+  import AppKit.NSFont
 #elseif os(iOS) || os(tvOS) || os(watchOS)
-import UIKit.UIFont
+  import UIKit.UIFont
 #endif
 
 // Deprecated typealiases

--- a/Tests/Fixtures/Generated/Fonts/swift5/defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift5/defaults-publicAccess.swift
@@ -2,12 +2,14 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 #if os(OSX)
-  import AppKit.NSFont
-  public typealias Font = NSFont
+import AppKit.NSFont
 #elseif os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIFont
-  public typealias Font = UIFont
+import UIKit.UIFont
 #endif
+
+// Deprecated typealiases
+@available(*, deprecated, renamed: "FontConvertible.Font", message: "This typealias will be removed in SwiftGen 7.0")
+public typealias Font = FontConvertible.Font
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
@@ -66,6 +68,12 @@ public struct FontConvertible {
   public let family: String
   public let path: String
 
+  #if os(OSX)
+  public typealias Font = NSFont
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  public typealias Font = UIFont
+  #endif
+
   public func font(size: CGFloat) -> Font {
     guard let font = Font(font: self, size: size) else {
       fatalError("Unabble to initialize font '\(name)' (\(family))")
@@ -85,7 +93,7 @@ public struct FontConvertible {
   }
 }
 
-public extension Font {
+public extension FontConvertible.Font {
   convenience init?(font: FontConvertible, size: CGFloat) {
     #if os(iOS) || os(tvOS) || os(watchOS)
     if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {

--- a/Tests/Fixtures/Generated/Fonts/swift5/defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift5/defaults-publicAccess.swift
@@ -2,9 +2,9 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 #if os(OSX)
-import AppKit.NSFont
+  import AppKit.NSFont
 #elseif os(iOS) || os(tvOS) || os(watchOS)
-import UIKit.UIFont
+  import UIKit.UIFont
 #endif
 
 // Deprecated typealiases

--- a/Tests/Fixtures/Generated/Fonts/swift5/defaults.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift5/defaults.swift
@@ -2,12 +2,14 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 #if os(OSX)
-  import AppKit.NSFont
-  internal typealias Font = NSFont
+import AppKit.NSFont
 #elseif os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIFont
-  internal typealias Font = UIFont
+import UIKit.UIFont
 #endif
+
+// Deprecated typealiases
+@available(*, deprecated, renamed: "FontConvertible.Font", message: "This typealias will be removed in SwiftGen 7.0")
+internal typealias Font = FontConvertible.Font
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
@@ -66,6 +68,12 @@ internal struct FontConvertible {
   internal let family: String
   internal let path: String
 
+  #if os(OSX)
+  internal typealias Font = NSFont
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  internal typealias Font = UIFont
+  #endif
+
   internal func font(size: CGFloat) -> Font {
     guard let font = Font(font: self, size: size) else {
       fatalError("Unabble to initialize font '\(name)' (\(family))")
@@ -85,7 +93,7 @@ internal struct FontConvertible {
   }
 }
 
-internal extension Font {
+internal extension FontConvertible.Font {
   convenience init?(font: FontConvertible, size: CGFloat) {
     #if os(iOS) || os(tvOS) || os(watchOS)
     if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {

--- a/Tests/Fixtures/Generated/Fonts/swift5/defaults.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift5/defaults.swift
@@ -2,9 +2,9 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 #if os(OSX)
-import AppKit.NSFont
+  import AppKit.NSFont
 #elseif os(iOS) || os(tvOS) || os(watchOS)
-import UIKit.UIFont
+  import UIKit.UIFont
 #endif
 
 // Deprecated typealiases

--- a/Tests/TemplatesTests/FontsTests.swift
+++ b/Tests/TemplatesTests/FontsTests.swift
@@ -22,7 +22,14 @@ final class FontsTests: XCTestCase {
         suffix: ""
       ),
       (
-        context: try StencilContext.enrich(context: context, parameters: ["enumName=CustomFamily"]),
+        context: try StencilContext.enrich(
+          context: context,
+          parameters: [
+            "enumName=CustomFamily",
+            "fontTypeName=MyFontConvertible",
+            "fontAliasName=MyFont"
+          ]
+        ),
         suffix: "-customName"
       ),
       (

--- a/templates/fonts/swift4.stencil
+++ b/templates/fonts/swift4.stencil
@@ -5,9 +5,9 @@
 {% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
 {% set fontType %}{{param.fontTypeName|default:"FontConvertible"}}{% endset %}
 #if os(OSX)
-import AppKit.NSFont
+  import AppKit.NSFont
 #elseif os(iOS) || os(tvOS) || os(watchOS)
-import UIKit.UIFont
+  import UIKit.UIFont
 #endif
 
 // Deprecated typealiases

--- a/templates/fonts/swift4.stencil
+++ b/templates/fonts/swift4.stencil
@@ -3,13 +3,16 @@
 
 {% if families %}
 {% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+{% set fontType %}{{param.fontTypeName|default:"FontConvertible"}}{% endset %}
 #if os(OSX)
-  import AppKit.NSFont
-  {{accessModifier}} typealias Font = NSFont
+import AppKit.NSFont
 #elseif os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIFont
-  {{accessModifier}} typealias Font = UIFont
+import UIKit.UIFont
 #endif
+
+// Deprecated typealiases
+@available(*, deprecated, renamed: "{{fontType}}.Font", message: "This typealias will be removed in SwiftGen 7.0")
+{{accessModifier}} typealias {{param.fontAliasName|default:"Font"}} = {{fontType}}.Font
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
@@ -29,12 +32,12 @@
   {% for family in families %}
   {{accessModifier}} enum {{family.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
     {% for font in family.fonts %}
-    {{accessModifier}} static let {{font.style|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = FontConvertible(name: "{{font.name}}", family: "{{family.name}}", path: "{% call transformPath font.path %}")
+    {{accessModifier}} static let {{font.style|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{fontType}}(name: "{{font.name}}", family: "{{family.name}}", path: "{% call transformPath font.path %}")
     {% endfor %}
-    {{accessModifier}} static let all: [FontConvertible] = [{% for font in family.fonts %}{{font.style|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{{ ", " if not forloop.last }}{% endfor %}]
+    {{accessModifier}} static let all: [{{fontType}}] = [{% for font in family.fonts %}{{font.style|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{{ ", " if not forloop.last }}{% endfor %}]
   }
   {% endfor %}
-  {{accessModifier}} static let allCustomFonts: [FontConvertible] = [{% for family in families %}{{family.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}.all{{ ", " if not forloop.last }}{% endfor %}].flatMap { $0 }
+  {{accessModifier}} static let allCustomFonts: [{{fontType}}] = [{% for family in families %}{{family.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}.all{{ ", " if not forloop.last }}{% endfor %}].flatMap { $0 }
   {{accessModifier}} static func registerAllCustomFonts() {
     allCustomFonts.forEach { $0.register() }
   }
@@ -43,10 +46,16 @@
 
 // MARK: - Implementation Details
 
-{{accessModifier}} struct FontConvertible {
+{{accessModifier}} struct {{fontType}} {
   {{accessModifier}} let name: String
   {{accessModifier}} let family: String
   {{accessModifier}} let path: String
+
+  #if os(OSX)
+  {{accessModifier}} typealias Font = NSFont
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  {{accessModifier}} typealias Font = UIFont
+  #endif
 
   {{accessModifier}} func font(size: CGFloat) -> Font! {
     return Font(font: self, size: size)
@@ -64,8 +73,8 @@
   }
 }
 
-{{accessModifier}} extension Font {
-  convenience init!(font: FontConvertible, size: CGFloat) {
+{{accessModifier}} extension {{fontType}}.Font {
+  convenience init?(font: {{fontType}}, size: CGFloat) {
     #if os(iOS) || os(tvOS) || os(watchOS)
     if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
       font.register()

--- a/templates/fonts/swift5.stencil
+++ b/templates/fonts/swift5.stencil
@@ -5,9 +5,9 @@
 {% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
 {% set fontType %}{{param.fontTypeName|default:"FontConvertible"}}{% endset %}
 #if os(OSX)
-import AppKit.NSFont
+  import AppKit.NSFont
 #elseif os(iOS) || os(tvOS) || os(watchOS)
-import UIKit.UIFont
+  import UIKit.UIFont
 #endif
 
 // Deprecated typealiases

--- a/templates/fonts/swift5.stencil
+++ b/templates/fonts/swift5.stencil
@@ -3,13 +3,16 @@
 
 {% if families %}
 {% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+{% set fontType %}{{param.fontTypeName|default:"FontConvertible"}}{% endset %}
 #if os(OSX)
-  import AppKit.NSFont
-  {{accessModifier}} typealias Font = NSFont
+import AppKit.NSFont
 #elseif os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIFont
-  {{accessModifier}} typealias Font = UIFont
+import UIKit.UIFont
 #endif
+
+// Deprecated typealiases
+@available(*, deprecated, renamed: "{{fontType}}.Font", message: "This typealias will be removed in SwiftGen 7.0")
+{{accessModifier}} typealias {{param.fontAliasName|default:"Font"}} = {{fontType}}.Font
 
 // swiftlint:disable superfluous_disable_command
 // swiftlint:disable file_length
@@ -28,12 +31,12 @@
   {% for family in families %}
   {{accessModifier}} enum {{family.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
     {% for font in family.fonts %}
-    {{accessModifier}} static let {{font.style|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = FontConvertible(name: "{{font.name}}", family: "{{family.name}}", path: "{% call transformPath font.path %}")
+    {{accessModifier}} static let {{font.style|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{fontType}}(name: "{{font.name}}", family: "{{family.name}}", path: "{% call transformPath font.path %}")
     {% endfor %}
-    {{accessModifier}} static let all: [FontConvertible] = [{% for font in family.fonts %}{{font.style|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{{ ", " if not forloop.last }}{% endfor %}]
+    {{accessModifier}} static let all: [{{fontType}}] = [{% for font in family.fonts %}{{font.style|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{{ ", " if not forloop.last }}{% endfor %}]
   }
   {% endfor %}
-  {{accessModifier}} static let allCustomFonts: [FontConvertible] = [{% for family in families %}{{family.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}.all{{ ", " if not forloop.last }}{% endfor %}].flatMap { $0 }
+  {{accessModifier}} static let allCustomFonts: [{{fontType}}] = [{% for family in families %}{{family.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}.all{{ ", " if not forloop.last }}{% endfor %}].flatMap { $0 }
   {{accessModifier}} static func registerAllCustomFonts() {
     allCustomFonts.forEach { $0.register() }
   }
@@ -42,10 +45,16 @@
 
 // MARK: - Implementation Details
 
-{{accessModifier}} struct FontConvertible {
+{{accessModifier}} struct {{fontType}} {
   {{accessModifier}} let name: String
   {{accessModifier}} let family: String
   {{accessModifier}} let path: String
+
+  #if os(OSX)
+  {{accessModifier}} typealias Font = NSFont
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  {{accessModifier}} typealias Font = UIFont
+  #endif
 
   {{accessModifier}} func font(size: CGFloat) -> Font {
     guard let font = Font(font: self, size: size) else {
@@ -66,8 +75,8 @@
   }
 }
 
-{{accessModifier}} extension Font {
-  convenience init?(font: FontConvertible, size: CGFloat) {
+{{accessModifier}} extension {{fontType}}.Font {
+  convenience init?(font: {{fontType}}, size: CGFloat) {
     #if os(iOS) || os(tvOS) || os(watchOS)
     if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
       font.register()


### PR DESCRIPTION
Fixes #647.

Mirrors the implementation from the `xcassets` templates.
