### PR TITLE
[Internal] Update release:homebrew to match the new formula syntax #trivial

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -3,6 +3,7 @@
 require_relative 'rakelib/check_changelog'
 
 is_release = github.branch_for_head.start_with?('release/')
+is_hotfix = github.branch_for_head.start_with?('hotfix/')
 
 ################################################
 # Welcome message
@@ -48,6 +49,8 @@ if is_release
     stdout
   ]
   need_fixes << fail('Please fix the versions inconsistencies') unless status.success?
+elsif is_hotfix
+  message('This is a Hotfix PR')
 elsif !to_develop
   need_fixes << fail("Feature branches should start from and be merged into 'develop', " \
     "not #{github.branch_for_base}")

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -176,8 +176,8 @@ namespace :release do
       formula = File.read(formula_file)
 
       new_formula = formula
-                    .gsub(/(:tag\s+=>\s+)".*"/, %(\\1"#{tag}"))
-                    .gsub(/(:revision\s+=>\s+)".*"/, %(\\1"#{revision}"))
+                    .gsub(/(tag:\s+)".*"/, %(\\1"#{tag}"))
+                    .gsub(/(revision:\s+)".*"/, %(\\1"#{revision}"))
       File.write(formula_file, new_formula)
 
       Utils.print_info 'Formula has been auto-updated. Do you need to also do manual updates to it before continuing [y/n]?'


### PR DESCRIPTION
Homebrew updated all their formulae to use new ruby Hash syntax (`key: value`) instead of old rocket syntax (`:key => value`).

Since our Rakefile was using a regex to find those fields in the `swiftgen.rb` formula and update it, I had to update our scripts accordingly

* [ ] ~I've started my branch from the `develop` branch (gitflow)~ **NO: This is a hotfix**
  * [ ] ~And I've selected `develop` as the "base" branch for this Pull Request I'm about to create~
* [x] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself  
      _(or **added `#trivial` to the PR title** if I think it doesn't warrant a mention in the CHANGELOG)_
  * [ ] ~Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)~
  * [ ] ~Add a period and 2 spaces at the end of your short entry description~
  * [ ] ~Add links to your GitHub profile to credit yourself and to the related PR and issue after your description~

---

Note for the future: I just discovered that there's a `brew bump-formula-pr --tag 6.3.0 --revision <thesha1> swiftgen` command hidden in the `brew` CLI, which appears to do everything that we're doing manually in our `release:homebrew` rake task here… 🤦  Maybe one day we should migrate to use it instead of coding that ourselves… ==> https://github.com/SwiftGen/SwiftGen/issues/761