### PR TITLE
Deprecate plist `documents` in favour of `document`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
 
 _None_
 
+### Deprecations
+
+* JSON & Plist: if you wrote your own templates, know that the `documents` property of a file has been deprecated in favour of `document`. The old `documents` property will be removed in the next major release.  
+  [David Jennes](https://github.com/djbe)
+  [#702](https://github.com/SwiftGen/SwiftGen/pull/702)
+  [#732](https://github.com/SwiftGen/SwiftGen/pull/732)
+
 ### New Features
 
 _None_

--- a/Documentation/SwiftGenKit Contexts/plist.md
+++ b/Documentation/SwiftGenKit Contexts/plist.md
@@ -13,7 +13,7 @@ The output context has the following structure:
  - `files`: `Array` — List of files
     - `name`: `String` — Name of the file (without extension)
     - `path` : `String` — the path to the file, relative to the folder being scanned
-    - `documents`: `Array` — List of documents. Plist files will only have 1 document
+    - `document`: `Dictionary` - Describes the structure of the document
        - `data`: `Any` — The contents of the document
        - `metadata`: `Dictionary` — Describes the structure of the document
 
@@ -29,8 +29,8 @@ The metadata has the following properties:
 
 ```yaml
 files:
-- documents:
-  - data:
+- document:
+    data:
       UILaunchStoryboardName: "LaunchScreen"
       UIMainStoryboardFile: "Start"
       User Ambiguous Integer: true
@@ -74,8 +74,8 @@ files:
       type: "Dictionary"
   name: "Info"
   path: "Info.plist"
-- documents:
-  - data:
+- document:
+    data:
     - "Eggs"
     - "Bread"
     - "Milk"

--- a/Sources/SwiftGenKit/Stencil/JSONContext.swift
+++ b/Sources/SwiftGenKit/Stencil/JSONContext.swift
@@ -28,7 +28,7 @@ extension JSON.Parser {
       "name": file.name,
       "path": file.path.string,
       "document": document,
-      "documents": [document] // For legacy/compatibility reasons; will be removed in 7.0
+      "documents": [document] // Deprecated: remains for legacy/compatibility reasons; will be removed in 7.0
     ]
   }
 

--- a/Sources/SwiftGenKit/Stencil/PlistContext.swift
+++ b/Sources/SwiftGenKit/Stencil/PlistContext.swift
@@ -28,7 +28,7 @@ extension Plist.Parser {
       "name": file.name,
       "path": file.path.string,
       "document": document,
-      "documents": [document] // For legacy/compatibility reasons; will be removed in 7.0
+      "documents": [document] // Deprecated: remains for legacy/compatibility reasons; will be removed in 7.0
     ]
   }
 

--- a/Sources/SwiftGenKit/Stencil/PlistContext.swift
+++ b/Sources/SwiftGenKit/Stencil/PlistContext.swift
@@ -23,12 +23,12 @@ extension Plist.Parser {
   }
 
   private func map(file: Plist.File) -> [String: Any] {
-    [
+    let document = map(document: file.document)
+    return [
       "name": file.name,
       "path": file.path.string,
-      // Note: we wrap the document into a single-value array so that the structure of
-      // this context is identical to the one produced by the YAML parser
-      "documents": [map(document: file.document)]
+      "document": document,
+      "documents": [document] // For legacy/compatibility reasons; will be removed in 7.0
     ]
   }
 

--- a/Tests/Fixtures/StencilContexts/Plist/all.yaml
+++ b/Tests/Fixtures/StencilContexts/Plist/all.yaml
@@ -1,5 +1,137 @@
 files:
-- documents:
+- document:
+    data:
+      CFBundleDevelopmentRegion: "en"
+      CFBundleDisplayName: "${PRODUCT_NAME}"
+      CFBundleExecutable: "${EXECUTABLE_NAME}"
+      CFBundleIdentifier: "$(PRODUCT_BUNDLE_IDENTIFIER)"
+      CFBundleInfoDictionaryVersion: "6.0"
+      CFBundleName: "${PRODUCT_NAME}"
+      CFBundlePackageType: "APPL"
+      CFBundleShortVersionString: "1.2.0"
+      CFBundleSignature: "????"
+      CFBundleVersion: "0"
+      Fabric:
+        APIKey: "512345678900aaafffff"
+        Kits:
+        - KitInfo: {}
+          KitName: "Crashlytics"
+      ITSAppUsesNonExemptEncryption: false
+      LSRequiresIPhoneOS: true
+      NSAppTransportSecurity: {}
+      NSCameraUsageDescription: "24 Vision needs access to your camera for uploading
+        photos for caes, or for your profile picture."
+      NSPhotoLibraryUsageDescription: "24 Vision needs access to your photo library
+        for uploading photos for caes, or for your profile picture."
+      UIBackgroundModes:
+      - "remote-notification"
+      UILaunchStoryboardName: "LaunchScreen"
+      UIMainStoryboardFile: "Start"
+      UIRequiredDeviceCapabilities:
+      - "armv7"
+      UIRequiresFullScreen: true
+      UIStatusBarStyle: "UIStatusBarStyleDefault"
+      UISupportedInterfaceOrientations:
+      - "UIInterfaceOrientationPortrait"
+      - "UIInterfaceOrientationPortraitUpsideDown"
+      - "UIInterfaceOrientationLandscapeRight"
+      - "UIInterfaceOrientationLandscapeLeft"
+      UISupportedInterfaceOrientations~ipad:
+      - "UIInterfaceOrientationLandscapeLeft"
+      - "UIInterfaceOrientationLandscapeRight"
+      - "UIInterfaceOrientationPortraitUpsideDown"
+      - "UIInterfaceOrientationPortrait"
+      User Ambiguous Integer: true
+      User Boolean: false
+      User Date: 2018-05-05T03:39:26Z
+      User Float: 3.14e+0
+      User Integer: 5
+    metadata:
+      properties:
+        CFBundleDevelopmentRegion:
+          type: "String"
+        CFBundleDisplayName:
+          type: "String"
+        CFBundleExecutable:
+          type: "String"
+        CFBundleIdentifier:
+          type: "String"
+        CFBundleInfoDictionaryVersion:
+          type: "String"
+        CFBundleName:
+          type: "String"
+        CFBundlePackageType:
+          type: "String"
+        CFBundleShortVersionString:
+          type: "String"
+        CFBundleSignature:
+          type: "String"
+        CFBundleVersion:
+          type: "String"
+        Fabric:
+          properties:
+            APIKey:
+              type: "String"
+            Kits:
+              element:
+                items:
+                - properties:
+                    KitInfo:
+                      properties: {}
+                      type: "Dictionary"
+                    KitName:
+                      type: "String"
+                  type: "Dictionary"
+                type: "Dictionary"
+              type: "Array"
+          type: "Dictionary"
+        ITSAppUsesNonExemptEncryption:
+          type: "Bool"
+        LSRequiresIPhoneOS:
+          type: "Bool"
+        NSAppTransportSecurity:
+          properties: {}
+          type: "Dictionary"
+        NSCameraUsageDescription:
+          type: "String"
+        NSPhotoLibraryUsageDescription:
+          type: "String"
+        UIBackgroundModes:
+          element:
+            type: "String"
+          type: "Array"
+        UILaunchStoryboardName:
+          type: "String"
+        UIMainStoryboardFile:
+          type: "String"
+        UIRequiredDeviceCapabilities:
+          element:
+            type: "String"
+          type: "Array"
+        UIRequiresFullScreen:
+          type: "Bool"
+        UIStatusBarStyle:
+          type: "String"
+        UISupportedInterfaceOrientations:
+          element:
+            type: "String"
+          type: "Array"
+        UISupportedInterfaceOrientations~ipad:
+          element:
+            type: "String"
+          type: "Array"
+        User Ambiguous Integer:
+          type: "Bool"
+        User Boolean:
+          type: "Bool"
+        User Date:
+          type: "Date"
+        User Float:
+          type: "Double"
+        User Integer:
+          type: "Int"
+      type: "Dictionary"
+  documents:
   - data:
       CFBundleDevelopmentRegion: "en"
       CFBundleDisplayName: "${PRODUCT_NAME}"
@@ -133,7 +265,30 @@ files:
       type: "Dictionary"
   name: "Info"
   path: "Info.plist"
-- documents:
+- document:
+    data:
+      Environment: "development"
+      Names:
+      - "John"
+      - "Peter"
+      - "Nick"
+      Options:
+        Animation Style: "Party Mode"
+    metadata:
+      properties:
+        Environment:
+          type: "String"
+        Names:
+          element:
+            type: "String"
+          type: "Array"
+        Options:
+          properties:
+            Animation Style:
+              type: "String"
+          type: "Dictionary"
+      type: "Dictionary"
+  documents:
   - data:
       Environment: "development"
       Names:
@@ -158,7 +313,16 @@ files:
       type: "Dictionary"
   name: "configuration"
   path: "configuration.plist"
-- documents:
+- document:
+    data:
+    - "Eggs"
+    - "Bread"
+    - "Milk"
+    metadata:
+      element:
+        type: "String"
+      type: "Array"
+  documents:
   - data:
     - "Eggs"
     - "Bread"

--- a/Tests/Fixtures/StencilContexts/Plist/configuration.yaml
+++ b/Tests/Fixtures/StencilContexts/Plist/configuration.yaml
@@ -1,5 +1,28 @@
 files:
-- documents:
+- document:
+    data:
+      Environment: "development"
+      Names:
+      - "John"
+      - "Peter"
+      - "Nick"
+      Options:
+        Animation Style: "Party Mode"
+    metadata:
+      properties:
+        Environment:
+          type: "String"
+        Names:
+          element:
+            type: "String"
+          type: "Array"
+        Options:
+          properties:
+            Animation Style:
+              type: "String"
+          type: "Dictionary"
+      type: "Dictionary"
+  documents:
   - data:
       Environment: "development"
       Names:

--- a/Tests/Fixtures/StencilContexts/Plist/info.yaml
+++ b/Tests/Fixtures/StencilContexts/Plist/info.yaml
@@ -1,5 +1,137 @@
 files:
-- documents:
+- document:
+    data:
+      CFBundleDevelopmentRegion: "en"
+      CFBundleDisplayName: "${PRODUCT_NAME}"
+      CFBundleExecutable: "${EXECUTABLE_NAME}"
+      CFBundleIdentifier: "$(PRODUCT_BUNDLE_IDENTIFIER)"
+      CFBundleInfoDictionaryVersion: "6.0"
+      CFBundleName: "${PRODUCT_NAME}"
+      CFBundlePackageType: "APPL"
+      CFBundleShortVersionString: "1.2.0"
+      CFBundleSignature: "????"
+      CFBundleVersion: "0"
+      Fabric:
+        APIKey: "512345678900aaafffff"
+        Kits:
+        - KitInfo: {}
+          KitName: "Crashlytics"
+      ITSAppUsesNonExemptEncryption: false
+      LSRequiresIPhoneOS: true
+      NSAppTransportSecurity: {}
+      NSCameraUsageDescription: "24 Vision needs access to your camera for uploading
+        photos for caes, or for your profile picture."
+      NSPhotoLibraryUsageDescription: "24 Vision needs access to your photo library
+        for uploading photos for caes, or for your profile picture."
+      UIBackgroundModes:
+      - "remote-notification"
+      UILaunchStoryboardName: "LaunchScreen"
+      UIMainStoryboardFile: "Start"
+      UIRequiredDeviceCapabilities:
+      - "armv7"
+      UIRequiresFullScreen: true
+      UIStatusBarStyle: "UIStatusBarStyleDefault"
+      UISupportedInterfaceOrientations:
+      - "UIInterfaceOrientationPortrait"
+      - "UIInterfaceOrientationPortraitUpsideDown"
+      - "UIInterfaceOrientationLandscapeRight"
+      - "UIInterfaceOrientationLandscapeLeft"
+      UISupportedInterfaceOrientations~ipad:
+      - "UIInterfaceOrientationLandscapeLeft"
+      - "UIInterfaceOrientationLandscapeRight"
+      - "UIInterfaceOrientationPortraitUpsideDown"
+      - "UIInterfaceOrientationPortrait"
+      User Ambiguous Integer: true
+      User Boolean: false
+      User Date: 2018-05-05T03:39:26Z
+      User Float: 3.14e+0
+      User Integer: 5
+    metadata:
+      properties:
+        CFBundleDevelopmentRegion:
+          type: "String"
+        CFBundleDisplayName:
+          type: "String"
+        CFBundleExecutable:
+          type: "String"
+        CFBundleIdentifier:
+          type: "String"
+        CFBundleInfoDictionaryVersion:
+          type: "String"
+        CFBundleName:
+          type: "String"
+        CFBundlePackageType:
+          type: "String"
+        CFBundleShortVersionString:
+          type: "String"
+        CFBundleSignature:
+          type: "String"
+        CFBundleVersion:
+          type: "String"
+        Fabric:
+          properties:
+            APIKey:
+              type: "String"
+            Kits:
+              element:
+                items:
+                - properties:
+                    KitInfo:
+                      properties: {}
+                      type: "Dictionary"
+                    KitName:
+                      type: "String"
+                  type: "Dictionary"
+                type: "Dictionary"
+              type: "Array"
+          type: "Dictionary"
+        ITSAppUsesNonExemptEncryption:
+          type: "Bool"
+        LSRequiresIPhoneOS:
+          type: "Bool"
+        NSAppTransportSecurity:
+          properties: {}
+          type: "Dictionary"
+        NSCameraUsageDescription:
+          type: "String"
+        NSPhotoLibraryUsageDescription:
+          type: "String"
+        UIBackgroundModes:
+          element:
+            type: "String"
+          type: "Array"
+        UILaunchStoryboardName:
+          type: "String"
+        UIMainStoryboardFile:
+          type: "String"
+        UIRequiredDeviceCapabilities:
+          element:
+            type: "String"
+          type: "Array"
+        UIRequiresFullScreen:
+          type: "Bool"
+        UIStatusBarStyle:
+          type: "String"
+        UISupportedInterfaceOrientations:
+          element:
+            type: "String"
+          type: "Array"
+        UISupportedInterfaceOrientations~ipad:
+          element:
+            type: "String"
+          type: "Array"
+        User Ambiguous Integer:
+          type: "Bool"
+        User Boolean:
+          type: "Bool"
+        User Date:
+          type: "Date"
+        User Float:
+          type: "Double"
+        User Integer:
+          type: "Int"
+      type: "Dictionary"
+  documents:
   - data:
       CFBundleDevelopmentRegion: "en"
       CFBundleDisplayName: "${PRODUCT_NAME}"

--- a/Tests/Fixtures/StencilContexts/Plist/shopping-list.yaml
+++ b/Tests/Fixtures/StencilContexts/Plist/shopping-list.yaml
@@ -1,5 +1,14 @@
 files:
-- documents:
+- document:
+    data:
+    - "Eggs"
+    - "Bread"
+    - "Milk"
+    metadata:
+      element:
+        type: "String"
+      type: "Array"
+  documents:
   - data:
     - "Eggs"
     - "Bread"

--- a/templates/json/inline-swift4.stencil
+++ b/templates/json/inline-swift4.stencil
@@ -3,7 +3,6 @@
 
 {% if files %}
 {% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
-{% set documentPrefix %}{{param.documentName|default:"Document"}}{% endset %}
 import Foundation
 
 // swiftlint:disable superfluous_disable_command
@@ -11,16 +10,7 @@ import Foundation
 
 // MARK: - JSON Files
 {% macro fileBlock file %}
-  {% if file.documents.count > 1 %}
-  {% for document in file.documents %}
-  {% set documentName %}{{documentPrefix}}{{forloop.counter}}{% endset %}
-  {{accessModifier}} enum {{documentName|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call documentBlock file document %}{% endfilter %}
-  }
-  {% endfor %}
-  {% else %}
-  {% call documentBlock file file.documents.first %}
-  {% endif %}
+  {% call documentBlock file file.document %}
 {% endmacro %}
 {% macro documentBlock file document %}
   {% set rootType %}{% call typeBlock document.metadata %}{% endset %}

--- a/templates/json/inline-swift5.stencil
+++ b/templates/json/inline-swift5.stencil
@@ -3,7 +3,6 @@
 
 {% if files %}
 {% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
-{% set documentPrefix %}{{param.documentName|default:"Document"}}{% endset %}
 import Foundation
 
 // swiftlint:disable superfluous_disable_command
@@ -11,16 +10,7 @@ import Foundation
 
 // MARK: - JSON Files
 {% macro fileBlock file %}
-  {% if file.documents.count > 1 %}
-  {% for document in file.documents %}
-  {% set documentName %}{{documentPrefix}}{{forloop.counter}}{% endset %}
-  {{accessModifier}} enum {{documentName|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call documentBlock file document %}{% endfilter %}
-  }
-  {% endfor %}
-  {% else %}
-  {% call documentBlock file file.documents.first %}
-  {% endif %}
+  {% call documentBlock file file.document %}
 {% endmacro %}
 {% macro documentBlock file document %}
   {% set rootType %}{% call typeBlock document.metadata %}{% endset %}

--- a/templates/json/runtime-swift4.stencil
+++ b/templates/json/runtime-swift4.stencil
@@ -3,7 +3,6 @@
 
 {% if files %}
 {% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
-{% set documentPrefix %}{{param.documentName|default:"Document"}}{% endset %}
 import Foundation
 
 // swiftlint:disable superfluous_disable_command
@@ -11,16 +10,7 @@ import Foundation
 
 // MARK: - JSON Files
 {% macro fileBlock file %}
-  {% if file.documents.count > 1 %}
-  {% for document in file.documents %}
-  {% set documentName %}{{documentPrefix}}{{forloop.counter}}{% endset %}
-  {{accessModifier}} enum {{documentName|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call documentBlock file document %}{% endfilter %}
-  }
-  {% endfor %}
-  {% else %}
-  {% call documentBlock file file.documents.first %}
-  {% endif %}
+  {% call documentBlock file file.document %}
 {% endmacro %}
 {% macro documentBlock file document %}
   {% set rootType %}{% call typeBlock document.metadata %}{% endset %}

--- a/templates/json/runtime-swift5.stencil
+++ b/templates/json/runtime-swift5.stencil
@@ -3,7 +3,6 @@
 
 {% if files %}
 {% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
-{% set documentPrefix %}{{param.documentName|default:"Document"}}{% endset %}
 import Foundation
 
 // swiftlint:disable superfluous_disable_command
@@ -11,16 +10,7 @@ import Foundation
 
 // MARK: - JSON Files
 {% macro fileBlock file %}
-  {% if file.documents.count > 1 %}
-  {% for document in file.documents %}
-  {% set documentName %}{{documentPrefix}}{{forloop.counter}}{% endset %}
-  {{accessModifier}} enum {{documentName|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call documentBlock file document %}{% endfilter %}
-  }
-  {% endfor %}
-  {% else %}
-  {% call documentBlock file file.documents.first %}
-  {% endif %}
+  {% call documentBlock file file.document %}
 {% endmacro %}
 {% macro documentBlock file document %}
   {% set rootType %}{% call typeBlock document.metadata %}{% endset %}

--- a/templates/plist/inline-swift4.stencil
+++ b/templates/plist/inline-swift4.stencil
@@ -3,7 +3,6 @@
 
 {% if files %}
 {% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
-{% set documentPrefix %}{{param.documentName|default:"Document"}}{% endset %}
 import Foundation
 
 // swiftlint:disable superfluous_disable_command
@@ -11,16 +10,7 @@ import Foundation
 
 // MARK: - Plist Files
 {% macro fileBlock file %}
-  {% if file.documents.count > 1 %}
-  {% for document in file.documents %}
-  {% set documentName %}{{documentPrefix}}{{forloop.counter}}{% endset %}
-  {{accessModifier}} enum {{documentName|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call documentBlock file document %}{% endfilter %}
-  }
-  {% endfor %}
-  {% else %}
-  {% call documentBlock file file.documents.first %}
-  {% endif %}
+  {% call documentBlock file file.document %}
 {% endmacro %}
 {% macro documentBlock file document %}
   {% set rootType %}{% call typeBlock document.metadata %}{% endset %}

--- a/templates/plist/inline-swift5.stencil
+++ b/templates/plist/inline-swift5.stencil
@@ -3,7 +3,6 @@
 
 {% if files %}
 {% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
-{% set documentPrefix %}{{param.documentName|default:"Document"}}{% endset %}
 import Foundation
 
 // swiftlint:disable superfluous_disable_command
@@ -11,16 +10,7 @@ import Foundation
 
 // MARK: - Plist Files
 {% macro fileBlock file %}
-  {% if file.documents.count > 1 %}
-  {% for document in file.documents %}
-  {% set documentName %}{{documentPrefix}}{{forloop.counter}}{% endset %}
-  {{accessModifier}} enum {{documentName|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call documentBlock file document %}{% endfilter %}
-  }
-  {% endfor %}
-  {% else %}
-  {% call documentBlock file file.documents.first %}
-  {% endif %}
+  {% call documentBlock file file.document %}
 {% endmacro %}
 {% macro documentBlock file document %}
   {% set rootType %}{% call typeBlock document.metadata %}{% endset %}

--- a/templates/plist/runtime-swift4.stencil
+++ b/templates/plist/runtime-swift4.stencil
@@ -3,7 +3,6 @@
 
 {% if files %}
 {% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
-{% set documentPrefix %}{{param.documentName|default:"Document"}}{% endset %}
 import Foundation
 
 // swiftlint:disable superfluous_disable_command
@@ -11,16 +10,7 @@ import Foundation
 
 // MARK: - Plist Files
 {% macro fileBlock file %}
-  {% if file.documents.count > 1 %}
-  {% for document in file.documents %}
-  {% set documentName %}{{documentPrefix}}{{forloop.counter}}{% endset %}
-  {{accessModifier}} enum {{documentName|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call documentBlock file document %}{% endfilter %}
-  }
-  {% endfor %}
-  {% else %}
-  {% call documentBlock file file.documents.first %}
-  {% endif %}
+  {% call documentBlock file file.document %}
 {% endmacro %}
 {% macro documentBlock file document %}
   {% set rootType %}{% call typeBlock document.metadata %}{% endset %}

--- a/templates/plist/runtime-swift5.stencil
+++ b/templates/plist/runtime-swift5.stencil
@@ -3,7 +3,6 @@
 
 {% if files %}
 {% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
-{% set documentPrefix %}{{param.documentName|default:"Document"}}{% endset %}
 import Foundation
 
 // swiftlint:disable superfluous_disable_command
@@ -11,16 +10,7 @@ import Foundation
 
 // MARK: - Plist Files
 {% macro fileBlock file %}
-  {% if file.documents.count > 1 %}
-  {% for document in file.documents %}
-  {% set documentName %}{{documentPrefix}}{{forloop.counter}}{% endset %}
-  {{accessModifier}} enum {{documentName|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call documentBlock file document %}{% endfilter %}
-  }
-  {% endfor %}
-  {% else %}
-  {% call documentBlock file file.documents.first %}
-  {% endif %}
+  {% call documentBlock file file.document %}
 {% endmacro %}
 {% macro documentBlock file document %}
   {% set rootType %}{% call typeBlock document.metadata %}{% endset %}


### PR DESCRIPTION
So I noticed that in #702 that while we deprecated `documents` in the json contexts, we forgot to do the same for plist contexts.

I've also updated (simplified) the templates, but kept the `fileBlock`/`documentBlock` separation to keep the similarity with yaml templates.