### PR TITLE
Template `lookupFunction` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ _None_
 * Fonts/IB/JSON/Plist/Strings/XCAssets: all templates that load data at runtime from a bundle now support a `bundle` template parameter, which you can use to override the bundle from which resources are loaded. Check out the [template specific documentation](Documentation/templates/) for more information.  
   [David Jennes](https://github.com/djbe)
   [#737](https://github.com/SwiftGen/SwiftGen/pull/737)
+* Fonts/IB/JSON/Plist: Similar to the `strings` templates, these templates now support a `lookupFunction` template parameter, which allows you to provide your own resource lookup mechanism at runtime. Check the [template specific documentation](Documentation/templates/) for more information.  
+  [David Jennes](https://github.com/djbe)
+  [#738](https://github.com/SwiftGen/SwiftGen/pull/738)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ _None_
 * CoreData: Deprecates `fetchRequest()` and adds `makeFetchRequest()` to avoid ambiguous function usage.  
   [David Rothera](https://github.com/davidrothera)
   [#726](https://github.com/SwiftGen/SwiftGen/pull/726)
-* XCassets: image assets now load faster on macOS if they're in the `main` bundle. MacOS only provides a caching mechanism for images in the `main` bundle, for other cases you may need to provide your own caching mechanism as needed.  
+* XCAssets: image assets now load faster on macOS if they're in the `main` bundle. MacOS only provides a caching mechanism for images in the `main` bundle, for other cases you may need to provide your own caching mechanism as needed.  
   [David Jennes](https://github.com/djbe)
   [#648](https://github.com/SwiftGen/SwiftGen/issues/648)
   [#733](https://github.com/SwiftGen/SwiftGen/pull/733)

--- a/Documentation/Articles/Customise-loading-of-resources.md
+++ b/Documentation/Articles/Customise-loading-of-resources.md
@@ -1,0 +1,59 @@
+# Customise loading of resources
+
+By default, the built-in templates provided by SwiftGen will load resources from the same bundle as where the generated code is located at:
+- If your generated code is in the main app, it will load resources from the `main` bundle.
+- If your generated code is in a Framework, it will load resources from that Framework's bundle.
+
+This works for most users, but there may be sitations where you'll need a more advanced solution.
+
+## Override the default Bundle
+
+Let's say you are developing a CocoaPods Pod for example. CocoaPods recommends the use of the `resource_bundles` option ([more info](https://guides.cocoapods.org/syntax/podspec.html#resource_bundles)) for adding resources to your Pod. Using this option, your resources will be grouped into a separate bundle.
+
+The advantage of this is that, no matter how an end-user adds your Pod to their project, your resources won't ever clash with their resources. This is especially important with static linking, where CocoaPods won't generate a Framework for each Pod and add everything to the main App bundle of a user.
+
+The disadvantage is that your resources are no longer located in the same bundle as your generated code, but in (for example) a sub-bundle `MyAwesomePodResources.bundle`. The generated code by SwiftGen will no longer work.
+
+### Solution
+
+To fix this, you can set the `bundle` template parameter to point to something in your code that represents your resources bundle.
+
+Let's say you have the following Swift code somewhere in your app:
+
+```swift
+final class MyAwesomePod {
+  // This is the bundle where your code resides in
+  static let bundle: Bundle = {
+    Bundle(for: MyAwesomePod.self)
+  }()
+
+  // Your resources bundle is inside that bundle
+  static let resourcesBundle: Bundle = {
+	guard let url = bundle.url(forResource: "MyAwesomePodResources", withExtension: "bundle"),
+      let bundle = Bundle(url: url) else {
+      fatalError("Can't find 'MyAwesomePodResources' bundle")
+    }
+    return bundle
+  }()
+}
+```
+
+You want SwiftGen to generate code to load resources from `MyAwesomePod.resourcesBundle`. Update your configuration file and add the `bundle` parameter, like so:
+
+```yaml
+input_dir: Resources
+output_dir: Sources
+strings:
+  inputs: en.lproj/Localizable.strings
+  outputs:
+    templateName: structured-swift5
+    output: Generated/Strings.swift
+    params:
+      bundle: MyAwesomePod.resourcesBundle
+```
+
+Run SwiftGen again to update the generated coide, and voila! Your generated code now works with a resources bundle.
+
+## Override the lookup function
+
+TODO

--- a/Documentation/Articles/Customise-loading-of-resources.md
+++ b/Documentation/Articles/Customise-loading-of-resources.md
@@ -23,13 +23,11 @@ Let's say you have the following Swift code somewhere in your app:
 ```swift
 final class MyAwesomePod {
   // This is the bundle where your code resides in
-  static let bundle: Bundle = {
-    Bundle(for: MyAwesomePod.self)
-  }()
+  static let bundle = Bundle(for: MyAwesomePod.self)
 
   // Your resources bundle is inside that bundle
   static let resourcesBundle: Bundle = {
-	guard let url = bundle.url(forResource: "MyAwesomePodResources", withExtension: "bundle"),
+  guard let url = bundle.url(forResource: "MyAwesomePodResources", withExtension: "bundle"),
       let bundle = Bundle(url: url) else {
       fatalError("Can't find 'MyAwesomePodResources' bundle")
     }

--- a/Documentation/Articles/Customize-loading-of-resources.md
+++ b/Documentation/Articles/Customize-loading-of-resources.md
@@ -1,4 +1,4 @@
-# Customise loading of resources
+# Customize loading of resources
 
 By default, the built-in templates provided by SwiftGen will load resources from the same bundle as where the generated code is located at:
 - If your generated code is in the main app, it will load resources from the `main` bundle.
@@ -27,7 +27,7 @@ final class MyAwesomePod {
 
   // Your resources bundle is inside that bundle
   static let resourcesBundle: Bundle = {
-  guard let url = bundle.url(forResource: "MyAwesomePodResources", withExtension: "bundle"),
+    guard let url = bundle.url(forResource: "MyAwesomePodResources", withExtension: "bundle"),
       let bundle = Bundle(url: url) else {
       fatalError("Can't find 'MyAwesomePodResources' bundle")
     }
@@ -37,10 +37,18 @@ final class MyAwesomePod {
 ```
 
 You want SwiftGen to generate code to load resources from `MyAwesomePod.resourcesBundle`. Update your configuration file and add the `bundle` parameter, like so:
+Since you want SwiftGen to generate code to load resources (localized strings and fonts for example) from `MyAwesomePod.resourcesBundle`, you can update your configuration file to add the `bundle` parameter, like so:
 
 ```yaml
 input_dir: Resources
 output_dir: Sources
+fonts:
+  inputs: Fonts
+  outputs:
+    templateName: swift5
+    output: Generated/Fonts.swift
+    params:
+      bundle: MyAwesomePod.resourcesBundle
 strings:
   inputs: en.lproj/Localizable.strings
   outputs:
@@ -50,13 +58,15 @@ strings:
       bundle: MyAwesomePod.resourcesBundle
 ```
 
-Run SwiftGen again to update the generated coide, and voila! Your generated code now works with a resources bundle.
+Run SwiftGen again to update the generated code, and voila! Your generated code will now load the localised strings and fonts from that resources bundle instead of the bundle where the generated code is.
+
+Consult each [templates documentation](../templates/) to learn more about this parameter and ensure it's supported by the template you want to use.
 
 ## Override the lookup function
 
-If you need a more advanced solution than which bundle is used for loading resources, you can override the "lookup function".
+If you need a more advanced solution than just changing the bundle used for loading resources, you can override the "lookup function".
 
-For example you may want to override the way localisation strings are loaded, if you want to override the device's language by some language chosen in your app.
+For example you may want to override the way localisation strings are loaded, if you want to override the device's language by some language chosen in your app. Another use case is if your project is organised in multiple white-label app targets, all using the same framework, and you want to allow the app target to override a translation otherwise provided by the common framework, etc…
 
 Another more complex example: lets say you have a system where you have a set strings localisation files for your application. These are of course embedded in your application as they always are. But you also want to be able to update these translations on-the-fly, by having your app regularly check and download newer versions of these translation files.
 
@@ -97,4 +107,8 @@ strings:
       lookupFunction: TranslationService.shared.lookupTranslation(forKey:inTable:)
 ```
 
-Note that we provided the full signature of the function. The signature of this `lookupFunction` will change depending on which parser & template you're using. Check the dedicated [template documentation](../templates) for more information.
+Note that we provided the full signature of the function.
+
+- The signature of this `lookupFunction` depends on which parser & template you're using. It will be different for `strings` templates vs `font` templates for example.
+- Note that this parameter currently is not available for `xcassets` templates (because XCAssets don't have just one but multiple methods used depending on the asset type).
+- Check [each template's dedicated documentation](../templates/) for more information.

--- a/Documentation/Articles/SwiftLint-Integration.md
+++ b/Documentation/Articles/SwiftLint-Integration.md
@@ -41,7 +41,7 @@ custom_rules:
 Feel free to use this and adapt to your needs, especially:
 
 * This example makes SwiftLint generate _errors_ when it finds an usage of the Apple API where a SwiftGen constant should be used instead. Maybe you prefer to be less strict about it and use `severity: warning` rather than error in your project
-* The `message` this example configuration displays mention the name of the `enums` generated that the user should use. If you've customised the name of such enum (typically with `params: { "enumName": "somethingElse" }` in your `swiftgen.yml` config file), you may want to adapt the messages reported by SwiftLint accordingly.
+* The `message` this example configuration displays mention the name of the `enums` generated that the user should use. If you've customized the name of such enum (typically with `params: { "enumName": "somethingElse" }` in your `swiftgen.yml` config file), you may want to adapt the messages reported by SwiftLint accordingly.
 
 ## Contribution
 

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -20,9 +20,9 @@ This directory contains documentation for various topics related to SwiftGen, su
 * Learn how to [create your own custom templates](Articles/Creating-custom-templates.md) to customize the code SwiftGen generates
 * Iterate quickly when creating custom templates by [watching a file or folder for changes](Articles/Watch-a-folder-for-changes.md)
 
-### Customise loading of resources
+### Customize loading of resources
 
-Most of the SwiftGen provided templates generate code that allows you to load resources at runtime, but in some cases you may want to modify how these resources are loaded. The built-in templates [can be configured to handle these cases](Articles/Customise-loading-of-resources.md) without resorting to custom templates.
+Most of the SwiftGen provided templates generate code that allows you to load resources at runtime, but in some cases you may want to modify how these resources are loaded. The built-in templates [can be configured to handle these cases](Articles/Customize-loading-of-resources.md) without resorting to custom templates.
 
 ## [Parsers Documentation](Parsers/)
 

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -20,6 +20,10 @@ This directory contains documentation for various topics related to SwiftGen, su
 * Learn how to [create your own custom templates](Articles/Creating-custom-templates.md) to customize the code SwiftGen generates
 * Iterate quickly when creating custom templates by [watching a file or folder for changes](Articles/Watch-a-folder-for-changes.md)
 
+### Customise loading of resources
+
+Most of the SwiftGen provided templates generate code that allows you to load resources at runtime, but in some cases you may want to modify how these resources are loaded. The built-in templates [can be configured to handle these cases](Articles/Customise-loading-of-resources.md) without resorting to custom templates.
+
 ## [Parsers Documentation](Parsers/)
 
 SwiftGen uses parsers to parse different type of input files, like asset catalogs, strings files, font files, etc.

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -37,7 +37,7 @@ The documentation for each template, their intended use, and their supported par
 
 The way SwiftGen works is to parse your input files (resources like Asset Catalogs, Strings files, etc) using those parsers described above, and transform them into a structured dictionary – that we call a "SwiftGenKit Context" – representing the parsed data.
 
-That parsed data ("Context") is then fed to our template engine (Stencil), alongside a template, to finally produce the generated code that you will use in your projects.
+That parsed data ("Context") is then fed to our template engine ([Stencil](https://github.com/stencilproject/Stencil)), alongside a template, to finally produce the generated code that you will use in your projects.
 
 > ```
 >                                          +----------+

--- a/Documentation/templates/fonts/swift4.md
+++ b/Documentation/templates/fonts/swift4.md
@@ -20,10 +20,12 @@ You can customize some elements of this template by overriding the following par
 | `bundle` | `BundleToken.bundle` | Allows you to set from which bundle font files are loaded from. By default, it'll point to the same bundle as where the generated code is. Note: ignored if `lookupFunction` parameter is set. |
 | `enumName` | `FontFamily` | Allows you to change the name of the generated `enum` containing all font families. |
 | `fontTypeName` | `FontConvertible` | Allows you to change the name of the struct type representing a font. |
-| `lookupFunction` | N/A | Allows you to set your own custom lookup function. The function needs to have as signature: `(name: String, family: String, path: String) -> URL?`. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `myFontFinder(name:family:path:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
+| `lookupFunction` | N/A¹ | Allows you to set your own custom lookup function. The function needs to have as signature: `(name: String, family: String, path: String) -> URL?`. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `myFontFinder(name:family:path:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
 | `preservePath` | N/A | Setting this parameter will disable the basename filter applied to all font paths. Use this if you added your font folder as a "folder reference" in your Xcode project, making that folder hierarchy preserved once copied in the build app bundle. The path will be relative to the folder you provided to SwiftGen. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
 | `fontAliasName` | `Font` | **Deprecated** Allows you to change the name of the `typealias` representing a font. Useful when working with SwiftUI, which defines it's own `Font` type. |
+
+1. _If you don't provide a `lookupFunction`, we will call `url(forResource:withExtension:)` on the `bundle` parameter instead._
 
 ## Generated Code
 

--- a/Documentation/templates/fonts/swift4.md
+++ b/Documentation/templates/fonts/swift4.md
@@ -25,7 +25,7 @@ You can customize some elements of this template by overriding the following par
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
 | `fontAliasName` | `Font` | **Deprecated** Allows you to change the name of the `typealias` representing a font. Useful when working with SwiftUI, which defines it's own `Font` type. |
 
-1. _If you don't provide a `lookupFunction`, we will call `url(forResource:withExtension:)` on the `bundle` parameter instead._
+1. _If you don't provide a `lookupFunction`, we will use `url(forResource:withExtension:)` on the `bundle` parameter instead._
 
 ## Generated Code
 

--- a/Documentation/templates/fonts/swift4.md
+++ b/Documentation/templates/fonts/swift4.md
@@ -17,9 +17,10 @@ You can customize some elements of this template by overriding the following par
 
 | Parameter Name | Default Value | Description |
 | -------------- | ------------- | ----------- |
-| `bundle` | `BundleToken.bundle` | Allows you to set from which bundle font files are loaded from. By default, it'll point to the same bundle as where the generated code is. |
+| `bundle` | `BundleToken.bundle` | Allows you to set from which bundle font files are loaded from. By default, it'll point to the same bundle as where the generated code is. Note: ignored if `lookupFunction` parameter is set. |
 | `enumName` | `FontFamily` | Allows you to change the name of the generated `enum` containing all font families. |
 | `fontTypeName` | `FontConvertible` | Allows you to change the name of the struct type representing a font. |
+| `lookupFunction` | N/A | Allows you to set your own custom lookup function. The function needs to have as signature: `(name: String, family: String, path: String) -> URL?`. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `myFontFinder(name:family:path:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
 | `preservePath` | N/A | Setting this parameter will disable the basename filter applied to all font paths. Use this if you added your font folder as a "folder reference" in your Xcode project, making that folder hierarchy preserved once copied in the build app bundle. The path will be relative to the folder you provided to SwiftGen. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
 | `fontAliasName` | `Font` | **Deprecated** Allows you to change the name of the `typealias` representing a font. Useful when working with SwiftUI, which defines it's own `Font` type. |

--- a/Documentation/templates/fonts/swift5.md
+++ b/Documentation/templates/fonts/swift5.md
@@ -20,10 +20,12 @@ You can customize some elements of this template by overriding the following par
 | `bundle` | `BundleToken.bundle` | Allows you to set from which bundle font files are loaded from. By default, it'll point to the same bundle as where the generated code is. Note: ignored if `lookupFunction` parameter is set. |
 | `enumName` | `FontFamily` | Allows you to change the name of the generated `enum` containing all font families. |
 | `fontTypeName` | `FontConvertible` | Allows you to change the name of the struct type representing a font. |
-| `lookupFunction` | N/A | Allows you to set your own custom lookup function. The function needs to have as signature: `(name: String, family: String, path: String) -> URL?`. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `myFontFinder(name:family:path:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
+| `lookupFunction` | N/A¹ | Allows you to set your own custom lookup function. The function needs to have as signature: `(name: String, family: String, path: String) -> URL?`. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `myFontFinder(name:family:path:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
 | `preservePath` | N/A | Setting this parameter will disable the basename filter applied to all font paths. Use this if you added your font folder as a "folder reference" in your Xcode project, making that folder hierarchy preserved once copied in the build app bundle. The path will be relative to the folder you provided to SwiftGen. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
 | `fontAliasName` | `Font` | **Deprecated** Allows you to change the name of the `typealias` representing a font. Useful when working with SwiftUI, which defines it's own `Font` type. |
+
+1. _If you don't provide a `lookupFunction`, we will call `url(forResource:withExtension:)` on the `bundle` parameter instead._
 
 ## Generated Code
 

--- a/Documentation/templates/fonts/swift5.md
+++ b/Documentation/templates/fonts/swift5.md
@@ -25,7 +25,7 @@ You can customize some elements of this template by overriding the following par
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
 | `fontAliasName` | `Font` | **Deprecated** Allows you to change the name of the `typealias` representing a font. Useful when working with SwiftUI, which defines it's own `Font` type. |
 
-1. _If you don't provide a `lookupFunction`, we will call `url(forResource:withExtension:)` on the `bundle` parameter instead._
+1. _If you don't provide a `lookupFunction`, we will use `url(forResource:withExtension:)` on the `bundle` parameter instead._
 
 ## Generated Code
 

--- a/Documentation/templates/fonts/swift5.md
+++ b/Documentation/templates/fonts/swift5.md
@@ -17,9 +17,10 @@ You can customize some elements of this template by overriding the following par
 
 | Parameter Name | Default Value | Description |
 | -------------- | ------------- | ----------- |
-| `bundle` | `BundleToken.bundle` | Allows you to set from which bundle font files are loaded from. By default, it'll point to the same bundle as where the generated code is. |
+| `bundle` | `BundleToken.bundle` | Allows you to set from which bundle font files are loaded from. By default, it'll point to the same bundle as where the generated code is. Note: ignored if `lookupFunction` parameter is set. |
 | `enumName` | `FontFamily` | Allows you to change the name of the generated `enum` containing all font families. |
 | `fontTypeName` | `FontConvertible` | Allows you to change the name of the struct type representing a font. |
+| `lookupFunction` | N/A | Allows you to set your own custom lookup function. The function needs to have as signature: `(name: String, family: String, path: String) -> URL?`. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `myFontFinder(name:family:path:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
 | `preservePath` | N/A | Setting this parameter will disable the basename filter applied to all font paths. Use this if you added your font folder as a "folder reference" in your Xcode project, making that folder hierarchy preserved once copied in the build app bundle. The path will be relative to the folder you provided to SwiftGen. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
 | `fontAliasName` | `Font` | **Deprecated** Allows you to change the name of the `typealias` representing a font. Useful when working with SwiftUI, which defines it's own `Font` type. |

--- a/Documentation/templates/ib/scenes-swift4.md
+++ b/Documentation/templates/ib/scenes-swift4.md
@@ -22,9 +22,11 @@ You can customize some elements of this template by overriding the following par
 | `bundle` | `BundleToken.bundle` | Allows you to set from which storyboard files are loaded from. By default, it'll point to the same bundle as where the generated code is. Note: ignored if `lookupFunction` parameter is set. |
 | `enumName` | `StoryboardScene` | Allows you to change the name of the generated `enum` containing all storyboard scenes. |
 | `ignoreTargetModule` | N/A | Setting this parameter will disable the behaviour of prefixing classes with their module name for (only) the target module. |
-| `lookupFunction` | N/A | Allows you to set your own custom lookup function. The function needs to have as signature: `(name: NSStoryboard.Name) -> NSStoryboard` on macOS, and `(name: String) -> UIStoryboard` on other platforms. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `myStoryboardFinder(name:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
+| `lookupFunction` | N/A¹ | Allows you to set your own custom lookup function. The function needs to have as signature: `(name: NSStoryboard.Name) -> NSStoryboard` on macOS, and `(name: String) -> UIStoryboard` on other platforms. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `myStoryboardFinder(name:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
 | `module` | N/A | By default, the template will import the needed modules for custom classes, but won’t import the target’s module to avoid an import warning — using the `PRODUCT_MODULE_NAME` environment variable to detect it. Should you need to ignore an additional module, you can provide it here. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
+
+1. _If you don't provide a `lookupFunction`, we will call `NS/UIStoryboard(name:bundle:)` with the `bundle` parameter instead._
 
 ## Generated Code
 

--- a/Documentation/templates/ib/scenes-swift4.md
+++ b/Documentation/templates/ib/scenes-swift4.md
@@ -19,9 +19,10 @@ You can customize some elements of this template by overriding the following par
 
 | Parameter Name | Default Value | Description |
 | -------------- | ------------- | ----------- |
-| `bundle` | `BundleToken.bundle` | Allows you to set from which storyboard files are loaded from. By default, it'll point to the same bundle as where the generated code is. |
+| `bundle` | `BundleToken.bundle` | Allows you to set from which storyboard files are loaded from. By default, it'll point to the same bundle as where the generated code is. Note: ignored if `lookupFunction` parameter is set. |
 | `enumName` | `StoryboardScene` | Allows you to change the name of the generated `enum` containing all storyboard scenes. |
 | `ignoreTargetModule` | N/A | Setting this parameter will disable the behaviour of prefixing classes with their module name for (only) the target module. |
+| `lookupFunction` | N/A | Allows you to set your own custom lookup function. The function needs to have as signature: `(name: NSStoryboard.Name) -> NSStoryboard` on macOS, and `(name: String) -> UIStoryboard` on other platforms. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `myStoryboardFinder(name:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
 | `module` | N/A | By default, the template will import the needed modules for custom classes, but won’t import the target’s module to avoid an import warning — using the `PRODUCT_MODULE_NAME` environment variable to detect it. Should you need to ignore an additional module, you can provide it here. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
 

--- a/Documentation/templates/ib/scenes-swift4.md
+++ b/Documentation/templates/ib/scenes-swift4.md
@@ -26,7 +26,7 @@ You can customize some elements of this template by overriding the following par
 | `module` | N/A | By default, the template will import the needed modules for custom classes, but won’t import the target’s module to avoid an import warning — using the `PRODUCT_MODULE_NAME` environment variable to detect it. Should you need to ignore an additional module, you can provide it here. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
 
-1. _If you don't provide a `lookupFunction`, we will call `NS/UIStoryboard(name:bundle:)` with the `bundle` parameter instead._
+1. _If you don't provide a `lookupFunction`, we will use `NS/UIStoryboard(name:bundle:)` with the `bundle` parameter instead._
 
 ## Generated Code
 

--- a/Documentation/templates/ib/scenes-swift5.md
+++ b/Documentation/templates/ib/scenes-swift5.md
@@ -22,9 +22,11 @@ You can customize some elements of this template by overriding the following par
 | `bundle` | `BundleToken.bundle` | Allows you to set from which storyboard files are loaded from. By default, it'll point to the same bundle as where the generated code is. Note: ignored if `lookupFunction` parameter is set. |
 | `enumName` | `StoryboardScene` | Allows you to change the name of the generated `enum` containing all storyboard scenes. |
 | `ignoreTargetModule` | N/A | Setting this parameter will disable the behaviour of prefixing classes with their module name for (only) the target module. |
-| `lookupFunction` | N/A | Allows you to set your own custom lookup function. The function needs to have as signature: `(name: NSStoryboard.Name) -> NSStoryboard` on macOS, and `(name: String) -> UIStoryboard` on other platforms. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `myStoryboardFinder(name:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
+| `lookupFunction` | N/A¹ | Allows you to set your own custom lookup function. The function needs to have as signature: `(name: NSStoryboard.Name) -> NSStoryboard` on macOS, and `(name: String) -> UIStoryboard` on other platforms. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `myStoryboardFinder(name:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
 | `module` | N/A | By default, the template will import the needed modules for custom classes, but won’t import the target’s module to avoid an import warning — using the `PRODUCT_MODULE_NAME` environment variable to detect it. Should you need to ignore an additional module, you can provide it here. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
+
+1. _If you don't provide a `lookupFunction`, we will call `NS/UIStoryboard(name:bundle:)` with the `bundle` parameter instead._
 
 ## Generated Code
 

--- a/Documentation/templates/ib/scenes-swift5.md
+++ b/Documentation/templates/ib/scenes-swift5.md
@@ -19,9 +19,10 @@ You can customize some elements of this template by overriding the following par
 
 | Parameter Name | Default Value | Description |
 | -------------- | ------------- | ----------- |
-| `bundle` | `BundleToken.bundle` | Allows you to set from which storyboard files are loaded from. By default, it'll point to the same bundle as where the generated code is. |
+| `bundle` | `BundleToken.bundle` | Allows you to set from which storyboard files are loaded from. By default, it'll point to the same bundle as where the generated code is. Note: ignored if `lookupFunction` parameter is set. |
 | `enumName` | `StoryboardScene` | Allows you to change the name of the generated `enum` containing all storyboard scenes. |
 | `ignoreTargetModule` | N/A | Setting this parameter will disable the behaviour of prefixing classes with their module name for (only) the target module. |
+| `lookupFunction` | N/A | Allows you to set your own custom lookup function. The function needs to have as signature: `(name: NSStoryboard.Name) -> NSStoryboard` on macOS, and `(name: String) -> UIStoryboard` on other platforms. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `myStoryboardFinder(name:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
 | `module` | N/A | By default, the template will import the needed modules for custom classes, but won’t import the target’s module to avoid an import warning — using the `PRODUCT_MODULE_NAME` environment variable to detect it. Should you need to ignore an additional module, you can provide it here. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
 

--- a/Documentation/templates/ib/scenes-swift5.md
+++ b/Documentation/templates/ib/scenes-swift5.md
@@ -26,7 +26,7 @@ You can customize some elements of this template by overriding the following par
 | `module` | N/A | By default, the template will import the needed modules for custom classes, but won’t import the target’s module to avoid an import warning — using the `PRODUCT_MODULE_NAME` environment variable to detect it. Should you need to ignore an additional module, you can provide it here. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
 
-1. _If you don't provide a `lookupFunction`, we will call `NS/UIStoryboard(name:bundle:)` with the `bundle` parameter instead._
+1. _If you don't provide a `lookupFunction`, we will use `NS/UIStoryboard(name:bundle:)` with the `bundle` parameter instead._
 
 ## Generated Code
 

--- a/Documentation/templates/json/runtime-swift4.md
+++ b/Documentation/templates/json/runtime-swift4.md
@@ -19,9 +19,10 @@ You can customize some elements of this template by overriding the following par
 
 | Parameter Name | Default Value | Description |
 | -------------- | ------------- | ----------- |
-| `bundle` | `BundleToken.bundle` | Allows you to set from which bundle JSON files are loaded from. By default, it'll point to the same bundle as where the generated code is. |
+| `bundle` | `BundleToken.bundle` | Allows you to set from which bundle JSON files are loaded from. By default, it'll point to the same bundle as where the generated code is. Note: ignored if `lookupFunction` parameter is set. |
 | `enumName` | `JSONFiles` | Allows you to change the name of the generated `enum` containing all files. |
 | `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
+| `lookupFunction` | N/A | Allows you to set your own custom lookup function. The function needs to have as signature: `(path: String) -> URL?`. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `myJSONFinder(path:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
 | `preservePath` | N/A | Setting this parameter will disable the basename filter applied to all file paths. Use this if you added your data folder as a "folder reference" in your Xcode project, making that folder hierarchy preserved once copied in the build app bundle. The path will be relative to the folder you provided to SwiftGen. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
 

--- a/Documentation/templates/json/runtime-swift4.md
+++ b/Documentation/templates/json/runtime-swift4.md
@@ -22,9 +22,11 @@ You can customize some elements of this template by overriding the following par
 | `bundle` | `BundleToken.bundle` | Allows you to set from which bundle JSON files are loaded from. By default, it'll point to the same bundle as where the generated code is. Note: ignored if `lookupFunction` parameter is set. |
 | `enumName` | `JSONFiles` | Allows you to change the name of the generated `enum` containing all files. |
 | `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
-| `lookupFunction` | N/A | Allows you to set your own custom lookup function. The function needs to have as signature: `(path: String) -> URL?`. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `myJSONFinder(path:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
+| `lookupFunction` | N/A¹ | Allows you to set your own custom lookup function. The function needs to have as signature: `(path: String) -> URL?`. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `myJSONFinder(path:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
 | `preservePath` | N/A | Setting this parameter will disable the basename filter applied to all file paths. Use this if you added your data folder as a "folder reference" in your Xcode project, making that folder hierarchy preserved once copied in the build app bundle. The path will be relative to the folder you provided to SwiftGen. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
+
+1. _If you don't provide a `lookupFunction`, we will call `url(forResource:withExtension:)` on the `bundle` parameter instead._
 
 ## Generated Code
 

--- a/Documentation/templates/json/runtime-swift4.md
+++ b/Documentation/templates/json/runtime-swift4.md
@@ -26,7 +26,7 @@ You can customize some elements of this template by overriding the following par
 | `preservePath` | N/A | Setting this parameter will disable the basename filter applied to all file paths. Use this if you added your data folder as a "folder reference" in your Xcode project, making that folder hierarchy preserved once copied in the build app bundle. The path will be relative to the folder you provided to SwiftGen. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
 
-1. _If you don't provide a `lookupFunction`, we will call `url(forResource:withExtension:)` on the `bundle` parameter instead._
+1. _If you don't provide a `lookupFunction`, we will use `url(forResource:withExtension:)` on the `bundle` parameter instead._
 
 ## Generated Code
 

--- a/Documentation/templates/json/runtime-swift5.md
+++ b/Documentation/templates/json/runtime-swift5.md
@@ -19,9 +19,10 @@ You can customize some elements of this template by overriding the following par
 
 | Parameter Name | Default Value | Description |
 | -------------- | ------------- | ----------- |
-| `bundle` | `BundleToken.bundle` | Allows you to set from which bundle JSON files are loaded from. By default, it'll point to the same bundle as where the generated code is. |
+| `bundle` | `BundleToken.bundle` | Allows you to set from which bundle JSON files are loaded from. By default, it'll point to the same bundle as where the generated code is. Note: ignored if `lookupFunction` parameter is set. |
 | `enumName` | `JSONFiles` | Allows you to change the name of the generated `enum` containing all files. |
 | `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
+| `lookupFunction` | N/A | Allows you to set your own custom lookup function. The function needs to have as signature: `(path: String) -> URL?`. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `myJSONFinder(path:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
 | `preservePath` | N/A | Setting this parameter will disable the basename filter applied to all file paths. Use this if you added your data folder as a "folder reference" in your Xcode project, making that folder hierarchy preserved once copied in the build app bundle. The path will be relative to the folder you provided to SwiftGen. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
 

--- a/Documentation/templates/json/runtime-swift5.md
+++ b/Documentation/templates/json/runtime-swift5.md
@@ -22,9 +22,11 @@ You can customize some elements of this template by overriding the following par
 | `bundle` | `BundleToken.bundle` | Allows you to set from which bundle JSON files are loaded from. By default, it'll point to the same bundle as where the generated code is. Note: ignored if `lookupFunction` parameter is set. |
 | `enumName` | `JSONFiles` | Allows you to change the name of the generated `enum` containing all files. |
 | `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
-| `lookupFunction` | N/A | Allows you to set your own custom lookup function. The function needs to have as signature: `(path: String) -> URL?`. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `myJSONFinder(path:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
+| `lookupFunction` | N/A¹ | Allows you to set your own custom lookup function. The function needs to have as signature: `(path: String) -> URL?`. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `myJSONFinder(path:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
 | `preservePath` | N/A | Setting this parameter will disable the basename filter applied to all file paths. Use this if you added your data folder as a "folder reference" in your Xcode project, making that folder hierarchy preserved once copied in the build app bundle. The path will be relative to the folder you provided to SwiftGen. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
+
+1. _If you don't provide a `lookupFunction`, we will call `url(forResource:withExtension:)` on the `bundle` parameter instead._
 
 ## Generated Code
 

--- a/Documentation/templates/json/runtime-swift5.md
+++ b/Documentation/templates/json/runtime-swift5.md
@@ -26,7 +26,7 @@ You can customize some elements of this template by overriding the following par
 | `preservePath` | N/A | Setting this parameter will disable the basename filter applied to all file paths. Use this if you added your data folder as a "folder reference" in your Xcode project, making that folder hierarchy preserved once copied in the build app bundle. The path will be relative to the folder you provided to SwiftGen. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
 
-1. _If you don't provide a `lookupFunction`, we will call `url(forResource:withExtension:)` on the `bundle` parameter instead._
+1. _If you don't provide a `lookupFunction`, we will use `url(forResource:withExtension:)` on the `bundle` parameter instead._
 
 ## Generated Code
 

--- a/Documentation/templates/plist/runtime-swift4.md
+++ b/Documentation/templates/plist/runtime-swift4.md
@@ -26,7 +26,7 @@ You can customize some elements of this template by overriding the following par
 | `preservePath` | N/A | Setting this parameter will disable the basename filter applied to all file paths. Use this if you added your data folder as a "folder reference" in your Xcode project, making that folder hierarchy preserved once copied in the build app bundle. The path will be relative to the folder you provided to SwiftGen. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
 
-1. _If you don't provide a `lookupFunction`, we will call `url(forResource:withExtension:)` on the `bundle` parameter instead._
+1. _If you don't provide a `lookupFunction`, we will use `url(forResource:withExtension:)` on the `bundle` parameter instead._
 
 ## Generated Code
 

--- a/Documentation/templates/plist/runtime-swift4.md
+++ b/Documentation/templates/plist/runtime-swift4.md
@@ -19,9 +19,10 @@ You can customize some elements of this template by overriding the following par
 
 | Parameter Name | Default Value | Description |
 | -------------- | ------------- | ----------- |
-| `bundle` | `BundleToken.bundle` | Allows you to set from which bundle Plist files are loaded from. By default, it'll point to the same bundle as where the generated code is. |
+| `bundle` | `BundleToken.bundle` | Allows you to set from which bundle Plist files are loaded from. By default, it'll point to the same bundle as where the generated code is. Note: ignored if `lookupFunction` parameter is set. |
 | `enumName` | `PlistFiles` | Allows you to change the name of the generated `enum` containing all files. |
 | `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
+| `lookupFunction` | N/A | Allows you to set your own custom lookup function. The function needs to have as signature: `(path: String) -> URL?`. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `myPlistFinder(path:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
 | `preservePath` | N/A | Setting this parameter will disable the basename filter applied to all file paths. Use this if you added your data folder as a "folder reference" in your Xcode project, making that folder hierarchy preserved once copied in the build app bundle. The path will be relative to the folder you provided to SwiftGen. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
 

--- a/Documentation/templates/plist/runtime-swift4.md
+++ b/Documentation/templates/plist/runtime-swift4.md
@@ -22,9 +22,11 @@ You can customize some elements of this template by overriding the following par
 | `bundle` | `BundleToken.bundle` | Allows you to set from which bundle Plist files are loaded from. By default, it'll point to the same bundle as where the generated code is. Note: ignored if `lookupFunction` parameter is set. |
 | `enumName` | `PlistFiles` | Allows you to change the name of the generated `enum` containing all files. |
 | `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
-| `lookupFunction` | N/A | Allows you to set your own custom lookup function. The function needs to have as signature: `(path: String) -> URL?`. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `myPlistFinder(path:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
+| `lookupFunction` | N/A¹ | Allows you to set your own custom lookup function. The function needs to have as signature: `(path: String) -> URL?`. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `myPlistFinder(path:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
 | `preservePath` | N/A | Setting this parameter will disable the basename filter applied to all file paths. Use this if you added your data folder as a "folder reference" in your Xcode project, making that folder hierarchy preserved once copied in the build app bundle. The path will be relative to the folder you provided to SwiftGen. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
+
+1. _If you don't provide a `lookupFunction`, we will call `url(forResource:withExtension:)` on the `bundle` parameter instead._
 
 ## Generated Code
 

--- a/Documentation/templates/plist/runtime-swift5.md
+++ b/Documentation/templates/plist/runtime-swift5.md
@@ -26,7 +26,7 @@ You can customize some elements of this template by overriding the following par
 | `preservePath` | N/A | Setting this parameter will disable the basename filter applied to all file paths. Use this if you added your data folder as a "folder reference" in your Xcode project, making that folder hierarchy preserved once copied in the build app bundle. The path will be relative to the folder you provided to SwiftGen. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
 
-1. _If you don't provide a `lookupFunction`, we will call `url(forResource:withExtension:)` on the `bundle` parameter instead._
+1. _If you don't provide a `lookupFunction`, we will use `url(forResource:withExtension:)` on the `bundle` parameter instead._
 
 ## Generated Code
 

--- a/Documentation/templates/plist/runtime-swift5.md
+++ b/Documentation/templates/plist/runtime-swift5.md
@@ -19,9 +19,10 @@ You can customize some elements of this template by overriding the following par
 
 | Parameter Name | Default Value | Description |
 | -------------- | ------------- | ----------- |
-| `bundle` | `BundleToken.bundle` | Allows you to set from which bundle Plist files are loaded from. By default, it'll point to the same bundle as where the generated code is. |
+| `bundle` | `BundleToken.bundle` | Allows you to set from which bundle Plist files are loaded from. By default, it'll point to the same bundle as where the generated code is. Note: ignored if `lookupFunction` parameter is set. |
 | `enumName` | `PlistFiles` | Allows you to change the name of the generated `enum` containing all files. |
 | `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
+| `lookupFunction` | N/A | Allows you to set your own custom lookup function. The function needs to have as signature: `(path: String) -> URL?`. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `myPlistFinder(path:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
 | `preservePath` | N/A | Setting this parameter will disable the basename filter applied to all file paths. Use this if you added your data folder as a "folder reference" in your Xcode project, making that folder hierarchy preserved once copied in the build app bundle. The path will be relative to the folder you provided to SwiftGen. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
 

--- a/Documentation/templates/plist/runtime-swift5.md
+++ b/Documentation/templates/plist/runtime-swift5.md
@@ -22,9 +22,11 @@ You can customize some elements of this template by overriding the following par
 | `bundle` | `BundleToken.bundle` | Allows you to set from which bundle Plist files are loaded from. By default, it'll point to the same bundle as where the generated code is. Note: ignored if `lookupFunction` parameter is set. |
 | `enumName` | `PlistFiles` | Allows you to change the name of the generated `enum` containing all files. |
 | `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
-| `lookupFunction` | N/A | Allows you to set your own custom lookup function. The function needs to have as signature: `(path: String) -> URL?`. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `myPlistFinder(path:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
+| `lookupFunction` | N/A¹ | Allows you to set your own custom lookup function. The function needs to have as signature: `(path: String) -> URL?`. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `myPlistFinder(path:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
 | `preservePath` | N/A | Setting this parameter will disable the basename filter applied to all file paths. Use this if you added your data folder as a "folder reference" in your Xcode project, making that folder hierarchy preserved once copied in the build app bundle. The path will be relative to the folder you provided to SwiftGen. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
+
+1. _If you don't provide a `lookupFunction`, we will call `url(forResource:withExtension:)` on the `bundle` parameter instead._
 
 ## Generated Code
 

--- a/Documentation/templates/strings/flat-swift4.md
+++ b/Documentation/templates/strings/flat-swift4.md
@@ -21,9 +21,11 @@ You can customize some elements of this template by overriding the following par
 | `bundle` | `BundleToken.bundle` | Allows you to set from which bundle strings are loaded from. By default, it'll point to the same bundle as where the generated code is. Note: ignored if `lookupFunction` parameter is set. |
 | `enumName` | `L10n` | Allows you to change the name of the generated `enum` containing all string tables. |
 | `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
-| `lookupFunction` | N/A | Allows you to set your own custom localization function. The function needs to have as signature: `(key: String, table: String) -> String`. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `yourFunctionName(forKey:table:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
+| `lookupFunction` | N/A¹ | Allows you to set your own custom localization function. The function needs to have as signature: `(key: String, table: String) -> String`. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `yourFunctionName(forKey:table:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
 | `noComments` | N/A | Setting this parameter will disable the comments describing the translation of a key. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
+
+1. _If you don't provide a `lookupFunction`, we will call `localizedString(forKey:value:table:)` on the `bundle` parameter instead._
 
 ## Generated Code
 

--- a/Documentation/templates/strings/flat-swift4.md
+++ b/Documentation/templates/strings/flat-swift4.md
@@ -25,7 +25,7 @@ You can customize some elements of this template by overriding the following par
 | `noComments` | N/A | Setting this parameter will disable the comments describing the translation of a key. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
 
-1. _If you don't provide a `lookupFunction`, we will call `localizedString(forKey:value:table:)` on the `bundle` parameter instead._
+1. _If you don't provide a `lookupFunction`, we will use `localizedString(forKey:value:table:)` on the `bundle` parameter instead._
 
 ## Generated Code
 

--- a/Documentation/templates/strings/flat-swift5.md
+++ b/Documentation/templates/strings/flat-swift5.md
@@ -21,9 +21,11 @@ You can customize some elements of this template by overriding the following par
 | `bundle` | `BundleToken.bundle` | Allows you to set from which bundle strings are loaded from. By default, it'll point to the same bundle as where the generated code is. Note: ignored if `lookupFunction` parameter is set. |
 | `enumName` | `L10n` | Allows you to change the name of the generated `enum` containing all string tables. |
 | `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
-| `lookupFunction` | N/A | Allows you to set your own custom localization function. The function needs to have as signature: `(key: String, table: String) -> String`. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `yourFunctionName(forKey:table:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
+| `lookupFunction` | N/A¹ | Allows you to set your own custom localization function. The function needs to have as signature: `(key: String, table: String) -> String`. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `yourFunctionName(forKey:table:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
 | `noComments` | N/A | Setting this parameter will disable the comments describing the translation of a key. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
+
+1. _If you don't provide a `lookupFunction`, we will call `localizedString(forKey:value:table:)` on the `bundle` parameter instead._
 
 ## Generated Code
 

--- a/Documentation/templates/strings/flat-swift5.md
+++ b/Documentation/templates/strings/flat-swift5.md
@@ -25,7 +25,7 @@ You can customize some elements of this template by overriding the following par
 | `noComments` | N/A | Setting this parameter will disable the comments describing the translation of a key. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
 
-1. _If you don't provide a `lookupFunction`, we will call `localizedString(forKey:value:table:)` on the `bundle` parameter instead._
+1. _If you don't provide a `lookupFunction`, we will use `localizedString(forKey:value:table:)` on the `bundle` parameter instead._
 
 ## Generated Code
 

--- a/Documentation/templates/strings/structured-swift4.md
+++ b/Documentation/templates/strings/structured-swift4.md
@@ -31,7 +31,7 @@ You can customize some elements of this template by overriding the following par
 | `noComments` | N/A | Setting this parameter will disable the comments describing the translation of a key. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
 
-1. _If you don't provide a `lookupFunction`, we will call `localizedString(forKey:value:table:)` on the `bundle` parameter instead._
+1. _If you don't provide a `lookupFunction`, we will use `localizedString(forKey:value:table:)` on the `bundle` parameter instead._
 
 ## Generated Code
 

--- a/Documentation/templates/strings/structured-swift4.md
+++ b/Documentation/templates/strings/structured-swift4.md
@@ -27,9 +27,11 @@ You can customize some elements of this template by overriding the following par
 | `bundle` | `BundleToken.bundle` | Allows you to set from which bundle strings are loaded from. By default, it'll point to the same bundle as where the generated code is. Note: ignored if `lookupFunction` parameter is set. |
 | `enumName` | `L10n` | Allows you to change the name of the generated `enum` containing all string tables. |
 | `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
-| `lookupFunction` | N/A | Allows you to set your own custom localization function. The function needs to have as signature: `(key: String, table: String) -> String`. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `yourFunctionName(forKey:table:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
+| `lookupFunction` | N/A¹ | Allows you to set your own custom localization function. The function needs to have as signature: `(key: String, table: String) -> String`. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `yourFunctionName(forKey:table:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
 | `noComments` | N/A | Setting this parameter will disable the comments describing the translation of a key. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
+
+1. _If you don't provide a `lookupFunction`, we will call `localizedString(forKey:value:table:)` on the `bundle` parameter instead._
 
 ## Generated Code
 

--- a/Documentation/templates/strings/structured-swift5.md
+++ b/Documentation/templates/strings/structured-swift5.md
@@ -31,7 +31,7 @@ You can customize some elements of this template by overriding the following par
 | `noComments` | N/A | Setting this parameter will disable the comments describing the translation of a key. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
 
-1. _If you don't provide a `lookupFunction`, we will call `localizedString(forKey:value:table:)` on the `bundle` parameter instead._
+1. _If you don't provide a `lookupFunction`, we will use `localizedString(forKey:value:table:)` on the `bundle` parameter instead._
 
 ## Generated Code
 

--- a/Documentation/templates/strings/structured-swift5.md
+++ b/Documentation/templates/strings/structured-swift5.md
@@ -27,9 +27,11 @@ You can customize some elements of this template by overriding the following par
 | `bundle` | `BundleToken.bundle` | Allows you to set from which bundle strings are loaded from. By default, it'll point to the same bundle as where the generated code is. Note: ignored if `lookupFunction` parameter is set. |
 | `enumName` | `L10n` | Allows you to change the name of the generated `enum` containing all string tables. |
 | `forceFileNameEnum` | N/A | Setting this parameter will generate an `enum <FileName>` _even if_ only one FileName was provided as input. |
-| `lookupFunction` | N/A | Allows you to set your own custom localization function. The function needs to have as signature: `(key: String, table: String) -> String`. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `yourFunctionName(forKey:table:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
+| `lookupFunction` | N/A¹ | Allows you to set your own custom localization function. The function needs to have as signature: `(key: String, table: String) -> String`. The parameters of your function can have any name (or even no external name), but if it has named parameters, you must provide the complete function signature, including those named parameters – e.g. `yourFunctionName(forKey:table:)`. Note: if you define this parameter, the `bundle` parameter will be ignored. |
 | `noComments` | N/A | Setting this parameter will disable the comments describing the translation of a key. |
 | `publicAccess` | N/A | If set, the generated constants will be marked as `public`. Otherwise, they'll be declared `internal`. |
+
+1. _If you don't provide a `lookupFunction`, we will call `localizedString(forKey:value:table:)` on the `bundle` parameter instead._
 
 ## Generated Code
 

--- a/Sources/SwiftGen/Config/Config+Example.swift
+++ b/Sources/SwiftGen/Config/Config+Example.swift
@@ -43,7 +43,7 @@ extension Config {
 
 
     # Generate constants for your Assets Catalogs, including constants for images, colors, ARKit resources, etc.
-    #   This example also shows how to provide additional parameters to your template to customise the output.
+    #   This example also shows how to provide additional parameters to your template to customize the output.
     #   - Especially the `forceProvidesNamespaces: true` param forces to create sub-namespace for each folder/group used in your Asset Catalogs, even the ones without "Provides Namespace". Without this param, SwiftGen only generates sub-namespaces for folders/groups which have the "Provides Namespace" box checked in the Inspector pane.
     #   - To know which params are supported for a template, use `swiftgen template doc xcassets swift5` to open the template documentation on GitHub.
     xcassets:

--- a/Tests/Fixtures/CompilationEnvironment/Common-LookupFunction.swift
+++ b/Tests/Fixtures/CompilationEnvironment/Common-LookupFunction.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+func myFontFinder(name: String, family: String, path: String) -> URL? {
+  return Bundle.main.url(forResource: path, withExtension: nil)
+}
+
+func myJSONFinder(path: String) -> URL? {
+  return Bundle.main.url(forResource: path, withExtension: nil)
+}
+
+func myPlistFinder(path: String) -> URL? {
+  return Bundle.main.url(forResource: path, withExtension: nil)
+}
+
+func XCTLocFunc(forKey key: String, table tableName: String?) -> String {
+  return NSLocalizedString(key, tableName: tableName, comment: "")
+}
+
+#if canImport(AppKit)
+import AppKit
+func myStoryboardFinder(name: NSStoryboard.Name) -> NSStoryboard {
+  return NSStoryboard(name: name, bundle: Bundle.main)
+}
+#elseif canImport(UIKit) && !os(watchOS)
+import UIKit
+func myStoryboardFinder(name: String) -> UIStoryboard {
+  return UIStoryboard(name: name, bundle: Bundle.main)
+}
+#endif

--- a/Tests/Fixtures/CompilationEnvironment/Strings-LocalizeFunction.swift
+++ b/Tests/Fixtures/CompilationEnvironment/Strings-LocalizeFunction.swift
@@ -1,5 +1,0 @@
-import Foundation
-
-func XCTLocFunc(forKey key: String, table tableName: String?) -> String {
-  return NSLocalizedString(key, tableName: tableName, comment: "")
-}

--- a/Tests/Fixtures/Generated/Fonts/swift4/compilation-configuration.yml
+++ b/Tests/Fixtures/Generated/Fonts/swift4/compilation-configuration.yml
@@ -7,3 +7,6 @@ file_specific:
   defaults-customBundle.swift:
     files:
       - Common-CustomBundle.swift
+  defaults-lookupFunction.swift:
+    files:
+      - Common-LookupFunction.swift

--- a/Tests/Fixtures/Generated/Fonts/swift4/defaults-lookupFunction.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift4/defaults-lookupFunction.swift
@@ -1,0 +1,107 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+#if os(OSX)
+  import AppKit.NSFont
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIFont
+#endif
+
+// Deprecated typealiases
+@available(*, deprecated, renamed: "FontConvertible.Font", message: "This typealias will be removed in SwiftGen 7.0")
+internal typealias Font = FontConvertible.Font
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+// swiftlint:disable implicit_return
+
+// MARK: - Fonts
+
+// swiftlint:disable identifier_name line_length type_body_length
+internal enum FontFamily {
+  internal enum SFNSDisplay {
+    internal static let black = FontConvertible(name: ".SFNSDisplay-Black", family: ".SF NS Display", path: "SFNSDisplay-Black.otf")
+    internal static let bold = FontConvertible(name: ".SFNSDisplay-Bold", family: ".SF NS Display", path: "SFNSDisplay-Bold.otf")
+    internal static let heavy = FontConvertible(name: ".SFNSDisplay-Heavy", family: ".SF NS Display", path: "SFNSDisplay-Heavy.otf")
+    internal static let regular = FontConvertible(name: ".SFNSDisplay-Regular", family: ".SF NS Display", path: "SFNSDisplay-Regular.otf")
+    internal static let all: [FontConvertible] = [black, bold, heavy, regular]
+  }
+  internal enum SFNSText {
+    internal static let bold = FontConvertible(name: ".SFNSText-Bold", family: ".SF NS Text", path: "SFNSText-Bold.otf")
+    internal static let heavy = FontConvertible(name: ".SFNSText-Heavy", family: ".SF NS Text", path: "SFNSText-Heavy.otf")
+    internal static let regular = FontConvertible(name: ".SFNSText-Regular", family: ".SF NS Text", path: "SFNSText-Regular.otf")
+    internal static let all: [FontConvertible] = [bold, heavy, regular]
+  }
+  internal enum Avenir {
+    internal static let black = FontConvertible(name: "Avenir-Black", family: "Avenir", path: "Avenir.ttc")
+    internal static let blackOblique = FontConvertible(name: "Avenir-BlackOblique", family: "Avenir", path: "Avenir.ttc")
+    internal static let book = FontConvertible(name: "Avenir-Book", family: "Avenir", path: "Avenir.ttc")
+    internal static let bookOblique = FontConvertible(name: "Avenir-BookOblique", family: "Avenir", path: "Avenir.ttc")
+    internal static let heavy = FontConvertible(name: "Avenir-Heavy", family: "Avenir", path: "Avenir.ttc")
+    internal static let heavyOblique = FontConvertible(name: "Avenir-HeavyOblique", family: "Avenir", path: "Avenir.ttc")
+    internal static let light = FontConvertible(name: "Avenir-Light", family: "Avenir", path: "Avenir.ttc")
+    internal static let lightOblique = FontConvertible(name: "Avenir-LightOblique", family: "Avenir", path: "Avenir.ttc")
+    internal static let medium = FontConvertible(name: "Avenir-Medium", family: "Avenir", path: "Avenir.ttc")
+    internal static let mediumOblique = FontConvertible(name: "Avenir-MediumOblique", family: "Avenir", path: "Avenir.ttc")
+    internal static let oblique = FontConvertible(name: "Avenir-Oblique", family: "Avenir", path: "Avenir.ttc")
+    internal static let roman = FontConvertible(name: "Avenir-Roman", family: "Avenir", path: "Avenir.ttc")
+    internal static let all: [FontConvertible] = [black, blackOblique, book, bookOblique, heavy, heavyOblique, light, lightOblique, medium, mediumOblique, oblique, roman]
+  }
+  internal enum ZapfDingbats {
+    internal static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
+    internal static let all: [FontConvertible] = [regular]
+  }
+  internal enum Public {
+    internal static let `internal` = FontConvertible(name: "private", family: "public", path: "class.ttf")
+    internal static let all: [FontConvertible] = [`internal`]
+  }
+  internal static let allCustomFonts: [FontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, ZapfDingbats.all, Public.all].flatMap { $0 }
+  internal static func registerAllCustomFonts() {
+    allCustomFonts.forEach { $0.register() }
+  }
+}
+// swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+internal struct FontConvertible {
+  internal let name: String
+  internal let family: String
+  internal let path: String
+
+  #if os(OSX)
+  internal typealias Font = NSFont
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  internal typealias Font = UIFont
+  #endif
+
+  internal func font(size: CGFloat) -> Font! {
+    return Font(font: self, size: size)
+  }
+
+  internal func register() {
+    // swiftlint:disable:next conditional_returns_on_newline
+    guard let url = url else { return }
+    CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
+  }
+
+  fileprivate var url: URL? {
+    return myFontFinder(name:family:path:)(name, family, path)
+  }
+}
+
+internal extension FontConvertible.Font {
+  convenience init?(font: FontConvertible, size: CGFloat) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
+      font.register()
+    }
+    #elseif os(OSX)
+    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
+      font.register()
+    }
+    #endif
+
+    self.init(name: font.name, size: size)
+  }
+}

--- a/Tests/Fixtures/Generated/Fonts/swift5/compilation-configuration.yml
+++ b/Tests/Fixtures/Generated/Fonts/swift5/compilation-configuration.yml
@@ -6,3 +6,6 @@ file_specific:
   defaults-customBundle.swift:
     files:
       - Common-CustomBundle.swift
+  defaults-lookupFunction.swift:
+    files:
+      - Common-LookupFunction.swift

--- a/Tests/Fixtures/Generated/Fonts/swift5/defaults-lookupFunction.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift5/defaults-lookupFunction.swift
@@ -1,0 +1,110 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+#if os(OSX)
+  import AppKit.NSFont
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIFont
+#endif
+
+// Deprecated typealiases
+@available(*, deprecated, renamed: "FontConvertible.Font", message: "This typealias will be removed in SwiftGen 7.0")
+internal typealias Font = FontConvertible.Font
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - Fonts
+
+// swiftlint:disable identifier_name line_length type_body_length
+internal enum FontFamily {
+  internal enum SFNSDisplay {
+    internal static let black = FontConvertible(name: ".SFNSDisplay-Black", family: ".SF NS Display", path: "SFNSDisplay-Black.otf")
+    internal static let bold = FontConvertible(name: ".SFNSDisplay-Bold", family: ".SF NS Display", path: "SFNSDisplay-Bold.otf")
+    internal static let heavy = FontConvertible(name: ".SFNSDisplay-Heavy", family: ".SF NS Display", path: "SFNSDisplay-Heavy.otf")
+    internal static let regular = FontConvertible(name: ".SFNSDisplay-Regular", family: ".SF NS Display", path: "SFNSDisplay-Regular.otf")
+    internal static let all: [FontConvertible] = [black, bold, heavy, regular]
+  }
+  internal enum SFNSText {
+    internal static let bold = FontConvertible(name: ".SFNSText-Bold", family: ".SF NS Text", path: "SFNSText-Bold.otf")
+    internal static let heavy = FontConvertible(name: ".SFNSText-Heavy", family: ".SF NS Text", path: "SFNSText-Heavy.otf")
+    internal static let regular = FontConvertible(name: ".SFNSText-Regular", family: ".SF NS Text", path: "SFNSText-Regular.otf")
+    internal static let all: [FontConvertible] = [bold, heavy, regular]
+  }
+  internal enum Avenir {
+    internal static let black = FontConvertible(name: "Avenir-Black", family: "Avenir", path: "Avenir.ttc")
+    internal static let blackOblique = FontConvertible(name: "Avenir-BlackOblique", family: "Avenir", path: "Avenir.ttc")
+    internal static let book = FontConvertible(name: "Avenir-Book", family: "Avenir", path: "Avenir.ttc")
+    internal static let bookOblique = FontConvertible(name: "Avenir-BookOblique", family: "Avenir", path: "Avenir.ttc")
+    internal static let heavy = FontConvertible(name: "Avenir-Heavy", family: "Avenir", path: "Avenir.ttc")
+    internal static let heavyOblique = FontConvertible(name: "Avenir-HeavyOblique", family: "Avenir", path: "Avenir.ttc")
+    internal static let light = FontConvertible(name: "Avenir-Light", family: "Avenir", path: "Avenir.ttc")
+    internal static let lightOblique = FontConvertible(name: "Avenir-LightOblique", family: "Avenir", path: "Avenir.ttc")
+    internal static let medium = FontConvertible(name: "Avenir-Medium", family: "Avenir", path: "Avenir.ttc")
+    internal static let mediumOblique = FontConvertible(name: "Avenir-MediumOblique", family: "Avenir", path: "Avenir.ttc")
+    internal static let oblique = FontConvertible(name: "Avenir-Oblique", family: "Avenir", path: "Avenir.ttc")
+    internal static let roman = FontConvertible(name: "Avenir-Roman", family: "Avenir", path: "Avenir.ttc")
+    internal static let all: [FontConvertible] = [black, blackOblique, book, bookOblique, heavy, heavyOblique, light, lightOblique, medium, mediumOblique, oblique, roman]
+  }
+  internal enum ZapfDingbats {
+    internal static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
+    internal static let all: [FontConvertible] = [regular]
+  }
+  internal enum Public {
+    internal static let `internal` = FontConvertible(name: "private", family: "public", path: "class.ttf")
+    internal static let all: [FontConvertible] = [`internal`]
+  }
+  internal static let allCustomFonts: [FontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, ZapfDingbats.all, Public.all].flatMap { $0 }
+  internal static func registerAllCustomFonts() {
+    allCustomFonts.forEach { $0.register() }
+  }
+}
+// swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+internal struct FontConvertible {
+  internal let name: String
+  internal let family: String
+  internal let path: String
+
+  #if os(OSX)
+  internal typealias Font = NSFont
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  internal typealias Font = UIFont
+  #endif
+
+  internal func font(size: CGFloat) -> Font {
+    guard let font = Font(font: self, size: size) else {
+      fatalError("Unabble to initialize font '\(name)' (\(family))")
+    }
+    return font
+  }
+
+  internal func register() {
+    // swiftlint:disable:next conditional_returns_on_newline
+    guard let url = url else { return }
+    CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
+  }
+
+  fileprivate var url: URL? {
+    // swiftlint:disable:next implicit_return
+    return myFontFinder(name:family:path:)(name, family, path)
+  }
+}
+
+internal extension FontConvertible.Font {
+  convenience init?(font: FontConvertible, size: CGFloat) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
+      font.register()
+    }
+    #elseif os(OSX)
+    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
+      font.register()
+    }
+    #endif
+
+    self.init(name: font.name, size: size)
+  }
+}

--- a/Tests/Fixtures/Generated/IB-iOS/scenes-swift4/all-lookupFunction.swift
+++ b/Tests/Fixtures/Generated/IB-iOS/scenes-swift4/all-lookupFunction.swift
@@ -1,0 +1,127 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+// swiftlint:disable sorted_imports
+import Foundation
+import AVKit
+import ExtraModule
+import GLKit
+import LocationPicker
+import SlackTextViewController
+import UIKit
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - Storyboard Scenes
+
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+internal enum StoryboardScene {
+  internal enum AdditionalImport: StoryboardType {
+    internal static let storyboardName = "AdditionalImport"
+
+    internal static let initialScene = InitialSceneType<LocationPicker.LocationPickerViewController>(storyboard: AdditionalImport.self)
+
+    internal static let `public` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "public")
+  }
+  internal enum Anonymous: StoryboardType {
+    internal static let storyboardName = "Anonymous"
+
+    internal static let initialScene = InitialSceneType<UIKit.UINavigationController>(storyboard: Anonymous.self)
+  }
+  internal enum Dependency: StoryboardType {
+    internal static let storyboardName = "Dependency"
+
+    internal static let dependent = SceneType<ExtraModule.ValidatePasswordViewController>(storyboard: Dependency.self, identifier: "Dependent")
+  }
+  internal enum KnownTypes: StoryboardType {
+    internal static let storyboardName = "Known Types"
+
+    internal static let item1 = SceneType<GLKit.GLKViewController>(storyboard: KnownTypes.self, identifier: "item 1")
+
+    internal static let item2 = SceneType<AVKit.AVPlayerViewController>(storyboard: KnownTypes.self, identifier: "item 2")
+
+    internal static let item3 = SceneType<UIKit.UITabBarController>(storyboard: KnownTypes.self, identifier: "item 3")
+
+    internal static let item4 = SceneType<UIKit.UINavigationController>(storyboard: KnownTypes.self, identifier: "item 4")
+
+    internal static let item5 = SceneType<UIKit.UISplitViewController>(storyboard: KnownTypes.self, identifier: "item 5")
+
+    internal static let item6 = SceneType<UIKit.UIPageViewController>(storyboard: KnownTypes.self, identifier: "item 6")
+
+    internal static let item7 = SceneType<UIKit.UITableViewController>(storyboard: KnownTypes.self, identifier: "item 7")
+
+    internal static let item8 = SceneType<UIKit.UICollectionViewController>(storyboard: KnownTypes.self, identifier: "item 8")
+
+    internal static let item9 = SceneType<UIKit.UIViewController>(storyboard: KnownTypes.self, identifier: "item 9")
+  }
+  internal enum Message: StoryboardType {
+    internal static let storyboardName = "Message"
+
+    internal static let initialScene = InitialSceneType<UIKit.UIViewController>(storyboard: Message.self)
+
+    internal static let composer = SceneType<UIKit.UIViewController>(storyboard: Message.self, identifier: "Composer")
+
+    internal static let messagesList = SceneType<UIKit.UITableViewController>(storyboard: Message.self, identifier: "MessagesList")
+
+    internal static let navCtrl = SceneType<UIKit.UINavigationController>(storyboard: Message.self, identifier: "NavCtrl")
+
+    internal static let urlChooser = SceneType<SwiftGen.PickerViewController>(storyboard: Message.self, identifier: "URLChooser")
+  }
+  internal enum Placeholder: StoryboardType {
+    internal static let storyboardName = "Placeholder"
+
+    internal static let navigation = SceneType<UIKit.UINavigationController>(storyboard: Placeholder.self, identifier: "Navigation")
+  }
+  internal enum Wizard: StoryboardType {
+    internal static let storyboardName = "Wizard"
+
+    internal static let initialScene = InitialSceneType<SwiftGen.CreateAccViewController>(storyboard: Wizard.self)
+
+    internal static let acceptToS = SceneType<UIKit.UIViewController>(storyboard: Wizard.self, identifier: "Accept-ToS")
+
+    internal static let createAccount = SceneType<SwiftGen.CreateAccViewController>(storyboard: Wizard.self, identifier: "CreateAccount")
+
+    internal static let preferences = SceneType<UIKit.UITableViewController>(storyboard: Wizard.self, identifier: "Preferences")
+
+    internal static let validatePassword = SceneType<ExtraModule.ValidatePasswordViewController>(storyboard: Wizard.self, identifier: "Validate_Password")
+  }
+}
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
+internal protocol StoryboardType {
+  static var storyboardName: String { get }
+}
+
+internal extension StoryboardType {
+  static var storyboard: UIStoryboard {
+    let name = self.storyboardName
+    return myStoryboardFinder(name:)(name)
+  }
+}
+
+internal struct SceneType<T: UIViewController> {
+  internal let storyboard: StoryboardType.Type
+  internal let identifier: String
+
+  internal func instantiate() -> T {
+    let identifier = self.identifier
+    guard let controller = storyboard.storyboard.instantiateViewController(withIdentifier: identifier) as? T else {
+      fatalError("ViewController '\(identifier)' is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal struct InitialSceneType<T: UIViewController> {
+  internal let storyboard: StoryboardType.Type
+
+  internal func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateInitialViewController() as? T else {
+      fatalError("ViewController is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}

--- a/Tests/Fixtures/Generated/IB-iOS/scenes-swift4/compilation-configuration.yml
+++ b/Tests/Fixtures/Generated/IB-iOS/scenes-swift4/compilation-configuration.yml
@@ -25,6 +25,10 @@ file_specific:
   all-ignoreTargetModule.swift:
     files:
       - IB-iOS-Definitions.swift
+  all-lookupFunction.swift:
+    files:
+      - IB-iOS-Definitions.swift
+      - Common-LookupFunction.swift
   all-noDefinedModule.swift:
     files:
       - IB-iOS-Definitions.swift

--- a/Tests/Fixtures/Generated/IB-iOS/scenes-swift5/all-lookupFunction.swift
+++ b/Tests/Fixtures/Generated/IB-iOS/scenes-swift5/all-lookupFunction.swift
@@ -1,0 +1,127 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+// swiftlint:disable sorted_imports
+import Foundation
+import AVKit
+import ExtraModule
+import GLKit
+import LocationPicker
+import SlackTextViewController
+import UIKit
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - Storyboard Scenes
+
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+internal enum StoryboardScene {
+  internal enum AdditionalImport: StoryboardType {
+    internal static let storyboardName = "AdditionalImport"
+
+    internal static let initialScene = InitialSceneType<LocationPicker.LocationPickerViewController>(storyboard: AdditionalImport.self)
+
+    internal static let `public` = SceneType<SlackTextViewController.SLKTextViewController>(storyboard: AdditionalImport.self, identifier: "public")
+  }
+  internal enum Anonymous: StoryboardType {
+    internal static let storyboardName = "Anonymous"
+
+    internal static let initialScene = InitialSceneType<UIKit.UINavigationController>(storyboard: Anonymous.self)
+  }
+  internal enum Dependency: StoryboardType {
+    internal static let storyboardName = "Dependency"
+
+    internal static let dependent = SceneType<ExtraModule.ValidatePasswordViewController>(storyboard: Dependency.self, identifier: "Dependent")
+  }
+  internal enum KnownTypes: StoryboardType {
+    internal static let storyboardName = "Known Types"
+
+    internal static let item1 = SceneType<GLKit.GLKViewController>(storyboard: KnownTypes.self, identifier: "item 1")
+
+    internal static let item2 = SceneType<AVKit.AVPlayerViewController>(storyboard: KnownTypes.self, identifier: "item 2")
+
+    internal static let item3 = SceneType<UIKit.UITabBarController>(storyboard: KnownTypes.self, identifier: "item 3")
+
+    internal static let item4 = SceneType<UIKit.UINavigationController>(storyboard: KnownTypes.self, identifier: "item 4")
+
+    internal static let item5 = SceneType<UIKit.UISplitViewController>(storyboard: KnownTypes.self, identifier: "item 5")
+
+    internal static let item6 = SceneType<UIKit.UIPageViewController>(storyboard: KnownTypes.self, identifier: "item 6")
+
+    internal static let item7 = SceneType<UIKit.UITableViewController>(storyboard: KnownTypes.self, identifier: "item 7")
+
+    internal static let item8 = SceneType<UIKit.UICollectionViewController>(storyboard: KnownTypes.self, identifier: "item 8")
+
+    internal static let item9 = SceneType<UIKit.UIViewController>(storyboard: KnownTypes.self, identifier: "item 9")
+  }
+  internal enum Message: StoryboardType {
+    internal static let storyboardName = "Message"
+
+    internal static let initialScene = InitialSceneType<UIKit.UIViewController>(storyboard: Message.self)
+
+    internal static let composer = SceneType<UIKit.UIViewController>(storyboard: Message.self, identifier: "Composer")
+
+    internal static let messagesList = SceneType<UIKit.UITableViewController>(storyboard: Message.self, identifier: "MessagesList")
+
+    internal static let navCtrl = SceneType<UIKit.UINavigationController>(storyboard: Message.self, identifier: "NavCtrl")
+
+    internal static let urlChooser = SceneType<SwiftGen.PickerViewController>(storyboard: Message.self, identifier: "URLChooser")
+  }
+  internal enum Placeholder: StoryboardType {
+    internal static let storyboardName = "Placeholder"
+
+    internal static let navigation = SceneType<UIKit.UINavigationController>(storyboard: Placeholder.self, identifier: "Navigation")
+  }
+  internal enum Wizard: StoryboardType {
+    internal static let storyboardName = "Wizard"
+
+    internal static let initialScene = InitialSceneType<SwiftGen.CreateAccViewController>(storyboard: Wizard.self)
+
+    internal static let acceptToS = SceneType<UIKit.UIViewController>(storyboard: Wizard.self, identifier: "Accept-ToS")
+
+    internal static let createAccount = SceneType<SwiftGen.CreateAccViewController>(storyboard: Wizard.self, identifier: "CreateAccount")
+
+    internal static let preferences = SceneType<UIKit.UITableViewController>(storyboard: Wizard.self, identifier: "Preferences")
+
+    internal static let validatePassword = SceneType<ExtraModule.ValidatePasswordViewController>(storyboard: Wizard.self, identifier: "Validate_Password")
+  }
+}
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
+internal protocol StoryboardType {
+  static var storyboardName: String { get }
+}
+
+internal extension StoryboardType {
+  static var storyboard: UIStoryboard {
+    let name = self.storyboardName
+    return myStoryboardFinder(name:)(name)
+  }
+}
+
+internal struct SceneType<T: UIViewController> {
+  internal let storyboard: StoryboardType.Type
+  internal let identifier: String
+
+  internal func instantiate() -> T {
+    let identifier = self.identifier
+    guard let controller = storyboard.storyboard.instantiateViewController(withIdentifier: identifier) as? T else {
+      fatalError("ViewController '\(identifier)' is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal struct InitialSceneType<T: UIViewController> {
+  internal let storyboard: StoryboardType.Type
+
+  internal func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateInitialViewController() as? T else {
+      fatalError("ViewController is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}

--- a/Tests/Fixtures/Generated/IB-iOS/scenes-swift5/compilation-configuration.yml
+++ b/Tests/Fixtures/Generated/IB-iOS/scenes-swift5/compilation-configuration.yml
@@ -24,6 +24,10 @@ file_specific:
   all-ignoreTargetModule.swift:
     files:
       - IB-iOS-Definitions.swift
+  all-lookupFunction.swift:
+    files:
+      - IB-iOS-Definitions.swift
+      - Common-LookupFunction.swift
   all-noDefinedModule.swift:
     files:
       - IB-iOS-Definitions.swift

--- a/Tests/Fixtures/Generated/IB-macOS/scenes-swift4/all-lookupFunction.swift
+++ b/Tests/Fixtures/Generated/IB-macOS/scenes-swift4/all-lookupFunction.swift
@@ -1,0 +1,101 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+// swiftlint:disable sorted_imports
+import Foundation
+import AppKit
+import ExtraModule
+import PrefsWindowController
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - Storyboard Scenes
+
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+internal enum StoryboardScene {
+  internal enum AdditionalImport: StoryboardType {
+    internal static let storyboardName = "AdditionalImport"
+
+    internal static let `private` = SceneType<PrefsWindowController.DBPrefsWindowController>(storyboard: AdditionalImport.self, identifier: "private")
+  }
+  internal enum Anonymous: StoryboardType {
+    internal static let storyboardName = "Anonymous"
+  }
+  internal enum Dependency: StoryboardType {
+    internal static let storyboardName = "Dependency"
+
+    internal static let dependent = SceneType<ExtraModule.LoginViewController>(storyboard: Dependency.self, identifier: "Dependent")
+  }
+  internal enum KnownTypes: StoryboardType {
+    internal static let storyboardName = "Known Types"
+
+    internal static let item1 = SceneType<AppKit.NSWindowController>(storyboard: KnownTypes.self, identifier: "item 1")
+
+    internal static let item2 = SceneType<AppKit.NSSplitViewController>(storyboard: KnownTypes.self, identifier: "item 2")
+
+    internal static let item3 = SceneType<AppKit.NSViewController>(storyboard: KnownTypes.self, identifier: "item 3")
+
+    internal static let item4 = SceneType<AppKit.NSPageController>(storyboard: KnownTypes.self, identifier: "item 4")
+
+    internal static let item5 = SceneType<AppKit.NSTabViewController>(storyboard: KnownTypes.self, identifier: "item 5")
+  }
+  internal enum Message: StoryboardType {
+    internal static let storyboardName = "Message"
+
+    internal static let messageDetails = SceneType<SwiftGen.DetailsViewController>(storyboard: Message.self, identifier: "MessageDetails")
+
+    internal static let messageList = SceneType<AppKit.NSViewController>(storyboard: Message.self, identifier: "MessageList")
+
+    internal static let messageListFooter = SceneType<AppKit.NSViewController>(storyboard: Message.self, identifier: "MessageListFooter")
+
+    internal static let messagesTab = SceneType<SwiftGen.CustomTabViewController>(storyboard: Message.self, identifier: "MessagesTab")
+
+    internal static let splitMessages = SceneType<AppKit.NSSplitViewController>(storyboard: Message.self, identifier: "SplitMessages")
+
+    internal static let windowCtrl = SceneType<AppKit.NSWindowController>(storyboard: Message.self, identifier: "WindowCtrl")
+  }
+  internal enum Placeholder: StoryboardType {
+    internal static let storyboardName = "Placeholder"
+
+    internal static let window = SceneType<AppKit.NSWindowController>(storyboard: Placeholder.self, identifier: "Window")
+  }
+}
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
+internal protocol StoryboardType {
+  static var storyboardName: String { get }
+}
+
+internal extension StoryboardType {
+  static var storyboard: NSStoryboard {
+    let name = NSStoryboard.Name(self.storyboardName)
+    return myStoryboardFinder(name:)(name)
+  }
+}
+
+internal struct SceneType<T> {
+  internal let storyboard: StoryboardType.Type
+  internal let identifier: String
+
+  internal func instantiate() -> T {
+    let identifier = NSStoryboard.SceneIdentifier(self.identifier)
+    guard let controller = storyboard.storyboard.instantiateController(withIdentifier: identifier) as? T else {
+      fatalError("Controller '\(identifier)' is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal struct InitialSceneType<T> {
+  internal let storyboard: StoryboardType.Type
+
+  internal func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateInitialController() as? T else {
+      fatalError("Controller is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}

--- a/Tests/Fixtures/Generated/IB-macOS/scenes-swift4/compilation-configuration.yml
+++ b/Tests/Fixtures/Generated/IB-macOS/scenes-swift4/compilation-configuration.yml
@@ -23,6 +23,10 @@ file_specific:
   all-ignoreTargetModule.swift:
     files:
       - IB-macOS-Definitions.swift
+  all-lookupFunction.swift:
+    files:
+      - IB-macOS-Definitions.swift
+      - Common-LookupFunction.swift
   all-noDefinedModule.swift:
     files:
       - IB-macOS-Definitions.swift

--- a/Tests/Fixtures/Generated/IB-macOS/scenes-swift5/all-lookupFunction.swift
+++ b/Tests/Fixtures/Generated/IB-macOS/scenes-swift5/all-lookupFunction.swift
@@ -1,0 +1,101 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+// swiftlint:disable sorted_imports
+import Foundation
+import AppKit
+import ExtraModule
+import PrefsWindowController
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - Storyboard Scenes
+
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+internal enum StoryboardScene {
+  internal enum AdditionalImport: StoryboardType {
+    internal static let storyboardName = "AdditionalImport"
+
+    internal static let `private` = SceneType<PrefsWindowController.DBPrefsWindowController>(storyboard: AdditionalImport.self, identifier: "private")
+  }
+  internal enum Anonymous: StoryboardType {
+    internal static let storyboardName = "Anonymous"
+  }
+  internal enum Dependency: StoryboardType {
+    internal static let storyboardName = "Dependency"
+
+    internal static let dependent = SceneType<ExtraModule.LoginViewController>(storyboard: Dependency.self, identifier: "Dependent")
+  }
+  internal enum KnownTypes: StoryboardType {
+    internal static let storyboardName = "Known Types"
+
+    internal static let item1 = SceneType<AppKit.NSWindowController>(storyboard: KnownTypes.self, identifier: "item 1")
+
+    internal static let item2 = SceneType<AppKit.NSSplitViewController>(storyboard: KnownTypes.self, identifier: "item 2")
+
+    internal static let item3 = SceneType<AppKit.NSViewController>(storyboard: KnownTypes.self, identifier: "item 3")
+
+    internal static let item4 = SceneType<AppKit.NSPageController>(storyboard: KnownTypes.self, identifier: "item 4")
+
+    internal static let item5 = SceneType<AppKit.NSTabViewController>(storyboard: KnownTypes.self, identifier: "item 5")
+  }
+  internal enum Message: StoryboardType {
+    internal static let storyboardName = "Message"
+
+    internal static let messageDetails = SceneType<SwiftGen.DetailsViewController>(storyboard: Message.self, identifier: "MessageDetails")
+
+    internal static let messageList = SceneType<AppKit.NSViewController>(storyboard: Message.self, identifier: "MessageList")
+
+    internal static let messageListFooter = SceneType<AppKit.NSViewController>(storyboard: Message.self, identifier: "MessageListFooter")
+
+    internal static let messagesTab = SceneType<SwiftGen.CustomTabViewController>(storyboard: Message.self, identifier: "MessagesTab")
+
+    internal static let splitMessages = SceneType<AppKit.NSSplitViewController>(storyboard: Message.self, identifier: "SplitMessages")
+
+    internal static let windowCtrl = SceneType<AppKit.NSWindowController>(storyboard: Message.self, identifier: "WindowCtrl")
+  }
+  internal enum Placeholder: StoryboardType {
+    internal static let storyboardName = "Placeholder"
+
+    internal static let window = SceneType<AppKit.NSWindowController>(storyboard: Placeholder.self, identifier: "Window")
+  }
+}
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
+
+// MARK: - Implementation Details
+
+internal protocol StoryboardType {
+  static var storyboardName: String { get }
+}
+
+internal extension StoryboardType {
+  static var storyboard: NSStoryboard {
+    let name = NSStoryboard.Name(self.storyboardName)
+    return myStoryboardFinder(name:)(name)
+  }
+}
+
+internal struct SceneType<T> {
+  internal let storyboard: StoryboardType.Type
+  internal let identifier: String
+
+  internal func instantiate() -> T {
+    let identifier = NSStoryboard.SceneIdentifier(self.identifier)
+    guard let controller = storyboard.storyboard.instantiateController(withIdentifier: identifier) as? T else {
+      fatalError("Controller '\(identifier)' is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}
+
+internal struct InitialSceneType<T> {
+  internal let storyboard: StoryboardType.Type
+
+  internal func instantiate() -> T {
+    guard let controller = storyboard.storyboard.instantiateInitialController() as? T else {
+      fatalError("Controller is not of the expected class \(T.self).")
+    }
+    return controller
+  }
+}

--- a/Tests/Fixtures/Generated/IB-macOS/scenes-swift5/compilation-configuration.yml
+++ b/Tests/Fixtures/Generated/IB-macOS/scenes-swift5/compilation-configuration.yml
@@ -22,6 +22,10 @@ file_specific:
   all-ignoreTargetModule.swift:
     files:
       - IB-macOS-Definitions.swift
+  all-lookupFunction.swift:
+    files:
+      - IB-macOS-Definitions.swift
+      - Common-LookupFunction.swift
   all-noDefinedModule.swift:
     files:
       - IB-macOS-Definitions.swift

--- a/Tests/Fixtures/Generated/JSON/runtime-swift4/all-lookupFunction.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift4/all-lookupFunction.swift
@@ -1,0 +1,50 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+import Foundation
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - JSON Files
+
+// swiftlint:disable identifier_name line_length type_body_length
+internal enum JSONFiles {
+  internal enum Array {
+    internal static let items: [String] = objectFromJSON(at: "array.json")
+  }
+  internal enum Configuration {
+    private static let _document = JSONDocument(path: "configuration.json")
+    internal static let apiVersion: String = _document["api-version"]
+    internal static let country: Any? = _document["country"]
+    internal static let environment: String = _document["environment"]
+    internal static let options: [String: Any] = _document["options"]
+  }
+}
+// swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+private func objectFromJSON<T>(at path: String) -> T {
+  guard let url = myJSONFinder(path:)(path),
+    let json = try? JSONSerialization.jsonObject(with: Data(contentsOf: url), options: []),
+    let result = json as? T else {
+    fatalError("Unable to load JSON at path: \(path)")
+  }
+  return result
+}
+
+private struct JSONDocument {
+  let data: [String: Any]
+
+  init(path: String) {
+    self.data = objectFromJSON(at: path)
+  }
+
+  subscript<T>(key: String) -> T {
+    guard let result = data[key] as? T else {
+      fatalError("Property '\(key)' is not of type \(T.self)")
+    }
+    return result
+  }
+}

--- a/Tests/Fixtures/Generated/JSON/runtime-swift4/compilation-configuration.yml
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift4/compilation-configuration.yml
@@ -7,3 +7,6 @@ file_specific:
   all-customBundle.swift:
     files:
       - Common-CustomBundle.swift
+  all-lookupFunction.swift:
+    files:
+      - Common-LookupFunction.swift

--- a/Tests/Fixtures/Generated/JSON/runtime-swift5/all-lookupFunction.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift5/all-lookupFunction.swift
@@ -1,0 +1,50 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+import Foundation
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - JSON Files
+
+// swiftlint:disable identifier_name line_length type_body_length
+internal enum JSONFiles {
+  internal enum Array {
+    internal static let items: [String] = objectFromJSON(at: "array.json")
+  }
+  internal enum Configuration {
+    private static let _document = JSONDocument(path: "configuration.json")
+    internal static let apiVersion: String = _document["api-version"]
+    internal static let country: Any? = _document["country"]
+    internal static let environment: String = _document["environment"]
+    internal static let options: [String: Any] = _document["options"]
+  }
+}
+// swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+private func objectFromJSON<T>(at path: String) -> T {
+  guard let url = myJSONFinder(path:)(path),
+    let json = try? JSONSerialization.jsonObject(with: Data(contentsOf: url), options: []),
+    let result = json as? T else {
+    fatalError("Unable to load JSON at path: \(path)")
+  }
+  return result
+}
+
+private struct JSONDocument {
+  let data: [String: Any]
+
+  init(path: String) {
+    self.data = objectFromJSON(at: path)
+  }
+
+  subscript<T>(key: String) -> T {
+    guard let result = data[key] as? T else {
+      fatalError("Property '\(key)' is not of type \(T.self)")
+    }
+    return result
+  }
+}

--- a/Tests/Fixtures/Generated/JSON/runtime-swift5/compilation-configuration.yml
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift5/compilation-configuration.yml
@@ -6,3 +6,6 @@ file_specific:
   all-customBundle.swift:
     files:
       - Common-CustomBundle.swift
+  all-lookupFunction.swift:
+    files:
+      - Common-LookupFunction.swift

--- a/Tests/Fixtures/Generated/Plist/runtime-swift4/all-lookupFunction.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift4/all-lookupFunction.swift
@@ -1,0 +1,84 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+import Foundation
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - Plist Files
+
+// swiftlint:disable identifier_name line_length type_body_length
+internal enum PlistFiles {
+  internal enum Info {
+    private static let _document = PlistDocument(path: "Info.plist")
+    internal static let cfBundleDevelopmentRegion: String = _document["CFBundleDevelopmentRegion"]
+    internal static let cfBundleDisplayName: String = _document["CFBundleDisplayName"]
+    internal static let cfBundleExecutable: String = _document["CFBundleExecutable"]
+    internal static let cfBundleIdentifier: String = _document["CFBundleIdentifier"]
+    internal static let cfBundleInfoDictionaryVersion: String = _document["CFBundleInfoDictionaryVersion"]
+    internal static let cfBundleName: String = _document["CFBundleName"]
+    internal static let cfBundlePackageType: String = _document["CFBundlePackageType"]
+    internal static let cfBundleShortVersionString: String = _document["CFBundleShortVersionString"]
+    internal static let cfBundleSignature: String = _document["CFBundleSignature"]
+    internal static let cfBundleVersion: String = _document["CFBundleVersion"]
+    internal static let fabric: [String: Any] = _document["Fabric"]
+    internal static let itsAppUsesNonExemptEncryption: Bool = _document["ITSAppUsesNonExemptEncryption"]
+    internal static let lsRequiresIPhoneOS: Bool = _document["LSRequiresIPhoneOS"]
+    internal static let nsAppTransportSecurity: [String: Any] = _document["NSAppTransportSecurity"]
+    internal static let nsCameraUsageDescription: String = _document["NSCameraUsageDescription"]
+    internal static let nsPhotoLibraryUsageDescription: String = _document["NSPhotoLibraryUsageDescription"]
+    internal static let uiBackgroundModes: [String] = _document["UIBackgroundModes"]
+    internal static let uiLaunchStoryboardName: String = _document["UILaunchStoryboardName"]
+    internal static let uiMainStoryboardFile: String = _document["UIMainStoryboardFile"]
+    internal static let uiRequiredDeviceCapabilities: [String] = _document["UIRequiredDeviceCapabilities"]
+    internal static let uiRequiresFullScreen: Bool = _document["UIRequiresFullScreen"]
+    internal static let uiStatusBarStyle: String = _document["UIStatusBarStyle"]
+    internal static let uiSupportedInterfaceOrientations: [String] = _document["UISupportedInterfaceOrientations"]
+    internal static let uiSupportedInterfaceOrientationsIpad: [String] = _document["UISupportedInterfaceOrientations~ipad"]
+    internal static let userAmbiguousInteger: Bool = _document["User Ambiguous Integer"]
+    internal static let userBoolean: Bool = _document["User Boolean"]
+    internal static let userDate: Date = _document["User Date"]
+    internal static let userFloat: Double = _document["User Float"]
+    internal static let userInteger: Int = _document["User Integer"]
+  }
+  internal enum Configuration {
+    private static let _document = PlistDocument(path: "configuration.plist")
+    internal static let environment: String = _document["Environment"]
+    internal static let names: [String] = _document["Names"]
+    internal static let options: [String: Any] = _document["Options"]
+  }
+  internal enum ShoppingList {
+    internal static let items: [String] = arrayFromPlist(at: "shopping-list.plist")
+  }
+}
+// swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+private func arrayFromPlist<T>(at path: String) -> [T] {
+  guard let url = myPlistFinder(path:)(path),
+    let data = NSArray(contentsOf: url) as? [T] else {
+    fatalError("Unable to load PLIST at path: \(path)")
+  }
+  return data
+}
+
+private struct PlistDocument {
+  let data: [String: Any]
+
+  init(path: String) {
+    guard let url = myPlistFinder(path:)(path),
+      let data = NSDictionary(contentsOf: url) as? [String: Any] else {
+        fatalError("Unable to load PLIST at path: \(path)")
+    }
+    self.data = data
+  }
+
+  subscript<T>(key: String) -> T {
+    guard let result = data[key] as? T else {
+      fatalError("Property '\(key)' is not of type \(T.self)")
+    }
+    return result
+  }
+}

--- a/Tests/Fixtures/Generated/Plist/runtime-swift4/compilation-configuration.yml
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift4/compilation-configuration.yml
@@ -7,3 +7,6 @@ file_specific:
   all-customBundle.swift:
     files:
       - Common-CustomBundle.swift
+  all-lookupFunction.swift:
+    files:
+      - Common-LookupFunction.swift

--- a/Tests/Fixtures/Generated/Plist/runtime-swift5/all-lookupFunction.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift5/all-lookupFunction.swift
@@ -1,0 +1,84 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+import Foundation
+
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
+
+// MARK: - Plist Files
+
+// swiftlint:disable identifier_name line_length type_body_length
+internal enum PlistFiles {
+  internal enum Info {
+    private static let _document = PlistDocument(path: "Info.plist")
+    internal static let cfBundleDevelopmentRegion: String = _document["CFBundleDevelopmentRegion"]
+    internal static let cfBundleDisplayName: String = _document["CFBundleDisplayName"]
+    internal static let cfBundleExecutable: String = _document["CFBundleExecutable"]
+    internal static let cfBundleIdentifier: String = _document["CFBundleIdentifier"]
+    internal static let cfBundleInfoDictionaryVersion: String = _document["CFBundleInfoDictionaryVersion"]
+    internal static let cfBundleName: String = _document["CFBundleName"]
+    internal static let cfBundlePackageType: String = _document["CFBundlePackageType"]
+    internal static let cfBundleShortVersionString: String = _document["CFBundleShortVersionString"]
+    internal static let cfBundleSignature: String = _document["CFBundleSignature"]
+    internal static let cfBundleVersion: String = _document["CFBundleVersion"]
+    internal static let fabric: [String: Any] = _document["Fabric"]
+    internal static let itsAppUsesNonExemptEncryption: Bool = _document["ITSAppUsesNonExemptEncryption"]
+    internal static let lsRequiresIPhoneOS: Bool = _document["LSRequiresIPhoneOS"]
+    internal static let nsAppTransportSecurity: [String: Any] = _document["NSAppTransportSecurity"]
+    internal static let nsCameraUsageDescription: String = _document["NSCameraUsageDescription"]
+    internal static let nsPhotoLibraryUsageDescription: String = _document["NSPhotoLibraryUsageDescription"]
+    internal static let uiBackgroundModes: [String] = _document["UIBackgroundModes"]
+    internal static let uiLaunchStoryboardName: String = _document["UILaunchStoryboardName"]
+    internal static let uiMainStoryboardFile: String = _document["UIMainStoryboardFile"]
+    internal static let uiRequiredDeviceCapabilities: [String] = _document["UIRequiredDeviceCapabilities"]
+    internal static let uiRequiresFullScreen: Bool = _document["UIRequiresFullScreen"]
+    internal static let uiStatusBarStyle: String = _document["UIStatusBarStyle"]
+    internal static let uiSupportedInterfaceOrientations: [String] = _document["UISupportedInterfaceOrientations"]
+    internal static let uiSupportedInterfaceOrientationsIpad: [String] = _document["UISupportedInterfaceOrientations~ipad"]
+    internal static let userAmbiguousInteger: Bool = _document["User Ambiguous Integer"]
+    internal static let userBoolean: Bool = _document["User Boolean"]
+    internal static let userDate: Date = _document["User Date"]
+    internal static let userFloat: Double = _document["User Float"]
+    internal static let userInteger: Int = _document["User Integer"]
+  }
+  internal enum Configuration {
+    private static let _document = PlistDocument(path: "configuration.plist")
+    internal static let environment: String = _document["Environment"]
+    internal static let names: [String] = _document["Names"]
+    internal static let options: [String: Any] = _document["Options"]
+  }
+  internal enum ShoppingList {
+    internal static let items: [String] = arrayFromPlist(at: "shopping-list.plist")
+  }
+}
+// swiftlint:enable identifier_name line_length type_body_length
+
+// MARK: - Implementation Details
+
+private func arrayFromPlist<T>(at path: String) -> [T] {
+  guard let url = myPlistFinder(path:)(path),
+    let data = NSArray(contentsOf: url) as? [T] else {
+    fatalError("Unable to load PLIST at path: \(path)")
+  }
+  return data
+}
+
+private struct PlistDocument {
+  let data: [String: Any]
+
+  init(path: String) {
+    guard let url = myPlistFinder(path:)(path),
+      let data = NSDictionary(contentsOf: url) as? [String: Any] else {
+        fatalError("Unable to load PLIST at path: \(path)")
+    }
+    self.data = data
+  }
+
+  subscript<T>(key: String) -> T {
+    guard let result = data[key] as? T else {
+      fatalError("Property '\(key)' is not of type \(T.self)")
+    }
+    return result
+  }
+}

--- a/Tests/Fixtures/Generated/Plist/runtime-swift5/compilation-configuration.yml
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift5/compilation-configuration.yml
@@ -6,3 +6,6 @@ file_specific:
   all-customBundle.swift:
     files:
       - Common-CustomBundle.swift
+  all-lookupFunction.swift:
+    files:
+      - Common-LookupFunction.swift

--- a/Tests/Fixtures/Generated/Strings/flat-swift4/compilation-configuration.yml
+++ b/Tests/Fixtures/Generated/Strings/flat-swift4/compilation-configuration.yml
@@ -9,4 +9,4 @@ file_specific:
       - Common-CustomBundle.swift
   localizable-lookupFunction.swift:
     files:
-      - Strings-LocalizeFunction.swift
+      - Common-LookupFunction.swift

--- a/Tests/Fixtures/Generated/Strings/flat-swift5/compilation-configuration.yml
+++ b/Tests/Fixtures/Generated/Strings/flat-swift5/compilation-configuration.yml
@@ -8,4 +8,4 @@ file_specific:
       - Common-CustomBundle.swift
   localizable-lookupFunction.swift:
     files:
-      - Strings-LocalizeFunction.swift
+      - Common-LookupFunction.swift

--- a/Tests/Fixtures/Generated/Strings/structured-swift4/compilation-configuration.yml
+++ b/Tests/Fixtures/Generated/Strings/structured-swift4/compilation-configuration.yml
@@ -9,4 +9,4 @@ file_specific:
       - Common-CustomBundle.swift
   localizable-lookupFunction.swift:
     files:
-      - Strings-LocalizeFunction.swift
+      - Common-LookupFunction.swift

--- a/Tests/Fixtures/Generated/Strings/structured-swift5/compilation-configuration.yml
+++ b/Tests/Fixtures/Generated/Strings/structured-swift5/compilation-configuration.yml
@@ -8,4 +8,4 @@ file_specific:
       - Common-CustomBundle.swift
   localizable-lookupFunction.swift:
     files:
-      - Strings-LocalizeFunction.swift
+      - Common-LookupFunction.swift

--- a/Tests/TemplatesTests/FontsTests.swift
+++ b/Tests/TemplatesTests/FontsTests.swift
@@ -13,6 +13,7 @@ final class FontsTests: XCTestCase {
   }
 
   // generate variations to test customname generation
+  // swiftlint:disable:next closure_body_length
   private let variations: VariationGenerator = { name, context in
     guard name == "defaults" else { return [(context: context, suffix: "")] }
 
@@ -35,6 +36,13 @@ final class FontsTests: XCTestCase {
           ]
         ),
         suffix: "-customName"
+      ),
+      (
+        context: try StencilContext.enrich(
+          context: context,
+          parameters: ["lookupFunction=myFontFinder(name:family:path:)"]
+        ),
+        suffix: "-lookupFunction"
       ),
       (
         context: try StencilContext.enrich(context: context, parameters: ["preservePath"]),

--- a/Tests/TemplatesTests/InterfaceBuilderTests.swift
+++ b/Tests/TemplatesTests/InterfaceBuilderTests.swift
@@ -94,6 +94,15 @@ class InterfaceBuilderTests: XCTestCase {
       (
         context: try StencilContext.enrich(context: context, parameters: ["bundle=ResourcesBundle.bundle"]),
         suffix: "-customBundle"
+      ),
+
+      // test: lookup function parameter
+      (
+        context: try StencilContext.enrich(
+          context: context,
+          parameters: ["lookupFunction=myStoryboardFinder(name:)"]
+        ),
+        suffix: "-lookupFunction"
       )
     ]
   }

--- a/Tests/TemplatesTests/JsonTests.swift
+++ b/Tests/TemplatesTests/JsonTests.swift
@@ -76,6 +76,13 @@ final class JsonTests: XCTestCase {
         suffix: "-forceFileNameEnum"
       ),
       (
+        context: try StencilContext.enrich(
+          context: context,
+          parameters: ["lookupFunction=myJSONFinder(path:)"]
+        ),
+        suffix: "-lookupFunction"
+      ),
+      (
         context: try StencilContext.enrich(context: context, parameters: ["preservePath"]),
         suffix: "-preservePath"
       ),

--- a/Tests/TemplatesTests/PlistTests.swift
+++ b/Tests/TemplatesTests/PlistTests.swift
@@ -76,6 +76,13 @@ final class PlistTests: XCTestCase {
         suffix: "-forceFileNameEnum"
       ),
       (
+        context: try StencilContext.enrich(
+          context: context,
+          parameters: ["lookupFunction=myPlistFinder(path:)"]
+        ),
+        suffix: "-lookupFunction"
+      ),
+      (
         context: try StencilContext.enrich(context: context, parameters: ["preservePath"]),
         suffix: "-preservePath"
       ),

--- a/templates/fonts/swift4.stencil
+++ b/templates/fonts/swift4.stencil
@@ -68,7 +68,11 @@
   }
 
   fileprivate var url: URL? {
+    {% if param.lookupFunction %}
+    return {{param.lookupFunction}}(name, family, path)
+    {% else %}
     return {{param.bundle|default:"BundleToken.bundle"}}.url(forResource: path, withExtension: nil)
+    {% endif %}
   }
 }
 
@@ -87,7 +91,7 @@
     self.init(name: font.name, size: size)
   }
 }
-{% if not param.bundle %}
+{% if not param.bundle and not param.lookupFunction %}
 
 // swiftlint:disable convenience_type
 private final class BundleToken {

--- a/templates/fonts/swift5.stencil
+++ b/templates/fonts/swift5.stencil
@@ -71,7 +71,11 @@
 
   fileprivate var url: URL? {
     // swiftlint:disable:next implicit_return
+    {% if param.lookupFunction %}
+    return {{param.lookupFunction}}(name, family, path)
+    {% else %}
     return {{param.bundle|default:"BundleToken.bundle"}}.url(forResource: path, withExtension: nil)
+    {% endif %}
   }
 }
 
@@ -90,7 +94,7 @@
     self.init(name: font.name, size: size)
   }
 }
-{% if not param.bundle %}
+{% if not param.bundle and not param.lookupFunction %}
 
 // swiftlint:disable convenience_type
 private final class BundleToken {

--- a/templates/ib/scenes-swift4.stencil
+++ b/templates/ib/scenes-swift4.stencil
@@ -62,7 +62,11 @@ import {{module}}
 {{accessModifier}} extension StoryboardType {
   static var storyboard: {{prefix}}Storyboard {
     let name = {% if isAppKit %}NSStoryboard.Name({% endif %}self.storyboardName{% if isAppKit %}){% endif %}
+    {% if param.lookupFunction %}
+    return {{param.lookupFunction}}(name)
+    {% else %}
     return {{prefix}}Storyboard(name: name, bundle: {{param.bundle|default:"BundleToken.bundle"}})
+    {% endif %}
   }
 }
 
@@ -89,7 +93,7 @@ import {{module}}
     return controller
   }
 }
-{% if not param.bundle %}
+{% if not param.bundle and not param.lookupFunction %}
 
 // swiftlint:disable convenience_type
 private final class BundleToken {

--- a/templates/ib/scenes-swift5.stencil
+++ b/templates/ib/scenes-swift5.stencil
@@ -62,7 +62,11 @@ import {{module}}
 {{accessModifier}} extension StoryboardType {
   static var storyboard: {{prefix}}Storyboard {
     let name = {% if isAppKit %}NSStoryboard.Name({% endif %}self.storyboardName{% if isAppKit %}){% endif %}
+    {% if param.lookupFunction %}
+    return {{param.lookupFunction}}(name)
+    {% else %}
     return {{prefix}}Storyboard(name: name, bundle: {{param.bundle|default:"BundleToken.bundle"}})
+    {% endif %}
   }
 }
 
@@ -89,7 +93,7 @@ import {{module}}
     return controller
   }
 }
-{% if not param.bundle %}
+{% if not param.bundle and not param.lookupFunction %}
 
 // swiftlint:disable convenience_type
 private final class BundleToken {

--- a/templates/json/runtime-swift4.stencil
+++ b/templates/json/runtime-swift4.stencil
@@ -67,7 +67,11 @@ import Foundation
 // MARK: - Implementation Details
 
 private func objectFromJSON<T>(at path: String) -> T {
+  {% if param.lookupFunction %}
+  guard let url = {{param.lookupFunction}}(path),
+  {% else %}
   guard let url = {{param.bundle|default:"BundleToken.bundle"}}.url(forResource: path, withExtension: nil),
+  {% endif %}
     let json = try? JSONSerialization.jsonObject(with: Data(contentsOf: url), options: []),
     let result = json as? T else {
     fatalError("Unable to load JSON at path: \(path)")
@@ -89,7 +93,7 @@ private struct JSONDocument {
     return result
   }
 }
-{% if not param.bundle %}
+{% if not param.bundle and not param.lookupFunction %}
 
 // swiftlint:disable convenience_type
 private final class BundleToken {

--- a/templates/json/runtime-swift5.stencil
+++ b/templates/json/runtime-swift5.stencil
@@ -67,7 +67,11 @@ import Foundation
 // MARK: - Implementation Details
 
 private func objectFromJSON<T>(at path: String) -> T {
+  {% if param.lookupFunction %}
+  guard let url = {{param.lookupFunction}}(path),
+  {% else %}
   guard let url = {{param.bundle|default:"BundleToken.bundle"}}.url(forResource: path, withExtension: nil),
+  {% endif %}
     let json = try? JSONSerialization.jsonObject(with: Data(contentsOf: url), options: []),
     let result = json as? T else {
     fatalError("Unable to load JSON at path: \(path)")
@@ -89,7 +93,7 @@ private struct JSONDocument {
     return result
   }
 }
-{% if not param.bundle %}
+{% if not param.bundle and not param.lookupFunction %}
 
 // swiftlint:disable convenience_type
 private final class BundleToken {

--- a/templates/plist/runtime-swift4.stencil
+++ b/templates/plist/runtime-swift4.stencil
@@ -65,7 +65,11 @@ import Foundation
 // MARK: - Implementation Details
 
 private func arrayFromPlist<T>(at path: String) -> [T] {
+  {% if param.lookupFunction %}
+  guard let url = {{param.lookupFunction}}(path),
+  {% else %}
   guard let url = {{param.bundle|default:"BundleToken.bundle"}}.url(forResource: path, withExtension: nil),
+  {% endif %}
     let data = NSArray(contentsOf: url) as? [T] else {
     fatalError("Unable to load PLIST at path: \(path)")
   }
@@ -76,7 +80,11 @@ private struct PlistDocument {
   let data: [String: Any]
 
   init(path: String) {
+    {% if param.lookupFunction %}
+    guard let url = {{param.lookupFunction}}(path),
+    {% else %}
     guard let url = {{param.bundle|default:"BundleToken.bundle"}}.url(forResource: path, withExtension: nil),
+    {% endif %}
       let data = NSDictionary(contentsOf: url) as? [String: Any] else {
         fatalError("Unable to load PLIST at path: \(path)")
     }
@@ -90,7 +98,7 @@ private struct PlistDocument {
     return result
   }
 }
-{% if not param.bundle %}
+{% if not param.bundle and not param.lookupFunction %}
 
 // swiftlint:disable convenience_type
 private final class BundleToken {

--- a/templates/plist/runtime-swift5.stencil
+++ b/templates/plist/runtime-swift5.stencil
@@ -65,7 +65,11 @@ import Foundation
 // MARK: - Implementation Details
 
 private func arrayFromPlist<T>(at path: String) -> [T] {
+  {% if param.lookupFunction %}
+  guard let url = {{param.lookupFunction}}(path),
+  {% else %}
   guard let url = {{param.bundle|default:"BundleToken.bundle"}}.url(forResource: path, withExtension: nil),
+  {% endif %}
     let data = NSArray(contentsOf: url) as? [T] else {
     fatalError("Unable to load PLIST at path: \(path)")
   }
@@ -76,7 +80,11 @@ private struct PlistDocument {
   let data: [String: Any]
 
   init(path: String) {
+    {% if param.lookupFunction %}
+    guard let url = {{param.lookupFunction}}(path),
+    {% else %}
     guard let url = {{param.bundle|default:"BundleToken.bundle"}}.url(forResource: path, withExtension: nil),
+    {% endif %}
       let data = NSDictionary(contentsOf: url) as? [String: Any] else {
         fatalError("Unable to load PLIST at path: \(path)")
     }
@@ -90,7 +98,7 @@ private struct PlistDocument {
     return result
   }
 }
-{% if not param.bundle %}
+{% if not param.bundle and not param.lookupFunction %}
 
 // swiftlint:disable convenience_type
 private final class BundleToken {


### PR DESCRIPTION
As discussed in https://github.com/SwiftGen/SwiftGen/pull/716#issuecomment-643852541:
> Adapt the `lookupFunction` parameter to other templates that support it: fonts, IB scenes, json, and plist.
> For now, we won't adapt `lookupFunction` to the assets templates, as we'd need multiple lookup functions (one for each type).

Applies to:
-  Fonts
- IB
- JSON
- Plist