### PR TITLE
Fix typo for swift5 font template #trivial

### DIFF
--- a/SwiftGen.playground/Pages/Fonts-Demo.xcplaygroundpage/Sources/Implementation Details.swift
+++ b/SwiftGen.playground/Pages/Fonts-Demo.xcplaygroundpage/Sources/Implementation Details.swift
@@ -15,7 +15,7 @@ public struct FontConvertible {
 
   public func font(size: CGFloat) -> Font {
     guard let font = Font(font: self, size: size) else {
-      fatalError("Unabble to initialize font '\(name)' (\(family))")
+      fatalError("Unable to initialize font '\(name)' (\(family))")
     }
     return font
   }

--- a/Tests/Fixtures/Generated/Fonts/swift5/defaults-customBundle.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift5/defaults-customBundle.swift
@@ -76,7 +76,7 @@ internal struct FontConvertible {
 
   internal func font(size: CGFloat) -> Font {
     guard let font = Font(font: self, size: size) else {
-      fatalError("Unabble to initialize font '\(name)' (\(family))")
+      fatalError("Unable to initialize font '\(name)' (\(family))")
     }
     return font
   }

--- a/Tests/Fixtures/Generated/Fonts/swift5/defaults-customName.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift5/defaults-customName.swift
@@ -76,7 +76,7 @@ internal struct MyFontConvertible {
 
   internal func font(size: CGFloat) -> Font {
     guard let font = Font(font: self, size: size) else {
-      fatalError("Unabble to initialize font '\(name)' (\(family))")
+      fatalError("Unable to initialize font '\(name)' (\(family))")
     }
     return font
   }

--- a/Tests/Fixtures/Generated/Fonts/swift5/defaults-lookupFunction.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift5/defaults-lookupFunction.swift
@@ -76,7 +76,7 @@ internal struct FontConvertible {
 
   internal func font(size: CGFloat) -> Font {
     guard let font = Font(font: self, size: size) else {
-      fatalError("Unabble to initialize font '\(name)' (\(family))")
+      fatalError("Unable to initialize font '\(name)' (\(family))")
     }
     return font
   }

--- a/Tests/Fixtures/Generated/Fonts/swift5/defaults-preservePath.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift5/defaults-preservePath.swift
@@ -76,7 +76,7 @@ internal struct FontConvertible {
 
   internal func font(size: CGFloat) -> Font {
     guard let font = Font(font: self, size: size) else {
-      fatalError("Unabble to initialize font '\(name)' (\(family))")
+      fatalError("Unable to initialize font '\(name)' (\(family))")
     }
     return font
   }

--- a/Tests/Fixtures/Generated/Fonts/swift5/defaults-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift5/defaults-publicAccess.swift
@@ -76,7 +76,7 @@ public struct FontConvertible {
 
   public func font(size: CGFloat) -> Font {
     guard let font = Font(font: self, size: size) else {
-      fatalError("Unabble to initialize font '\(name)' (\(family))")
+      fatalError("Unable to initialize font '\(name)' (\(family))")
     }
     return font
   }

--- a/Tests/Fixtures/Generated/Fonts/swift5/defaults.swift
+++ b/Tests/Fixtures/Generated/Fonts/swift5/defaults.swift
@@ -76,7 +76,7 @@ internal struct FontConvertible {
 
   internal func font(size: CGFloat) -> Font {
     guard let font = Font(font: self, size: size) else {
-      fatalError("Unabble to initialize font '\(name)' (\(family))")
+      fatalError("Unable to initialize font '\(name)' (\(family))")
     }
     return font
   }

--- a/templates/fonts/swift5.stencil
+++ b/templates/fonts/swift5.stencil
@@ -58,7 +58,7 @@
 
   {{accessModifier}} func font(size: CGFloat) -> Font {
     guard let font = Font(font: self, size: size) else {
-      fatalError("Unabble to initialize font '\(name)' (\(family))")
+      fatalError("Unable to initialize font '\(name)' (\(family))")
     }
     return font
   }


### PR DESCRIPTION
* [x] I've started my branch from the `develop` branch (gitflow)
  * [x] And I've selected `develop` as the "base" branch for this Pull Request I'm about to create
* [x] I've added `#trivial` to the PR title if I think it doesn't warrant a mention in the CHANGELOG
