### PR TITLE
Strings: support using `NSNumber` as variable in `stringsdict`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ _None_
   [@kevinstier](https://github.com/kevinstier)
   [#562](https://github.com/SwiftGen/SwiftGen/issues/562)
   [#768](https://github.com/SwiftGen/SwiftGen/pull/768)
+* Support using NSNumber as variable for stringsdict.  
+  [#777](https://github.com/SwiftGen/SwiftGen/pull/777)
+  [@KhaosT](https://github.com/KhaosT)
 
 ### Bug Fixes
 

--- a/Sources/SwiftGenKit/Parsers/Strings/PlaceholderType.swift
+++ b/Sources/SwiftGenKit/Parsers/Strings/PlaceholderType.swift
@@ -9,6 +9,7 @@ import Foundation
 extension Strings {
   public enum PlaceholderType: String {
     case object = "String"
+    case number = "NSNumber"
     case float = "Float"
     case int = "Int"
     case char = "CChar"
@@ -22,6 +23,8 @@ extension Strings {
       switch lcChar {
       case "@":
         self = .object
+      case "ℝ":
+        self = .number
       case "a", "e", "f", "g":
         self = .float
       case "d", "i", "o", "u", "x":
@@ -45,6 +48,8 @@ extension Strings.PlaceholderType {
     let patternInt = "(?:h|hh|l|ll|q|z|t|j)?([dioux])"
     // valid flags for float
     let patternFloat = "[aefg]"
+    // internal flags for NSNumber
+    let objectNumber = "[ℝ]"
     // like in "%3$" to make positional specifiers
     let position = "(\\d+\\$)?"
     // precision like in "%1.2f"
@@ -52,7 +57,7 @@ extension Strings.PlaceholderType {
 
     do {
       return try NSRegularExpression(
-        pattern: "(?:^|(?<!%)(?:%%)*)%\(position)\(precision)(@|\(patternInt)|\(patternFloat)|[csp])",
+        pattern: "(?:^|(?<!%)(?:%%)*)%\(position)\(precision)(@|\(patternInt)|\(patternFloat)|\(objectNumber)|[csp])",
         options: [.caseInsensitive]
       )
     } catch {


### PR DESCRIPTION
* [x] I've started my branch from the `develop` branch (gitflow)
  * [x] And I've selected `develop` as the "base" branch for this Pull Request I'm about to create
* [x] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself  
      _(or added `#trivial` to the PR title if I think it doesn't warrant a mention in the CHANGELOG)_
  * [x] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
  * [x] Add a period and 2 spaces at the end of your short entry description
  * [ ] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

This PR added the ability to use `%@` in `NSStringFormatValueTypeKey` for the stringsdict file. The generated Swift interface will take in `NSNumber` which allows localized string to be formatted more accurately when dealing with floating number with high precisions.

I wonder if this is something that this project is interested in merging?