### PR TITLE
[Internal] Use linguist gitattributes to improve GitHub diffs in PRs and lang stats #trivial

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/Tests/Fixtures/Generated/** linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,10 @@
+
+# Mark some files as being "Generated" so they are not loaded by default in GitHub PRs
 /Tests/Fixtures/Generated/** linguist-generated
 /Tests/Fixtures/StencilContexts/**  linguist-generated
+
+# Mark some files which are not really part of SwiftGen's codebase as "not detectable by linguist", so they are not counted in the repo's languages stats
+Rakefile -linguist-detectable
+rakelib/** -linguist-detectable
+/Scripts/** -linguist-detectable
+/Tests/Fixtures/**  -linguist-detectable

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 /Tests/Fixtures/Generated/** linguist-generated
+/Tests/Fixtures/StencilContexts/**  linguist-generated


### PR DESCRIPTION
* [x] I've started my branch from the `develop` branch (gitflow)
  * [x] And I've selected `develop` as the "base" branch for this Pull Request I'm about to create
* [x] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself  
      _(or added `#trivial` to the PR title if I think it doesn't warrant a mention in the CHANGELOG)_
  * [ ] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
  * [ ] Add a period and 2 spaces at the end of your short entry description
  * [ ] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

This PR:
* Adds `linguist-generated` attribute for files that we generate (outputs + stencil contexts).
  * This prevents those files to load in GitHub PR diffs UI by default (they can still be loaded on demand by clicking "Load diff")
  * This will make PR reviews nicer, by avoiding to pollute our diffs with generated code – while still allowing us to look at some of them to check the output is as expected
* Removes the `linguist-detectable` attribute for files and folders that we don't consider part of being the "codebase" of SwiftGen.
  * This impacts the "language stats" of the repo presented by GitHub