### PR TITLE
XCAssets: image loading performance on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ _None_
 * CoreData: Deprecates `fetchRequest()` and adds `makeFetchRequest()` to avoid ambiguous function usage.  
   [David Rothera](https://github.com/davidrothera)
   [#726](https://github.com/SwiftGen/SwiftGen/pull/726)
+* XCassets: image assets now load faster on macOS if they're in the `main` bundle. MacOS only provides a caching mechanism for images in the `main` bundle, for other cases you may need to provide your own caching mechanism as needed.  
+  [David Jennes](https://github.com/djbe)
+  [#648](https://github.com/SwiftGen/SwiftGen/issues/648)
+  [#733](https://github.com/SwiftGen/SwiftGen/pull/733)
 
 ### Bug Fixes
 
@@ -56,7 +60,7 @@ There are no major changes in this release, although JSON & Plist template write
   [@fjtrujy](https://github.com/fjtrujy)
 * Avoid breaking the system swift installation when installing SwiftGen via Homebrew on macOS 10.14.4 or higher.  
   [David Jennes](https://github.com/djbe)
-  [#686](https://github.com/SwiftGen/SwiftGen/issue/686)
+  [#686](https://github.com/SwiftGen/SwiftGen/issues/686)
   [#730](https://github.com/SwiftGen/SwiftGen/pull/730)
 
 ### Internal Changes

--- a/Tests/Fixtures/Generated/XCAssets/swift4/all-allValues.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift4/all-allValues.swift
@@ -239,7 +239,8 @@ internal struct ImageAsset {
     #if os(iOS) || os(tvOS)
     let image = Image(named: name, in: bundle, compatibleWith: nil)
     #elseif os(macOS)
-    let image = bundle.image(forResource: NSImage.Name(name))
+    let name = NSImage.Name(self.name)
+    let image = (bundle == .main) ? NSImage(named: name) : bundle.image(forResource: name)
     #elseif os(watchOS)
     let image = Image(named: name)
     #endif

--- a/Tests/Fixtures/Generated/XCAssets/swift4/all-customName.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift4/all-customName.swift
@@ -171,7 +171,8 @@ internal struct XCTImageAsset {
     #if os(iOS) || os(tvOS)
     let image = Image(named: name, in: bundle, compatibleWith: nil)
     #elseif os(macOS)
-    let image = bundle.image(forResource: NSImage.Name(name))
+    let name = NSImage.Name(self.name)
+    let image = (bundle == .main) ? NSImage(named: name) : bundle.image(forResource: name)
     #elseif os(watchOS)
     let image = Image(named: name)
     #endif

--- a/Tests/Fixtures/Generated/XCAssets/swift4/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift4/all-forceFileNameEnum.swift
@@ -171,7 +171,8 @@ internal struct ImageAsset {
     #if os(iOS) || os(tvOS)
     let image = Image(named: name, in: bundle, compatibleWith: nil)
     #elseif os(macOS)
-    let image = bundle.image(forResource: NSImage.Name(name))
+    let name = NSImage.Name(self.name)
+    let image = (bundle == .main) ? NSImage(named: name) : bundle.image(forResource: name)
     #elseif os(watchOS)
     let image = Image(named: name)
     #endif

--- a/Tests/Fixtures/Generated/XCAssets/swift4/all-forceNamespaces.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift4/all-forceNamespaces.swift
@@ -173,7 +173,8 @@ internal struct ImageAsset {
     #if os(iOS) || os(tvOS)
     let image = Image(named: name, in: bundle, compatibleWith: nil)
     #elseif os(macOS)
-    let image = bundle.image(forResource: NSImage.Name(name))
+    let name = NSImage.Name(self.name)
+    let image = (bundle == .main) ? NSImage(named: name) : bundle.image(forResource: name)
     #elseif os(watchOS)
     let image = Image(named: name)
     #endif

--- a/Tests/Fixtures/Generated/XCAssets/swift4/all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift4/all-publicAccess.swift
@@ -171,7 +171,8 @@ public struct ImageAsset {
     #if os(iOS) || os(tvOS)
     let image = Image(named: name, in: bundle, compatibleWith: nil)
     #elseif os(macOS)
-    let image = bundle.image(forResource: NSImage.Name(name))
+    let name = NSImage.Name(self.name)
+    let image = (bundle == .main) ? NSImage(named: name) : bundle.image(forResource: name)
     #elseif os(watchOS)
     let image = Image(named: name)
     #endif

--- a/Tests/Fixtures/Generated/XCAssets/swift4/all.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift4/all.swift
@@ -171,7 +171,8 @@ internal struct ImageAsset {
     #if os(iOS) || os(tvOS)
     let image = Image(named: name, in: bundle, compatibleWith: nil)
     #elseif os(macOS)
-    let image = bundle.image(forResource: NSImage.Name(name))
+    let name = NSImage.Name(self.name)
+    let image = (bundle == .main) ? NSImage(named: name) : bundle.image(forResource: name)
     #elseif os(watchOS)
     let image = Image(named: name)
     #endif

--- a/Tests/Fixtures/Generated/XCAssets/swift4/food.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift4/food.swift
@@ -51,7 +51,8 @@ internal struct ImageAsset {
     #if os(iOS) || os(tvOS)
     let image = Image(named: name, in: bundle, compatibleWith: nil)
     #elseif os(macOS)
-    let image = bundle.image(forResource: NSImage.Name(name))
+    let name = NSImage.Name(self.name)
+    let image = (bundle == .main) ? NSImage(named: name) : bundle.image(forResource: name)
     #elseif os(watchOS)
     let image = Image(named: name)
     #endif

--- a/Tests/Fixtures/Generated/XCAssets/swift5/all-allValues.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift5/all-allValues.swift
@@ -247,7 +247,8 @@ internal struct ImageAsset {
     #if os(iOS) || os(tvOS)
     let image = Image(named: name, in: bundle, compatibleWith: nil)
     #elseif os(macOS)
-    let image = bundle.image(forResource: NSImage.Name(name))
+    let name = NSImage.Name(self.name)
+    let image = (bundle == .main) ? NSImage(named: name) : bundle.image(forResource: name)
     #elseif os(watchOS)
     let image = Image(named: name)
     #endif

--- a/Tests/Fixtures/Generated/XCAssets/swift5/all-customName.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift5/all-customName.swift
@@ -179,7 +179,8 @@ internal struct XCTImageAsset {
     #if os(iOS) || os(tvOS)
     let image = Image(named: name, in: bundle, compatibleWith: nil)
     #elseif os(macOS)
-    let image = bundle.image(forResource: NSImage.Name(name))
+    let name = NSImage.Name(self.name)
+    let image = (bundle == .main) ? NSImage(named: name) : bundle.image(forResource: name)
     #elseif os(watchOS)
     let image = Image(named: name)
     #endif

--- a/Tests/Fixtures/Generated/XCAssets/swift5/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift5/all-forceFileNameEnum.swift
@@ -179,7 +179,8 @@ internal struct ImageAsset {
     #if os(iOS) || os(tvOS)
     let image = Image(named: name, in: bundle, compatibleWith: nil)
     #elseif os(macOS)
-    let image = bundle.image(forResource: NSImage.Name(name))
+    let name = NSImage.Name(self.name)
+    let image = (bundle == .main) ? NSImage(named: name) : bundle.image(forResource: name)
     #elseif os(watchOS)
     let image = Image(named: name)
     #endif

--- a/Tests/Fixtures/Generated/XCAssets/swift5/all-forceNamespaces.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift5/all-forceNamespaces.swift
@@ -181,7 +181,8 @@ internal struct ImageAsset {
     #if os(iOS) || os(tvOS)
     let image = Image(named: name, in: bundle, compatibleWith: nil)
     #elseif os(macOS)
-    let image = bundle.image(forResource: NSImage.Name(name))
+    let name = NSImage.Name(self.name)
+    let image = (bundle == .main) ? NSImage(named: name) : bundle.image(forResource: name)
     #elseif os(watchOS)
     let image = Image(named: name)
     #endif

--- a/Tests/Fixtures/Generated/XCAssets/swift5/all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift5/all-publicAccess.swift
@@ -179,7 +179,8 @@ public struct ImageAsset {
     #if os(iOS) || os(tvOS)
     let image = Image(named: name, in: bundle, compatibleWith: nil)
     #elseif os(macOS)
-    let image = bundle.image(forResource: NSImage.Name(name))
+    let name = NSImage.Name(self.name)
+    let image = (bundle == .main) ? NSImage(named: name) : bundle.image(forResource: name)
     #elseif os(watchOS)
     let image = Image(named: name)
     #endif

--- a/Tests/Fixtures/Generated/XCAssets/swift5/all.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift5/all.swift
@@ -179,7 +179,8 @@ internal struct ImageAsset {
     #if os(iOS) || os(tvOS)
     let image = Image(named: name, in: bundle, compatibleWith: nil)
     #elseif os(macOS)
-    let image = bundle.image(forResource: NSImage.Name(name))
+    let name = NSImage.Name(self.name)
+    let image = (bundle == .main) ? NSImage(named: name) : bundle.image(forResource: name)
     #elseif os(watchOS)
     let image = Image(named: name)
     #endif

--- a/Tests/Fixtures/Generated/XCAssets/swift5/food.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift5/food.swift
@@ -51,7 +51,8 @@ internal struct ImageAsset {
     #if os(iOS) || os(tvOS)
     let image = Image(named: name, in: bundle, compatibleWith: nil)
     #elseif os(macOS)
-    let image = bundle.image(forResource: NSImage.Name(name))
+    let name = NSImage.Name(self.name)
+    let image = (bundle == .main) ? NSImage(named: name) : bundle.image(forResource: name)
     #elseif os(watchOS)
     let image = Image(named: name)
     #endif

--- a/templates/xcassets/swift4.stencil
+++ b/templates/xcassets/swift4.stencil
@@ -220,7 +220,8 @@
     #if os(iOS) || os(tvOS)
     let image = Image(named: name, in: bundle, compatibleWith: nil)
     #elseif os(macOS)
-    let image = bundle.image(forResource: NSImage.Name(name))
+    let name = NSImage.Name(self.name)
+    let image = (bundle == .main) ? NSImage(named: name) : bundle.image(forResource: name)
     #elseif os(watchOS)
     let image = Image(named: name)
     #endif

--- a/templates/xcassets/swift5.stencil
+++ b/templates/xcassets/swift5.stencil
@@ -228,7 +228,8 @@
     #if os(iOS) || os(tvOS)
     let image = Image(named: name, in: bundle, compatibleWith: nil)
     #elseif os(macOS)
-    let image = bundle.image(forResource: NSImage.Name(name))
+    let name = NSImage.Name(self.name)
+    let image = (bundle == .main) ? NSImage(named: name) : bundle.image(forResource: name)
     #elseif os(watchOS)
     let image = Image(named: name)
     #endif


### PR DESCRIPTION
Fixes #648.

On macOS, images loaded via `bundle.image(forResource:)` are not cached. Images loaded using `NSImage(named:)` are cached, but that method only works in the `main` bundle. 

The solution is simple: use the faster method if we can, namely check if the bundle == `main`.
