### PR TITLE
Strings: fix multi-line translations in comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ _None_
 * Generate `xcfilelist`: Adds the template file path to the inputs `xcfilelist` (for custom templates).  
   [Craig Siemens](https://github.com/CraigSiemens)
   [#815](https://github.com/SwiftGen/SwiftGen/pull/815)
+* Strings: built-in templates now have better handling of multi-line translations.  
+  [@mrackwitz](https://github.com/mrackwitz)
+  [#774](https://github.com/SwiftGen/SwiftGen/pull/774)
 
 ### Internal Changes
 

--- a/Documentation/templates/strings/objc.md
+++ b/Documentation/templates/strings/objc.md
@@ -27,13 +27,13 @@ You can customize some elements of this template by overriding the following par
 
 ```swift
 @interface Localizable : NSObject
-// alert__message --> "Some alert body there"
+/// alert__message --> "Some alert body there"
 + (NSString*)alertMessage;
-// alert__title --> "Title of the alert"
+/// alert__title --> "Title of the alert"
 + (NSString*)alertTitle;
-// ObjectOwnership --> "These are %3$@'s %1$d %2$@."
+/// ObjectOwnership --> "These are %3$@'s %1$d %2$@."
 + (NSString*)objectOwnershipWithValues:(NSInteger)p1 :(NSString*)p2 :(NSString*)p3;
-// percent --> "This is a %% character."
+/// percent --> "This is a %% character."
 + (NSString*)percent;
 ...
 @end

--- a/Sources/SwiftGenCLI/templates/strings/flat-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/flat-swift4.stencil
@@ -34,7 +34,9 @@ import Foundation
 {% macro recursiveBlock table item %}
   {% for string in item.strings %}
   {% if not param.noComments %}
-  /// {{string.translation}}
+  {% for line in string.translation|split:"\n" %}
+  /// {{line}}
+  {% endfor %}
   {% endif %}
   {% if string.types %}
   {{accessModifier}} static func {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}({% call parametersBlock string.types %}) -> String {

--- a/Sources/SwiftGenCLI/templates/strings/flat-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/flat-swift5.stencil
@@ -34,7 +34,9 @@ import Foundation
 {% macro recursiveBlock table item %}
   {% for string in item.strings %}
   {% if not param.noComments %}
-  /// {{string.translation}}
+  {% for line in string.translation|split:"\n" %}
+  /// {{line}}
+  {% endfor %}
   {% endif %}
   {% if string.types %}
   {{accessModifier}} static func {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}({% call parametersBlock string.types %}) -> String {

--- a/Sources/SwiftGenCLI/templates/strings/objc-h.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/objc-h.stencil
@@ -37,7 +37,9 @@ NS_ASSUME_NONNULL_BEGIN
 {% macro emitOneMethod table item %}
 {% for string in item.strings %}
 {% if not param.noComments %}
-/// {{string.key}} --> "{{string.translation}}"
+{% for line in string.translation|split:"\n" %}
+/// {{line}}
+{% endfor %}
 {% endif %}
 {% if string.types %}
   {% if string.types.count == 1 %}

--- a/Sources/SwiftGenCLI/templates/strings/structured-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/structured-swift4.stencil
@@ -34,7 +34,9 @@ import Foundation
 {% macro recursiveBlock table item %}
   {% for string in item.strings %}
   {% if not param.noComments %}
-  /// {{string.translation}}
+  {% for line in string.translation|split:"\n" %}
+  /// {{line}}
+  {% endfor %}
   {% endif %}
   {% if string.types %}
   {{accessModifier}} static func {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}({% call parametersBlock string.types %}) -> String {

--- a/Sources/SwiftGenCLI/templates/strings/structured-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/structured-swift5.stencil
@@ -34,7 +34,9 @@ import Foundation
 {% macro recursiveBlock table item %}
   {% for string in item.strings %}
   {% if not param.noComments %}
-  /// {{string.translation}}
+  {% for line in string.translation|split:"\n" %}
+  /// {{line}}
+  {% endfor %}
   {% endif %}
   {% if string.types %}
   {{accessModifier}} static func {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}({% call parametersBlock string.types %}) -> String {

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/multiple.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/multiple.swift
@@ -56,11 +56,14 @@ internal enum L10n {
     internal static let settingsUserProfileSectionHEADERTITLE = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE")
   }
   internal enum LocMultiline {
-    /// multi\nline
+    /// multi
+    /// line
     internal static let multiline = L10n.tr("LocMultiline", "MULTILINE")
     /// test
     internal static let multiLineNKey = L10n.tr("LocMultiline", "multiLine\nKey")
-    /// another\nmulti\n    line
+    /// another
+    /// multi
+    ///     line
     internal static let multiline2 = L10n.tr("LocMultiline", "MULTILINE2")
     /// single line
     internal static let singleline = L10n.tr("LocMultiline", "SINGLELINE")

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/multiple.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/multiple.swift
@@ -56,11 +56,14 @@ internal enum L10n {
     internal static let settingsUserProfileSectionHEADERTITLE = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE")
   }
   internal enum LocMultiline {
-    /// multi\nline
+    /// multi
+    /// line
     internal static let multiline = L10n.tr("LocMultiline", "MULTILINE")
     /// test
     internal static let multiLineNKey = L10n.tr("LocMultiline", "multiLine\nKey")
-    /// another\nmulti\n    line
+    /// another
+    /// multi
+    ///     line
     internal static let multiline2 = L10n.tr("LocMultiline", "MULTILINE2")
     /// single line
     internal static let singleline = L10n.tr("LocMultiline", "SINGLELINE")

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/localizable-customBundle.h
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/localizable-customBundle.h
@@ -5,35 +5,35 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface Localizable : NSObject
-/// alert__message --> "Some alert body there"
+/// Some alert body there
 + (NSString*)alertMessage;
-/// alert__title --> "Title of the alert"
+/// Title of the alert
 + (NSString*)alertTitle;
-/// ObjectOwnership --> "These are %3$@'s %1$d %2$@."
+/// These are %3$@'s %1$d %2$@.
 + (NSString*)objectOwnershipWithValues:(NSInteger)p1 :(id)p2 :(id)p3;
-/// percent --> "This is a %% character."
+/// This is a %% character.
 + (NSString*)percent;
-/// private --> "Hello, my name is %@ and I'm %d"
+/// Hello, my name is %@ and I'm %d
 + (NSString*)privateWithValues:(id)p1 :(NSInteger)p2;
-/// types --> "Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"
+/// Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'
 + (NSString*)typesWithValues:(id)p1 :(char)p2 :(NSInteger)p3 :(float)p4 :(char*)p5 :(void*)p6;
-/// apples.count --> "You have %d apples"
+/// You have %d apples
 + (NSString*)applesCountWithValue:(NSInteger)p1;
-/// bananas.owner --> "Those %d bananas belong to %@."
+/// Those %d bananas belong to %@.
 + (NSString*)bananasOwnerWithValues:(NSInteger)p1 :(id)p2;
-/// many.placeholders.base --> "%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"
+/// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
 + (NSString*)manyPlaceholdersBaseWithValues:(id)p1 :(NSInteger)p2 :(float)p3 :(float)p4 :(NSInteger)p5 :(NSInteger)p6 :(id)p7 :(float)p8 :(id)p9 :(NSInteger)p10 :(float)p11;
-/// many.placeholders.zero --> "%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"
+/// %@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
 + (NSString*)manyPlaceholdersZeroWithValues:(id)p1 :(NSInteger)p2 :(float)p3 :(float)p4 :(NSInteger)p5 :(NSInteger)p6 :(id)p7 :(float)p8 :(id)p9 :(NSInteger)p10 :(float)p11;
-/// settings.navigation-bar.self --> "Some Reserved Keyword there"
+/// Some Reserved Keyword there
 + (NSString*)settingsNavigationBarSelf;
-/// settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep --> "DeepSettings"
+/// DeepSettings
 + (NSString*)settingsNavigationBarTitleDeeperThanWeCanHandleNoReallyThisIsDeep;
-/// settings.navigation-bar.title.even.deeper --> "Settings"
+/// Settings
 + (NSString*)settingsNavigationBarTitleEvenDeeper;
-/// settings.user__profile_section.footer_text --> "Here you can change some user profile settings."
+/// Here you can change some user profile settings.
 + (NSString*)settingsUserProfileSectionFooterText;
-/// settings.user__profile_section.HEADER_TITLE --> "User Profile Settings"
+/// User Profile Settings
 + (NSString*)settingsUserProfileSectionHEADERTITLE;
 @end
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/localizable-headerName.h
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/localizable-headerName.h
@@ -5,35 +5,35 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface Localizable : NSObject
-/// alert__message --> "Some alert body there"
+/// Some alert body there
 + (NSString*)alertMessage;
-/// alert__title --> "Title of the alert"
+/// Title of the alert
 + (NSString*)alertTitle;
-/// ObjectOwnership --> "These are %3$@'s %1$d %2$@."
+/// These are %3$@'s %1$d %2$@.
 + (NSString*)objectOwnershipWithValues:(NSInteger)p1 :(id)p2 :(id)p3;
-/// percent --> "This is a %% character."
+/// This is a %% character.
 + (NSString*)percent;
-/// private --> "Hello, my name is %@ and I'm %d"
+/// Hello, my name is %@ and I'm %d
 + (NSString*)privateWithValues:(id)p1 :(NSInteger)p2;
-/// types --> "Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"
+/// Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'
 + (NSString*)typesWithValues:(id)p1 :(char)p2 :(NSInteger)p3 :(float)p4 :(char*)p5 :(void*)p6;
-/// apples.count --> "You have %d apples"
+/// You have %d apples
 + (NSString*)applesCountWithValue:(NSInteger)p1;
-/// bananas.owner --> "Those %d bananas belong to %@."
+/// Those %d bananas belong to %@.
 + (NSString*)bananasOwnerWithValues:(NSInteger)p1 :(id)p2;
-/// many.placeholders.base --> "%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"
+/// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
 + (NSString*)manyPlaceholdersBaseWithValues:(id)p1 :(NSInteger)p2 :(float)p3 :(float)p4 :(NSInteger)p5 :(NSInteger)p6 :(id)p7 :(float)p8 :(id)p9 :(NSInteger)p10 :(float)p11;
-/// many.placeholders.zero --> "%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"
+/// %@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
 + (NSString*)manyPlaceholdersZeroWithValues:(id)p1 :(NSInteger)p2 :(float)p3 :(float)p4 :(NSInteger)p5 :(NSInteger)p6 :(id)p7 :(float)p8 :(id)p9 :(NSInteger)p10 :(float)p11;
-/// settings.navigation-bar.self --> "Some Reserved Keyword there"
+/// Some Reserved Keyword there
 + (NSString*)settingsNavigationBarSelf;
-/// settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep --> "DeepSettings"
+/// DeepSettings
 + (NSString*)settingsNavigationBarTitleDeeperThanWeCanHandleNoReallyThisIsDeep;
-/// settings.navigation-bar.title.even.deeper --> "Settings"
+/// Settings
 + (NSString*)settingsNavigationBarTitleEvenDeeper;
-/// settings.user__profile_section.footer_text --> "Here you can change some user profile settings."
+/// Here you can change some user profile settings.
 + (NSString*)settingsUserProfileSectionFooterText;
-/// settings.user__profile_section.HEADER_TITLE --> "User Profile Settings"
+/// User Profile Settings
 + (NSString*)settingsUserProfileSectionHEADERTITLE;
 @end
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/localizable.h
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/localizable.h
@@ -5,35 +5,35 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface Localizable : NSObject
-/// alert__message --> "Some alert body there"
+/// Some alert body there
 + (NSString*)alertMessage;
-/// alert__title --> "Title of the alert"
+/// Title of the alert
 + (NSString*)alertTitle;
-/// ObjectOwnership --> "These are %3$@'s %1$d %2$@."
+/// These are %3$@'s %1$d %2$@.
 + (NSString*)objectOwnershipWithValues:(NSInteger)p1 :(id)p2 :(id)p3;
-/// percent --> "This is a %% character."
+/// This is a %% character.
 + (NSString*)percent;
-/// private --> "Hello, my name is %@ and I'm %d"
+/// Hello, my name is %@ and I'm %d
 + (NSString*)privateWithValues:(id)p1 :(NSInteger)p2;
-/// types --> "Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"
+/// Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'
 + (NSString*)typesWithValues:(id)p1 :(char)p2 :(NSInteger)p3 :(float)p4 :(char*)p5 :(void*)p6;
-/// apples.count --> "You have %d apples"
+/// You have %d apples
 + (NSString*)applesCountWithValue:(NSInteger)p1;
-/// bananas.owner --> "Those %d bananas belong to %@."
+/// Those %d bananas belong to %@.
 + (NSString*)bananasOwnerWithValues:(NSInteger)p1 :(id)p2;
-/// many.placeholders.base --> "%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"
+/// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
 + (NSString*)manyPlaceholdersBaseWithValues:(id)p1 :(NSInteger)p2 :(float)p3 :(float)p4 :(NSInteger)p5 :(NSInteger)p6 :(id)p7 :(float)p8 :(id)p9 :(NSInteger)p10 :(float)p11;
-/// many.placeholders.zero --> "%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"
+/// %@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
 + (NSString*)manyPlaceholdersZeroWithValues:(id)p1 :(NSInteger)p2 :(float)p3 :(float)p4 :(NSInteger)p5 :(NSInteger)p6 :(id)p7 :(float)p8 :(id)p9 :(NSInteger)p10 :(float)p11;
-/// settings.navigation-bar.self --> "Some Reserved Keyword there"
+/// Some Reserved Keyword there
 + (NSString*)settingsNavigationBarSelf;
-/// settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep --> "DeepSettings"
+/// DeepSettings
 + (NSString*)settingsNavigationBarTitleDeeperThanWeCanHandleNoReallyThisIsDeep;
-/// settings.navigation-bar.title.even.deeper --> "Settings"
+/// Settings
 + (NSString*)settingsNavigationBarTitleEvenDeeper;
-/// settings.user__profile_section.footer_text --> "Here you can change some user profile settings."
+/// Here you can change some user profile settings.
 + (NSString*)settingsUserProfileSectionFooterText;
-/// settings.user__profile_section.HEADER_TITLE --> "User Profile Settings"
+/// User Profile Settings
 + (NSString*)settingsUserProfileSectionHEADERTITLE;
 @end
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/multiple.h
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/multiple.h
@@ -5,52 +5,55 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface Localizable : NSObject
-/// alert__message --> "Some alert body there"
+/// Some alert body there
 + (NSString*)alertMessage;
-/// alert__title --> "Title of the alert"
+/// Title of the alert
 + (NSString*)alertTitle;
-/// ObjectOwnership --> "These are %3$@'s %1$d %2$@."
+/// These are %3$@'s %1$d %2$@.
 + (NSString*)objectOwnershipWithValues:(NSInteger)p1 :(id)p2 :(id)p3;
-/// percent --> "This is a %% character."
+/// This is a %% character.
 + (NSString*)percent;
-/// private --> "Hello, my name is %@ and I'm %d"
+/// Hello, my name is %@ and I'm %d
 + (NSString*)privateWithValues:(id)p1 :(NSInteger)p2;
-/// types --> "Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"
+/// Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'
 + (NSString*)typesWithValues:(id)p1 :(char)p2 :(NSInteger)p3 :(float)p4 :(char*)p5 :(void*)p6;
-/// apples.count --> "You have %d apples"
+/// You have %d apples
 + (NSString*)applesCountWithValue:(NSInteger)p1;
-/// bananas.owner --> "Those %d bananas belong to %@."
+/// Those %d bananas belong to %@.
 + (NSString*)bananasOwnerWithValues:(NSInteger)p1 :(id)p2;
-/// many.placeholders.base --> "%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"
+/// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
 + (NSString*)manyPlaceholdersBaseWithValues:(id)p1 :(NSInteger)p2 :(float)p3 :(float)p4 :(NSInteger)p5 :(NSInteger)p6 :(id)p7 :(float)p8 :(id)p9 :(NSInteger)p10 :(float)p11;
-/// many.placeholders.zero --> "%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"
+/// %@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
 + (NSString*)manyPlaceholdersZeroWithValues:(id)p1 :(NSInteger)p2 :(float)p3 :(float)p4 :(NSInteger)p5 :(NSInteger)p6 :(id)p7 :(float)p8 :(id)p9 :(NSInteger)p10 :(float)p11;
-/// settings.navigation-bar.self --> "Some Reserved Keyword there"
+/// Some Reserved Keyword there
 + (NSString*)settingsNavigationBarSelf;
-/// settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep --> "DeepSettings"
+/// DeepSettings
 + (NSString*)settingsNavigationBarTitleDeeperThanWeCanHandleNoReallyThisIsDeep;
-/// settings.navigation-bar.title.even.deeper --> "Settings"
+/// Settings
 + (NSString*)settingsNavigationBarTitleEvenDeeper;
-/// settings.user__profile_section.footer_text --> "Here you can change some user profile settings."
+/// Here you can change some user profile settings.
 + (NSString*)settingsUserProfileSectionFooterText;
-/// settings.user__profile_section.HEADER_TITLE --> "User Profile Settings"
+/// User Profile Settings
 + (NSString*)settingsUserProfileSectionHEADERTITLE;
 @end
 
 @interface LocMultiline : NSObject
-/// MULTILINE --> "multi\nline"
+/// multi
+/// line
 + (NSString*)multiline;
-/// multiLine\nKey --> "test"
+/// test
 + (NSString*)multiLineNKey;
-/// MULTILINE2 --> "another\nmulti\n    line"
+/// another
+/// multi
+///     line
 + (NSString*)multiline2;
-/// SINGLELINE --> "single line"
+/// single line
 + (NSString*)singleline;
-/// SINGLELINE2 --> "another single line"
+/// another single line
 + (NSString*)singleline2;
-/// ending.with. --> "Ceci n'est pas une pipe."
+/// Ceci n'est pas une pipe.
 + (NSString*)endingWith;
-/// ..some..dots.and..empty..components.. --> "Veni, vidi, vici"
+/// Veni, vidi, vici
 + (NSString*)someDotsAndEmptyComponents;
 @end
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/plurals-advanced.h
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/plurals-advanced.h
@@ -5,21 +5,21 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface LocPluralAdvanced : NSObject
-/// many.placeholders.plurals.base --> "Plural format key: "%@ - %#@d2@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@""
+/// Plural format key: "%@ - %#@d2@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@"
 + (NSString*)manyPlaceholdersPluralsBaseWithValues:(id)p1 :(NSInteger)p2 :(float)p3 :(float)p4 :(NSInteger)p5 :(NSInteger)p6 :(id)p7 :(id)p8 :(NSInteger)p9 :(float)p10;
-/// many.placeholders.plurals.zero --> "Plural format key: "%@ - %#@d2@ - %0$#@zero@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@""
+/// Plural format key: "%@ - %#@d2@ - %0$#@zero@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@"
 + (NSString*)manyPlaceholdersPluralsZeroWithValues:(id)p1 :(NSInteger)p2 :(float)p3 :(float)p4 :(NSInteger)p5 :(NSInteger)p6 :(id)p7 :(id)p8 :(NSInteger)p9 :(float)p10;
-/// mixed.placeholders-and-variables.positionalstring-positional3int --> "Plural format key: "%1$@ %3$#@has_rating@""
+/// Plural format key: "%1$@ %3$#@has_rating@"
 + (NSString*)mixedPlaceholdersAndVariablesPositionalstringPositional3intWithValues:(id)p1 :(NSInteger)p2;
-/// mixed.placeholders-and-variables.string-int --> "Plural format key: "%@ %#@has_rating@""
+/// Plural format key: "%@ %#@has_rating@"
 + (NSString*)mixedPlaceholdersAndVariablesStringIntWithValues:(id)p1 :(NSInteger)p2;
-/// mixed.placeholders-and-variables.string-positional2int --> "Plural format key: "%@ %2$#@has_rating@""
+/// Plural format key: "%@ %2$#@has_rating@"
 + (NSString*)mixedPlaceholdersAndVariablesStringPositional2intWithValues:(id)p1 :(NSInteger)p2;
-/// mixed.placeholders-and-variables.string-positional3int --> "Plural format key: "%@ %3$#@has_rating@""
+/// Plural format key: "%@ %3$#@has_rating@"
 + (NSString*)mixedPlaceholdersAndVariablesStringPositional3intWithValues:(id)p1 :(NSInteger)p2;
-/// multiple.placeholders-and-variables.int-string-string --> "Plural format key: "Your %3$@ list contains %1$#@first@ %2$@.""
+/// Plural format key: "Your %3$@ list contains %1$#@first@ %2$@."
 + (NSString*)multiplePlaceholdersAndVariablesIntStringStringWithValues:(NSInteger)p1 :(id)p2 :(id)p3;
-/// multiple.variables.three-variables-in-formatkey --> "Plural format key: "%#@files@ (%#@bytes@, %#@minutes@)""
+/// Plural format key: "%#@files@ (%#@bytes@, %#@minutes@)"
 + (NSString*)multipleVariablesThreeVariablesInFormatkeyWithValues:(NSInteger)p1 :(NSInteger)p2 :(NSInteger)p3;
 @end
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/plurals-same-table.h
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/plurals-same-table.h
@@ -5,39 +5,39 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface Localizable : NSObject
-/// alert__message --> "Some alert body there"
+/// Some alert body there
 + (NSString*)alertMessage;
-/// alert__title --> "Title of the alert"
+/// Title of the alert
 + (NSString*)alertTitle;
-/// ObjectOwnership --> "These are %3$@'s %1$d %2$@."
+/// These are %3$@'s %1$d %2$@.
 + (NSString*)objectOwnershipWithValues:(NSInteger)p1 :(id)p2 :(id)p3;
-/// percent --> "This is a %% character."
+/// This is a %% character.
 + (NSString*)percent;
-/// private --> "Hello, my name is %@ and I'm %d"
+/// Hello, my name is %@ and I'm %d
 + (NSString*)privateWithValues:(id)p1 :(NSInteger)p2;
-/// types --> "Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"
+/// Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'
 + (NSString*)typesWithValues:(id)p1 :(char)p2 :(NSInteger)p3 :(float)p4 :(char*)p5 :(void*)p6;
-/// apples.count --> "Plural format key: "%#@apples@""
+/// Plural format key: "%#@apples@"
 + (NSString*)applesCountWithValue:(NSInteger)p1;
-/// bananas.owner --> "Those %d bananas belong to %@."
+/// Those %d bananas belong to %@.
 + (NSString*)bananasOwnerWithValues:(NSInteger)p1 :(id)p2;
-/// competition.event.number-of-matches --> "Plural format key: "%#@Matches@""
+/// Plural format key: "%#@Matches@"
 + (NSString*)competitionEventNumberOfMatchesWithValue:(NSInteger)p1;
-/// feed.subscription.count --> "Plural format key: "%#@Subscriptions@""
+/// Plural format key: "%#@Subscriptions@"
 + (NSString*)feedSubscriptionCountWithValue:(NSInteger)p1;
-/// many.placeholders.base --> "%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"
+/// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
 + (NSString*)manyPlaceholdersBaseWithValues:(id)p1 :(NSInteger)p2 :(float)p3 :(float)p4 :(NSInteger)p5 :(NSInteger)p6 :(id)p7 :(float)p8 :(id)p9 :(NSInteger)p10 :(float)p11;
-/// many.placeholders.zero --> "%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"
+/// %@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
 + (NSString*)manyPlaceholdersZeroWithValues:(id)p1 :(NSInteger)p2 :(float)p3 :(float)p4 :(NSInteger)p5 :(NSInteger)p6 :(id)p7 :(float)p8 :(id)p9 :(NSInteger)p10 :(float)p11;
-/// settings.navigation-bar.self --> "Some Reserved Keyword there"
+/// Some Reserved Keyword there
 + (NSString*)settingsNavigationBarSelf;
-/// settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep --> "DeepSettings"
+/// DeepSettings
 + (NSString*)settingsNavigationBarTitleDeeperThanWeCanHandleNoReallyThisIsDeep;
-/// settings.navigation-bar.title.even.deeper --> "Settings"
+/// Settings
 + (NSString*)settingsNavigationBarTitleEvenDeeper;
-/// settings.user__profile_section.footer_text --> "Here you can change some user profile settings."
+/// Here you can change some user profile settings.
 + (NSString*)settingsUserProfileSectionFooterText;
-/// settings.user__profile_section.HEADER_TITLE --> "User Profile Settings"
+/// User Profile Settings
 + (NSString*)settingsUserProfileSectionHEADERTITLE;
 @end
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/plurals-unsupported.h
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/plurals-unsupported.h
@@ -5,7 +5,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface LocPluralUnsupported : NSObject
-/// unsupported-use.placeholders-in-variable-rule.string-int --> "Plural format key: "%#@elements@""
+/// Plural format key: "%#@elements@"
 + (NSString*)unsupportedUsePlaceholdersInVariableRuleStringIntWithValue:(NSInteger)p1;
 @end
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/plurals.h
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/plurals.h
@@ -5,11 +5,11 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface Localizable : NSObject
-/// apples.count --> "Plural format key: "%#@apples@""
+/// Plural format key: "%#@apples@"
 + (NSString*)applesCountWithValue:(NSInteger)p1;
-/// competition.event.number-of-matches --> "Plural format key: "%#@Matches@""
+/// Plural format key: "%#@Matches@"
 + (NSString*)competitionEventNumberOfMatchesWithValue:(NSInteger)p1;
-/// feed.subscription.count --> "Plural format key: "%#@Subscriptions@""
+/// Plural format key: "%#@Subscriptions@"
 + (NSString*)feedSubscriptionCountWithValue:(NSInteger)p1;
 @end
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/multiple.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/multiple.swift
@@ -93,11 +93,14 @@ internal enum L10n {
     }
   }
   internal enum LocMultiline {
-    /// multi\nline
+    /// multi
+    /// line
     internal static let multiline = L10n.tr("LocMultiline", "MULTILINE")
     /// test
     internal static let multiLineKey = L10n.tr("LocMultiline", "multiLine\nKey")
-    /// another\nmulti\n    line
+    /// another
+    /// multi
+    ///     line
     internal static let multiline2 = L10n.tr("LocMultiline", "MULTILINE2")
     /// single line
     internal static let singleline = L10n.tr("LocMultiline", "SINGLELINE")

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/multiple.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/multiple.swift
@@ -93,11 +93,14 @@ internal enum L10n {
     }
   }
   internal enum LocMultiline {
-    /// multi\nline
+    /// multi
+    /// line
     internal static let multiline = L10n.tr("LocMultiline", "MULTILINE")
     /// test
     internal static let multiLineKey = L10n.tr("LocMultiline", "multiLine\nKey")
-    /// another\nmulti\n    line
+    /// another
+    /// multi
+    ///     line
     internal static let multiline2 = L10n.tr("LocMultiline", "MULTILINE2")
     /// single line
     internal static let singleline = L10n.tr("LocMultiline", "SINGLELINE")


### PR DESCRIPTION
Hey there, I saw some discussion in earlier issues around this, but I'm not quite sure what's the last take on multi-line strings.

## Problem 

What I do know is, that using `structured-swift5` generated invalid Swift code, bc the additional lines of my multi-line translation made it into the comment, the newlines were not stripped out, so the resulting Swift code is invalid and fails to compile.
This change fixed it.

## Limitations

~This change probably needs to be also applied to a few other templates, if it turns out this is indeed the desired fix. Also there should be probably tests covering this. I have not enough context and can't dig deeper into this right now, especially not knowing what's the latest take on multi-line translation string support, but I wanted to share what fixed it for me at least.~ 
Done!