### PR TITLE
Fix breaking swift when installing via Homebrew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ _None_
 * Plist/JSON/YAML: Fix issue with homogeneous `Array`s in the Inline templates (such as `[String`]).  
   [#687](https://github.com/SwiftGen/SwiftGen/pull/687)
   [@fjtrujy](https://github.com/fjtrujy)
+* Avoid breaking the system swift installation when installing SwiftGen via Homebrew on macOS 10.14.4 or higher.  
+  [David Jennes](https://github.com/djbe)
+  [#686](https://github.com/SwiftGen/SwiftGen/issue/686)
+  [#730](https://github.com/SwiftGen/SwiftGen/pull/730)
 
 ### Internal Changes
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ $ mint install SwiftGen/SwiftGen
 ```
 ---
 </details>
-
 <details>
 <summary><strong>Compile from source</strong> <em>(only recommended if you need features from the `stable` branch or want to test a PR)</em></summary>
 
@@ -165,6 +164,16 @@ Or add the path to the `bin` folder to your `$PATH` and invoke `swiftgen` direct
 
 ---
 </details>
+
+### Known Installation Issues On macOS Before 10.14.4
+
+Starting with [SwiftGen 6.2.1](https://github.com/SwiftGen/SwiftGen/releases/6.2.1), if you get an error similar to `dyld: Symbol not found: _$s11SubSequenceSlTl` when running SwiftGen, you'll need to install the [Swift 5 Runtime Support for Command Line Tools](https://support.apple.com/kb/DL1998).
+
+Alternatively, you can:
+
+- Update to macOS 10.14.4 or later
+- Install Xcode 10.2 or later at `/Applications/Xcode.app`
+- Rebuild SwiftGen from source using Xcode 10.2 or later
 
 ## Configuration File
 

--- a/Rakefile
+++ b/Rakefile
@@ -77,6 +77,15 @@ namespace :cli do
                 %(cp -fR "#{generated_bundle_path}/Frameworks/" "#{fmkdir}")
               ], task, 'copy_frameworks')
 
+    # Hack: remove swift libraries on 10.14.4 or higher, to avoid issues with brew
+    macOS_version = Gem::Version.new(`sw_vers -productVersion`)
+    if macOS_version >= Gem::Version.new('10.14.4')
+      Utils.print_header "Removing bundled swift libraries from #{fmkdir}"
+      Utils.run([
+                  %(rm "#{fmkdir}"/libswift*.dylib)
+                ], task, 'remove_bundled_swift')
+    end
+
     Utils.print_header "Fixing binary's @rpath"
     Utils.run([
                 %(install_name_tool -delete_rpath "@executable_path/../Frameworks" "#{bindir}/#{BIN_NAME}"),


### PR DESCRIPTION
Fixes #686.

When installing via Homebrew, if we embed the Swift libraries, it'll symlink them into `/usr/local/lib`, which apparently breaks Swift itself on macOS 10.14.4 or higher.

For now, if we detect installation on such a macOS version, we'll delete our embedded swift libraries. At some later point, we should switch all installation methods to compilation via SPM, which avoids this issue altogether (see #723).