### PR TITLE
Plist: fix handling of Bool properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ _None_
 * Update the Swift version in `.swift-version` so that the right version is used when building manually (using `swiftenv`).  
   [@cfiken](https://github.com/cfiken)
   [#764](https://github.com/SwiftGen/SwiftGen/issues/764)
+* Plist: fix Bool being assigned Integer when using `inline` template.  
+  [@fortmarek](https://github.com/fortmarek)
+  [#779](https://github.com/SwiftGen/SwiftGen/pull/779)
 
 ### Internal Changes
 
@@ -73,9 +76,6 @@ _None_
 * Strings: fix incorrect interpretation of format placeholders when there were missing positional parameters (e.g. `"%2$@"` without a `%1$…` defined).  
   [@AliSoftware](https://github.com/AliSoftware)
   [#634](https://github.com/SwiftGen/SwiftGen/pull/634)
-* Plist: fix Bool being assigned Integer when using `inline` template
-  [@fortmarek](https://github.com/fortmarek)
-  [#779](https://github.com/SwiftGen/SwiftGen/pull/779)
 
 ## 6.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ _None_
 ### Bug Fixes
 
 * Strings: fix incorrect interpretation of format placeholders when there were missing positional parameters (e.g. `"%2$@"` without a `%1$…` defined).  
-  [@AliSoftware](https://github.com/AliSoftware)
+  [Olivier Halligon](https://github.com/AliSoftware)
   [#634](https://github.com/SwiftGen/SwiftGen/pull/634)
 
 ## 6.2.1
@@ -133,25 +133,25 @@ Read the [SwiftGen 6.2 Migration Guide](Documentation/MigrationGuide.md#migratin
   [David Jennes](https://github.com/djbe)
   [#614](https://github.com/SwiftGen/SwiftGen/pull/614)
 * The use of `swiftgen <parser>` (e.g. `swiftgen strings`, `swiftgen xcassets`, …) command line for running individual parsers is now deprecated in favor of `swiftgen run <parser>`. See "New Features" below.  
-  [@AliSoftware](https://github.com/AliSoftware)
+  [Olivier Halligon](https://github.com/AliSoftware)
   [#705](https://github.com/SwiftGen/SwiftGen/pull/705)
 * The subcommand `swiftgen templates` has been renamed `swiftgen template` (singular); the plural form of the command has been deprecated and will be removed in next major version.  
-  [@AliSoftware](https://github.com/AliSoftware)
+  [Olivier Halligon](https://github.com/AliSoftware)
   [#697](https://github.com/SwiftGen/SwiftGen/pull/697)
 * The ability for SwiftGen to search custom named templates in `~/Library/Application Support` has been deprecated and will be removed in SwiftGen 7.0. This little known feature made SwiftGen dependent on the machine it was running on. Use `templatePath` to reference custom templates by path instead.  
-  [@AliSoftware](https://github.com/AliSoftware)
+  [Olivier Halligon](https://github.com/AliSoftware)
   [#717](https://github.com/SwiftGen/SwiftGen/pull/717)
 
 ### New Features
 
 * Invoking individual parsers from the command line is now done via `swiftgen run <parser>`.  We still highly recommend to use a configuration file for flexibility and performance reasons in your projects, and only use `swiftgen run <parser>` for things like quick iterations when writing your own custom templates.  
-  [@AliSoftware](https://github.com/AliSoftware)
+  [Olivier Halligon](https://github.com/AliSoftware)
   [#705](https://github.com/SwiftGen/SwiftGen/pull/705)
 * You can now easily create a new config file using `swiftgen config init`. This will create an example and commented config file and open it to let you edit it to your needs.  _Note that the generated config file is static content which doesn't take the user's project into account (though that might change in the future)_.  
-  [@AliSoftware](https://github.com/AliSoftware)
+  [Olivier Halligon](https://github.com/AliSoftware)
   [#694](https://github.com/SwiftGen/SwiftGen/pull/694)
 * You can now use `swiftgen template doc [parser] [templateName]` on the command line to quickly open the documentation for templates on GitHub directly from your terminal.  
-  [@AliSoftware](https://github.com/AliSoftware)
+  [Olivier Halligon](https://github.com/AliSoftware)
   [#697](https://github.com/SwiftGen/SwiftGen/pull/697)
 * Each parser now accepts an `options` dictionary, with which you can set internal parser settings to change its behaviour. See the parser's specific documentation for available options.  
   [David Jennes](https://github.com/djbe)
@@ -193,13 +193,13 @@ Read the [SwiftGen 6.2 Migration Guide](Documentation/MigrationGuide.md#migratin
 * Most templates now accept a parameter to force having the file name used as namespace (`enum <FileName>`) in generated code _even if_ there's only one single input file.  
   [Viktoras Laukevičius](https://github.com/viktorasl)
   [#669](https://github.com/SwiftGen/SwiftGen/issues/669)
-  [@AliSoftware](https://github.com/AliSoftware)
+  [Olivier Halligon](https://github.com/AliSoftware)
   [#693](https://github.com/SwiftGen/SwiftGen/pull/693)
 
 ### Bug Fixes
 
 * SwiftGen now properly shows a better help message and the command usage when running an incomplete command, instead of complaining about a config file.  
-  [@AliSoftware](https://github.com/AliSoftware)
+  [Olivier Halligon](https://github.com/AliSoftware)
   [#706](https://github.com/SwiftGen/SwiftGen/pull/706)
 * XCAssets: improved the performance for color assets by caching the resolved colors.  
   [David Jennes](https://github.com/djbe)
@@ -228,13 +228,13 @@ Read the [SwiftGen 6.2 Migration Guide](Documentation/MigrationGuide.md#migratin
 ### Internal Changes
 
 * The main branch of the repository has been renamed from `master` to `stable`. If you pointed your `Podfile` or dependency managment tool to `master` instead of an official release/tag, you will have to update the branch name in your dependency file.  
-  [@AliSoftware](https://github.com/AliSoftware)
+  [Olivier Halligon](https://github.com/AliSoftware)
   [#714](https://github.com/SwiftGen/SwiftGen/pull/714)
 * Documentation: Improved doc for creating custom templates, and added a Documentation Table of Contents.  
-  [@AliSoftware](https://github.com/AliSoftware)
+  [Olivier Halligon](https://github.com/AliSoftware)
   [#713](https://github.com/SwiftGen/SwiftGen/pull/713)
 * Refactoring: Reduce globals & rearrange CLI code.  
-  [@AliSoftware](https://github.com/AliSoftware)
+  [Olivier Halligon](https://github.com/AliSoftware)
   [#586](https://github.com/SwiftGen/SwiftGen/pull/586)
 * Moved generated test output files into subdirectories per template.  
   [David Jennes](https://github.com/djbe)
@@ -786,7 +786,7 @@ See [#244](https://github.com/SwiftGen/SwiftGen/issues/244) and [the Migration G
 
 * SwiftGen has migrated to [its own GitHub organization](https://github.com/SwiftGen/SwiftGen) 🎉.  
 * SwiftGen has been split in multiple repositories and separate modules.  
-  [@AliSoftware](https://github.com/AliSoftware)
+  [Olivier Halligon](https://github.com/AliSoftware)
   [@djbe](https://github.com/djbe)
   [#240](https://github.com/SwiftGen/SwiftGen/issues/240)
   [#265](https://github.com/SwiftGen/SwiftGen/pull/265)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ _None_
 * Strings: fix incorrect interpretation of format placeholders when there were missing positional parameters (e.g. `"%2$@"` without a `%1$…` defined).  
   [@AliSoftware](https://github.com/AliSoftware)
   [#634](https://github.com/SwiftGen/SwiftGen/pull/634)
+* Plist: fix Bool being assigned Integer when using `inline` template
+  [@fortmarek](https://github.com/fortmarek)
+  [#779](https://github.com/SwiftGen/SwiftGen/pull/779)
 
 ## 6.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,9 @@ _None_
 * Update the Swift version in `.swift-version` so that the right version is used when building manually (using `swiftenv`).  
   [@cfiken](https://github.com/cfiken)
   [#764](https://github.com/SwiftGen/SwiftGen/issues/764)
-* Plist: fix Bool being assigned Integer when using `inline` template.  
+* Plist: Update the parsing strategy (using `Codable`) to fix parsing of `Bool` values as `Integer` in some cases.  
   [@fortmarek](https://github.com/fortmarek)
+  [Olivier Halligon](https://github.com/AliSoftware)
   [#779](https://github.com/SwiftGen/SwiftGen/pull/779)
 
 ### Internal Changes

--- a/Sources/SwiftGenKit/Parsers/AnyCodable.swift
+++ b/Sources/SwiftGenKit/Parsers/AnyCodable.swift
@@ -1,0 +1,129 @@
+//
+// SwiftGen
+// Copyright © 2020 SwiftGen
+// MIT Licence
+//
+
+import Foundation
+
+// swiftlint:disable cyclomatic_complexity force_unwrapping function_body_length
+public struct AnyCodable: Codable {
+  public let value: Any?
+
+  public init(_ value: Any?) {
+    self.value = value
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+
+    if container.decodeNil() {
+      self.value = nil
+    } else if let value = try? container.decode([String: AnyCodable].self) {
+      self.value = value.filter({ $0.value.value != nil }).mapValues({ $0.value! })
+    } else if let value = try? container.decode([AnyCodable].self) {
+      self.value = value.compactMap({ $0.value })
+    } else if let value = try? container.decode(Bool.self) {
+      self.value = value
+    } else if let value = try? container.decode(String.self) {
+      self.value = value
+    } else if let value = try? container.decode(Date.self) {
+      self.value = value
+    } else if let value = try? container.decode(Int.self) {
+      self.value = value
+    } else if let value = try? container.decode(Int8.self) {
+      self.value = value
+    } else if let value = try? container.decode(Int16.self) {
+      self.value = value
+    } else if let value = try? container.decode(Int32.self) {
+      self.value = value
+    } else if let value = try? container.decode(Int64.self) {
+      self.value = value
+    } else if let value = try? container.decode(UInt.self) {
+      self.value = value
+    } else if let value = try? container.decode(UInt8.self) {
+      self.value = value
+    } else if let value = try? container.decode(UInt16.self) {
+      self.value = value
+    } else if let value = try? container.decode(UInt32.self) {
+      self.value = value
+    } else if let value = try? container.decode(UInt64.self) {
+      self.value = value
+    } else if let value = try? container.decode(Double.self) {
+      self.value = value
+    } else if let value = try? container.decode(Float.self) {
+      self.value = value
+    } else {
+      throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unable to decode value")
+    }
+  }
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+
+    switch value {
+    case nil:
+      try container.encodeNil()
+    case let value as [String: AnyCodable]:
+      try container.encode(value)
+    case let value as [String: Any]:
+      try container.encode(value.mapValues(AnyCodable.init))
+    case let value as [AnyCodable]:
+      try container.encode(value)
+    case let value as [Any]:
+      try container.encode(value.map(AnyCodable.init))
+    case let value as Bool:
+      try container.encode(value)
+    case let value as String:
+      try container.encode(value)
+    case let value as Date:
+      try container.encode(value)
+    case let value as Int:
+      try container.encode(value)
+    case let value as Int8:
+      try container.encode(value)
+    case let value as Int16:
+      try container.encode(value)
+    case let value as Int32:
+      try container.encode(value)
+    case let value as Int64:
+      try container.encode(value)
+    case let value as UInt:
+      try container.encode(value)
+    case let value as UInt8:
+      try container.encode(value)
+    case let value as UInt16:
+      try container.encode(value)
+    case let value as UInt32:
+      try container.encode(value)
+    case let value as UInt64:
+      try container.encode(value)
+    case let value as Double:
+      try container.encode(value)
+    case let value as Float:
+      try container.encode(value)
+    default:
+      throw EncodingError.invalidValue(value!, .init(codingPath: [], debugDescription: "Unable to encode value"))
+    }
+  }
+}
+// swiftlint:enable cyclomatic_complexity force_unwrapping function_body_length
+
+extension KeyedDecodingContainer {
+  public func decode(_ type: [String: Any].Type, forKey key: K) throws -> [String: Any] {
+    let anyCodable = try decode(AnyCodable.self, forKey: key)
+    guard let value = anyCodable.value as? [String: Any] else {
+      let type = Swift.type(of: anyCodable.value)
+      throw DecodingError.typeMismatch(
+        type,
+        .init(codingPath: [], debugDescription: "Expected [String: Any], found \(type)")
+      )
+    }
+    return value
+  }
+}
+
+extension KeyedEncodingContainer {
+  public mutating func encode(_ value: [String: Any], forKey key: K) throws {
+    try encode(AnyCodable(value), forKey: key)
+  }
+}

--- a/Sources/SwiftGenKit/Parsers/AnyCodable.swift
+++ b/Sources/SwiftGenKit/Parsers/AnyCodable.swift
@@ -4,6 +4,8 @@
 // MIT Licence
 //
 
+// Original credits to Ian Keen (https://gist.github.com/IanKeen/df3bed29e2613ead94aa3b16967b9d14)
+
 import Foundation
 
 // swiftlint:disable cyclomatic_complexity force_unwrapping function_body_length

--- a/Sources/SwiftGenKit/Stencil/ContextHelpers.swift
+++ b/Sources/SwiftGenKit/Stencil/ContextHelpers.swift
@@ -18,9 +18,7 @@ final class StencilContextLazyDocument: NSObject, ContextConvertible {
   @objc private(set) lazy var metadata: [String: Any] = Metadata.generate(for: data)
 
   init(data: Any) {
-    // Make a round trip to YAML to fix NSDictionary-land interpretation of NSNumber/Bool and similar
-    let normalizedData = try? YAML.decode(string: YAML.encode(object: data))
-    self.data = normalizedData ?? data
+    self.data = data
     super.init()
   }
 }

--- a/Sources/SwiftGenKit/Stencil/ContextHelpers.swift
+++ b/Sources/SwiftGenKit/Stencil/ContextHelpers.swift
@@ -18,7 +18,9 @@ final class StencilContextLazyDocument: NSObject, ContextConvertible {
   @objc private(set) lazy var metadata: [String: Any] = Metadata.generate(for: data)
 
   init(data: Any) {
-    self.data = data
+    // Make a round trip to YAML to fix NSDictionary-land interpretation of NSNumber/Bool and similar
+    let normalizedData = try? YAML.decode(string: YAML.encode(object: data))
+    self.data = normalizedData ?? data
     super.init()
   }
 }

--- a/SwiftGen.xcodeproj/project.pbxproj
+++ b/SwiftGen.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		093405101F815B2500187787 /* config-with-params.yml in Resources */ = {isa = PBXBuildFile; fileRef = 093405071F81539100187787 /* config-with-params.yml */; };
 		093405131F87AA6A00187787 /* config-with-multi-entries.yml in Resources */ = {isa = PBXBuildFile; fileRef = 093405111F87AA6500187787 /* config-with-multi-entries.yml */; };
 		0987AC7A2475802700388153 /* Config+Example.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0987AC792475802700388153 /* Config+Example.swift */; };
+		099E49DD2521184200F7269D /* AnyCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 099E49DB2521182100F7269D /* AnyCodable.swift */; };
 		09A87B581BCCA2CF00D9B9F5 /* TestsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09030C171B6D43D400275BF5 /* TestsHelper.swift */; };
 		09A87B5C1BCCA37F00D9B9F5 /* ConfigReadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09030BD81B6D2E5900275BF5 /* ConfigReadTests.swift */; };
 		09D009FF1F9BB3450026A755 /* ConfigEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D009FE1F9BB3450026A755 /* ConfigEntry.swift */; };
@@ -338,6 +339,7 @@
 		0934050D1F815A8C00187787 /* ParserCLI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParserCLI.swift; sourceTree = "<group>"; };
 		093405111F87AA6500187787 /* config-with-multi-entries.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "config-with-multi-entries.yml"; sourceTree = "<group>"; };
 		0987AC792475802700388153 /* Config+Example.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Config+Example.swift"; sourceTree = "<group>"; };
+		099E49DB2521182100F7269D /* AnyCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCodable.swift; sourceTree = "<group>"; };
 		09A87B501BCCA2C600D9B9F5 /* SwiftGen UnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwiftGen UnitTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		09C7B2D31BCC382800D7F488 /* main.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; tabWidth = 2; };
 		09D009FE1F9BB3450026A755 /* ConfigEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigEntry.swift; sourceTree = "<group>"; };
@@ -753,6 +755,7 @@
 				DDCC331A220E3FE700982694 /* ParserOption.swift */,
 				DDCC331C220E491600982694 /* ParserOptionList.swift */,
 				DD48AD7E2210AC5E00336621 /* ParserOptionValues.swift */,
+				099E49DB2521182100F7269D /* AnyCodable.swift */,
 			);
 			path = Parsers;
 			sourceTree = "<group>";
@@ -1562,6 +1565,7 @@
 				DDC82117209672E1007A55F3 /* String.swift in Sources */,
 				DD9F687420955D0C004EB720 /* ColorsFileTypeParser.swift in Sources */,
 				D4A93E27247E307400BE8651 /* JSONParser.swift in Sources */,
+				099E49DD2521184200F7269D /* AnyCodable.swift in Sources */,
 				DD9F687C20955D51004EB720 /* Catalog.swift in Sources */,
 				C322627121012F42001AC9CD /* Attribute.swift in Sources */,
 				DDCC331D220E491600982694 /* ParserOptionList.swift in Sources */,

--- a/Tests/Fixtures/Generated/Plist/inline-swift4/all-customname.swift
+++ b/Tests/Fixtures/Generated/Plist/inline-swift4/all-customname.swift
@@ -35,7 +35,7 @@ internal enum CustomPlist {
     internal static let uiStatusBarStyle: String = "UIStatusBarStyleDefault"
     internal static let uiSupportedInterfaceOrientations: [String] = ["UIInterfaceOrientationPortrait", "UIInterfaceOrientationPortraitUpsideDown", "UIInterfaceOrientationLandscapeRight", "UIInterfaceOrientationLandscapeLeft"]
     internal static let uiSupportedInterfaceOrientationsIpad: [String] = ["UIInterfaceOrientationLandscapeLeft", "UIInterfaceOrientationLandscapeRight", "UIInterfaceOrientationPortraitUpsideDown", "UIInterfaceOrientationPortrait"]
-    internal static let userAmbiguousInteger: Bool = true
+    internal static let userAmbiguousInteger: Int = 1
     internal static let userBoolean: Bool = false
     internal static let userDate: Date = Date(timeIntervalSinceReferenceDate: 547184366)
     internal static let userFloat: Double = 3.14

--- a/Tests/Fixtures/Generated/Plist/inline-swift4/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/Plist/inline-swift4/all-forceFileNameEnum.swift
@@ -35,7 +35,7 @@ internal enum PlistFiles {
     internal static let uiStatusBarStyle: String = "UIStatusBarStyleDefault"
     internal static let uiSupportedInterfaceOrientations: [String] = ["UIInterfaceOrientationPortrait", "UIInterfaceOrientationPortraitUpsideDown", "UIInterfaceOrientationLandscapeRight", "UIInterfaceOrientationLandscapeLeft"]
     internal static let uiSupportedInterfaceOrientationsIpad: [String] = ["UIInterfaceOrientationLandscapeLeft", "UIInterfaceOrientationLandscapeRight", "UIInterfaceOrientationPortraitUpsideDown", "UIInterfaceOrientationPortrait"]
-    internal static let userAmbiguousInteger: Bool = true
+    internal static let userAmbiguousInteger: Int = 1
     internal static let userBoolean: Bool = false
     internal static let userDate: Date = Date(timeIntervalSinceReferenceDate: 547184366)
     internal static let userFloat: Double = 3.14

--- a/Tests/Fixtures/Generated/Plist/inline-swift4/all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Plist/inline-swift4/all-publicAccess.swift
@@ -35,7 +35,7 @@ public enum PlistFiles {
     public static let uiStatusBarStyle: String = "UIStatusBarStyleDefault"
     public static let uiSupportedInterfaceOrientations: [String] = ["UIInterfaceOrientationPortrait", "UIInterfaceOrientationPortraitUpsideDown", "UIInterfaceOrientationLandscapeRight", "UIInterfaceOrientationLandscapeLeft"]
     public static let uiSupportedInterfaceOrientationsIpad: [String] = ["UIInterfaceOrientationLandscapeLeft", "UIInterfaceOrientationLandscapeRight", "UIInterfaceOrientationPortraitUpsideDown", "UIInterfaceOrientationPortrait"]
-    public static let userAmbiguousInteger: Bool = true
+    public static let userAmbiguousInteger: Int = 1
     public static let userBoolean: Bool = false
     public static let userDate: Date = Date(timeIntervalSinceReferenceDate: 547184366)
     public static let userFloat: Double = 3.14

--- a/Tests/Fixtures/Generated/Plist/inline-swift4/all.swift
+++ b/Tests/Fixtures/Generated/Plist/inline-swift4/all.swift
@@ -35,7 +35,7 @@ internal enum PlistFiles {
     internal static let uiStatusBarStyle: String = "UIStatusBarStyleDefault"
     internal static let uiSupportedInterfaceOrientations: [String] = ["UIInterfaceOrientationPortrait", "UIInterfaceOrientationPortraitUpsideDown", "UIInterfaceOrientationLandscapeRight", "UIInterfaceOrientationLandscapeLeft"]
     internal static let uiSupportedInterfaceOrientationsIpad: [String] = ["UIInterfaceOrientationLandscapeLeft", "UIInterfaceOrientationLandscapeRight", "UIInterfaceOrientationPortraitUpsideDown", "UIInterfaceOrientationPortrait"]
-    internal static let userAmbiguousInteger: Bool = true
+    internal static let userAmbiguousInteger: Int = 1
     internal static let userBoolean: Bool = false
     internal static let userDate: Date = Date(timeIntervalSinceReferenceDate: 547184366)
     internal static let userFloat: Double = 3.14

--- a/Tests/Fixtures/Generated/Plist/inline-swift5/all-customname.swift
+++ b/Tests/Fixtures/Generated/Plist/inline-swift5/all-customname.swift
@@ -35,7 +35,7 @@ internal enum CustomPlist {
     internal static let uiStatusBarStyle: String = "UIStatusBarStyleDefault"
     internal static let uiSupportedInterfaceOrientations: [String] = ["UIInterfaceOrientationPortrait", "UIInterfaceOrientationPortraitUpsideDown", "UIInterfaceOrientationLandscapeRight", "UIInterfaceOrientationLandscapeLeft"]
     internal static let uiSupportedInterfaceOrientationsIpad: [String] = ["UIInterfaceOrientationLandscapeLeft", "UIInterfaceOrientationLandscapeRight", "UIInterfaceOrientationPortraitUpsideDown", "UIInterfaceOrientationPortrait"]
-    internal static let userAmbiguousInteger: Bool = true
+    internal static let userAmbiguousInteger: Int = 1
     internal static let userBoolean: Bool = false
     internal static let userDate: Date = Date(timeIntervalSinceReferenceDate: 547184366)
     internal static let userFloat: Double = 3.14

--- a/Tests/Fixtures/Generated/Plist/inline-swift5/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/Plist/inline-swift5/all-forceFileNameEnum.swift
@@ -35,7 +35,7 @@ internal enum PlistFiles {
     internal static let uiStatusBarStyle: String = "UIStatusBarStyleDefault"
     internal static let uiSupportedInterfaceOrientations: [String] = ["UIInterfaceOrientationPortrait", "UIInterfaceOrientationPortraitUpsideDown", "UIInterfaceOrientationLandscapeRight", "UIInterfaceOrientationLandscapeLeft"]
     internal static let uiSupportedInterfaceOrientationsIpad: [String] = ["UIInterfaceOrientationLandscapeLeft", "UIInterfaceOrientationLandscapeRight", "UIInterfaceOrientationPortraitUpsideDown", "UIInterfaceOrientationPortrait"]
-    internal static let userAmbiguousInteger: Bool = true
+    internal static let userAmbiguousInteger: Int = 1
     internal static let userBoolean: Bool = false
     internal static let userDate: Date = Date(timeIntervalSinceReferenceDate: 547184366)
     internal static let userFloat: Double = 3.14

--- a/Tests/Fixtures/Generated/Plist/inline-swift5/all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Plist/inline-swift5/all-publicAccess.swift
@@ -35,7 +35,7 @@ public enum PlistFiles {
     public static let uiStatusBarStyle: String = "UIStatusBarStyleDefault"
     public static let uiSupportedInterfaceOrientations: [String] = ["UIInterfaceOrientationPortrait", "UIInterfaceOrientationPortraitUpsideDown", "UIInterfaceOrientationLandscapeRight", "UIInterfaceOrientationLandscapeLeft"]
     public static let uiSupportedInterfaceOrientationsIpad: [String] = ["UIInterfaceOrientationLandscapeLeft", "UIInterfaceOrientationLandscapeRight", "UIInterfaceOrientationPortraitUpsideDown", "UIInterfaceOrientationPortrait"]
-    public static let userAmbiguousInteger: Bool = true
+    public static let userAmbiguousInteger: Int = 1
     public static let userBoolean: Bool = false
     public static let userDate: Date = Date(timeIntervalSinceReferenceDate: 547184366)
     public static let userFloat: Double = 3.14

--- a/Tests/Fixtures/Generated/Plist/inline-swift5/all.swift
+++ b/Tests/Fixtures/Generated/Plist/inline-swift5/all.swift
@@ -35,7 +35,7 @@ internal enum PlistFiles {
     internal static let uiStatusBarStyle: String = "UIStatusBarStyleDefault"
     internal static let uiSupportedInterfaceOrientations: [String] = ["UIInterfaceOrientationPortrait", "UIInterfaceOrientationPortraitUpsideDown", "UIInterfaceOrientationLandscapeRight", "UIInterfaceOrientationLandscapeLeft"]
     internal static let uiSupportedInterfaceOrientationsIpad: [String] = ["UIInterfaceOrientationLandscapeLeft", "UIInterfaceOrientationLandscapeRight", "UIInterfaceOrientationPortraitUpsideDown", "UIInterfaceOrientationPortrait"]
-    internal static let userAmbiguousInteger: Bool = true
+    internal static let userAmbiguousInteger: Int = 1
     internal static let userBoolean: Bool = false
     internal static let userDate: Date = Date(timeIntervalSinceReferenceDate: 547184366)
     internal static let userFloat: Double = 3.14

--- a/Tests/Fixtures/Generated/Plist/runtime-swift4/all-customBundle.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift4/all-customBundle.swift
@@ -36,7 +36,7 @@ internal enum PlistFiles {
     internal static let uiStatusBarStyle: String = _document["UIStatusBarStyle"]
     internal static let uiSupportedInterfaceOrientations: [String] = _document["UISupportedInterfaceOrientations"]
     internal static let uiSupportedInterfaceOrientationsIpad: [String] = _document["UISupportedInterfaceOrientations~ipad"]
-    internal static let userAmbiguousInteger: Bool = _document["User Ambiguous Integer"]
+    internal static let userAmbiguousInteger: Int = _document["User Ambiguous Integer"]
     internal static let userBoolean: Bool = _document["User Boolean"]
     internal static let userDate: Date = _document["User Date"]
     internal static let userFloat: Double = _document["User Float"]

--- a/Tests/Fixtures/Generated/Plist/runtime-swift4/all-customName.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift4/all-customName.swift
@@ -36,7 +36,7 @@ internal enum CustomPlist {
     internal static let uiStatusBarStyle: String = _document["UIStatusBarStyle"]
     internal static let uiSupportedInterfaceOrientations: [String] = _document["UISupportedInterfaceOrientations"]
     internal static let uiSupportedInterfaceOrientationsIpad: [String] = _document["UISupportedInterfaceOrientations~ipad"]
-    internal static let userAmbiguousInteger: Bool = _document["User Ambiguous Integer"]
+    internal static let userAmbiguousInteger: Int = _document["User Ambiguous Integer"]
     internal static let userBoolean: Bool = _document["User Boolean"]
     internal static let userDate: Date = _document["User Date"]
     internal static let userFloat: Double = _document["User Float"]

--- a/Tests/Fixtures/Generated/Plist/runtime-swift4/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift4/all-forceFileNameEnum.swift
@@ -36,7 +36,7 @@ internal enum PlistFiles {
     internal static let uiStatusBarStyle: String = _document["UIStatusBarStyle"]
     internal static let uiSupportedInterfaceOrientations: [String] = _document["UISupportedInterfaceOrientations"]
     internal static let uiSupportedInterfaceOrientationsIpad: [String] = _document["UISupportedInterfaceOrientations~ipad"]
-    internal static let userAmbiguousInteger: Bool = _document["User Ambiguous Integer"]
+    internal static let userAmbiguousInteger: Int = _document["User Ambiguous Integer"]
     internal static let userBoolean: Bool = _document["User Boolean"]
     internal static let userDate: Date = _document["User Date"]
     internal static let userFloat: Double = _document["User Float"]

--- a/Tests/Fixtures/Generated/Plist/runtime-swift4/all-lookupFunction.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift4/all-lookupFunction.swift
@@ -36,7 +36,7 @@ internal enum PlistFiles {
     internal static let uiStatusBarStyle: String = _document["UIStatusBarStyle"]
     internal static let uiSupportedInterfaceOrientations: [String] = _document["UISupportedInterfaceOrientations"]
     internal static let uiSupportedInterfaceOrientationsIpad: [String] = _document["UISupportedInterfaceOrientations~ipad"]
-    internal static let userAmbiguousInteger: Bool = _document["User Ambiguous Integer"]
+    internal static let userAmbiguousInteger: Int = _document["User Ambiguous Integer"]
     internal static let userBoolean: Bool = _document["User Boolean"]
     internal static let userDate: Date = _document["User Date"]
     internal static let userFloat: Double = _document["User Float"]

--- a/Tests/Fixtures/Generated/Plist/runtime-swift4/all-preservePath.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift4/all-preservePath.swift
@@ -36,7 +36,7 @@ internal enum PlistFiles {
     internal static let uiStatusBarStyle: String = _document["UIStatusBarStyle"]
     internal static let uiSupportedInterfaceOrientations: [String] = _document["UISupportedInterfaceOrientations"]
     internal static let uiSupportedInterfaceOrientationsIpad: [String] = _document["UISupportedInterfaceOrientations~ipad"]
-    internal static let userAmbiguousInteger: Bool = _document["User Ambiguous Integer"]
+    internal static let userAmbiguousInteger: Int = _document["User Ambiguous Integer"]
     internal static let userBoolean: Bool = _document["User Boolean"]
     internal static let userDate: Date = _document["User Date"]
     internal static let userFloat: Double = _document["User Float"]

--- a/Tests/Fixtures/Generated/Plist/runtime-swift4/all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift4/all-publicAccess.swift
@@ -36,7 +36,7 @@ public enum PlistFiles {
     public static let uiStatusBarStyle: String = _document["UIStatusBarStyle"]
     public static let uiSupportedInterfaceOrientations: [String] = _document["UISupportedInterfaceOrientations"]
     public static let uiSupportedInterfaceOrientationsIpad: [String] = _document["UISupportedInterfaceOrientations~ipad"]
-    public static let userAmbiguousInteger: Bool = _document["User Ambiguous Integer"]
+    public static let userAmbiguousInteger: Int = _document["User Ambiguous Integer"]
     public static let userBoolean: Bool = _document["User Boolean"]
     public static let userDate: Date = _document["User Date"]
     public static let userFloat: Double = _document["User Float"]

--- a/Tests/Fixtures/Generated/Plist/runtime-swift4/all.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift4/all.swift
@@ -36,7 +36,7 @@ internal enum PlistFiles {
     internal static let uiStatusBarStyle: String = _document["UIStatusBarStyle"]
     internal static let uiSupportedInterfaceOrientations: [String] = _document["UISupportedInterfaceOrientations"]
     internal static let uiSupportedInterfaceOrientationsIpad: [String] = _document["UISupportedInterfaceOrientations~ipad"]
-    internal static let userAmbiguousInteger: Bool = _document["User Ambiguous Integer"]
+    internal static let userAmbiguousInteger: Int = _document["User Ambiguous Integer"]
     internal static let userBoolean: Bool = _document["User Boolean"]
     internal static let userDate: Date = _document["User Date"]
     internal static let userFloat: Double = _document["User Float"]

--- a/Tests/Fixtures/Generated/Plist/runtime-swift5/all-customBundle.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift5/all-customBundle.swift
@@ -36,7 +36,7 @@ internal enum PlistFiles {
     internal static let uiStatusBarStyle: String = _document["UIStatusBarStyle"]
     internal static let uiSupportedInterfaceOrientations: [String] = _document["UISupportedInterfaceOrientations"]
     internal static let uiSupportedInterfaceOrientationsIpad: [String] = _document["UISupportedInterfaceOrientations~ipad"]
-    internal static let userAmbiguousInteger: Bool = _document["User Ambiguous Integer"]
+    internal static let userAmbiguousInteger: Int = _document["User Ambiguous Integer"]
     internal static let userBoolean: Bool = _document["User Boolean"]
     internal static let userDate: Date = _document["User Date"]
     internal static let userFloat: Double = _document["User Float"]

--- a/Tests/Fixtures/Generated/Plist/runtime-swift5/all-customName.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift5/all-customName.swift
@@ -36,7 +36,7 @@ internal enum CustomPlist {
     internal static let uiStatusBarStyle: String = _document["UIStatusBarStyle"]
     internal static let uiSupportedInterfaceOrientations: [String] = _document["UISupportedInterfaceOrientations"]
     internal static let uiSupportedInterfaceOrientationsIpad: [String] = _document["UISupportedInterfaceOrientations~ipad"]
-    internal static let userAmbiguousInteger: Bool = _document["User Ambiguous Integer"]
+    internal static let userAmbiguousInteger: Int = _document["User Ambiguous Integer"]
     internal static let userBoolean: Bool = _document["User Boolean"]
     internal static let userDate: Date = _document["User Date"]
     internal static let userFloat: Double = _document["User Float"]

--- a/Tests/Fixtures/Generated/Plist/runtime-swift5/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift5/all-forceFileNameEnum.swift
@@ -36,7 +36,7 @@ internal enum PlistFiles {
     internal static let uiStatusBarStyle: String = _document["UIStatusBarStyle"]
     internal static let uiSupportedInterfaceOrientations: [String] = _document["UISupportedInterfaceOrientations"]
     internal static let uiSupportedInterfaceOrientationsIpad: [String] = _document["UISupportedInterfaceOrientations~ipad"]
-    internal static let userAmbiguousInteger: Bool = _document["User Ambiguous Integer"]
+    internal static let userAmbiguousInteger: Int = _document["User Ambiguous Integer"]
     internal static let userBoolean: Bool = _document["User Boolean"]
     internal static let userDate: Date = _document["User Date"]
     internal static let userFloat: Double = _document["User Float"]

--- a/Tests/Fixtures/Generated/Plist/runtime-swift5/all-lookupFunction.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift5/all-lookupFunction.swift
@@ -36,7 +36,7 @@ internal enum PlistFiles {
     internal static let uiStatusBarStyle: String = _document["UIStatusBarStyle"]
     internal static let uiSupportedInterfaceOrientations: [String] = _document["UISupportedInterfaceOrientations"]
     internal static let uiSupportedInterfaceOrientationsIpad: [String] = _document["UISupportedInterfaceOrientations~ipad"]
-    internal static let userAmbiguousInteger: Bool = _document["User Ambiguous Integer"]
+    internal static let userAmbiguousInteger: Int = _document["User Ambiguous Integer"]
     internal static let userBoolean: Bool = _document["User Boolean"]
     internal static let userDate: Date = _document["User Date"]
     internal static let userFloat: Double = _document["User Float"]

--- a/Tests/Fixtures/Generated/Plist/runtime-swift5/all-preservePath.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift5/all-preservePath.swift
@@ -36,7 +36,7 @@ internal enum PlistFiles {
     internal static let uiStatusBarStyle: String = _document["UIStatusBarStyle"]
     internal static let uiSupportedInterfaceOrientations: [String] = _document["UISupportedInterfaceOrientations"]
     internal static let uiSupportedInterfaceOrientationsIpad: [String] = _document["UISupportedInterfaceOrientations~ipad"]
-    internal static let userAmbiguousInteger: Bool = _document["User Ambiguous Integer"]
+    internal static let userAmbiguousInteger: Int = _document["User Ambiguous Integer"]
     internal static let userBoolean: Bool = _document["User Boolean"]
     internal static let userDate: Date = _document["User Date"]
     internal static let userFloat: Double = _document["User Float"]

--- a/Tests/Fixtures/Generated/Plist/runtime-swift5/all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift5/all-publicAccess.swift
@@ -36,7 +36,7 @@ public enum PlistFiles {
     public static let uiStatusBarStyle: String = _document["UIStatusBarStyle"]
     public static let uiSupportedInterfaceOrientations: [String] = _document["UISupportedInterfaceOrientations"]
     public static let uiSupportedInterfaceOrientationsIpad: [String] = _document["UISupportedInterfaceOrientations~ipad"]
-    public static let userAmbiguousInteger: Bool = _document["User Ambiguous Integer"]
+    public static let userAmbiguousInteger: Int = _document["User Ambiguous Integer"]
     public static let userBoolean: Bool = _document["User Boolean"]
     public static let userDate: Date = _document["User Date"]
     public static let userFloat: Double = _document["User Float"]

--- a/Tests/Fixtures/Generated/Plist/runtime-swift5/all.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift5/all.swift
@@ -36,7 +36,7 @@ internal enum PlistFiles {
     internal static let uiStatusBarStyle: String = _document["UIStatusBarStyle"]
     internal static let uiSupportedInterfaceOrientations: [String] = _document["UISupportedInterfaceOrientations"]
     internal static let uiSupportedInterfaceOrientationsIpad: [String] = _document["UISupportedInterfaceOrientations~ipad"]
-    internal static let userAmbiguousInteger: Bool = _document["User Ambiguous Integer"]
+    internal static let userAmbiguousInteger: Int = _document["User Ambiguous Integer"]
     internal static let userBoolean: Bool = _document["User Boolean"]
     internal static let userDate: Date = _document["User Date"]
     internal static let userFloat: Double = _document["User Float"]

--- a/Tests/Fixtures/StencilContexts/Plist/all.yaml
+++ b/Tests/Fixtures/StencilContexts/Plist/all.yaml
@@ -41,7 +41,7 @@ files:
       - "UIInterfaceOrientationLandscapeRight"
       - "UIInterfaceOrientationPortraitUpsideDown"
       - "UIInterfaceOrientationPortrait"
-      User Ambiguous Integer: true
+      User Ambiguous Integer: 1
       User Boolean: false
       User Date: 2018-05-05T03:39:26Z
       User Float: 3.14e+0
@@ -121,7 +121,7 @@ files:
             type: "String"
           type: "Array"
         User Ambiguous Integer:
-          type: "Bool"
+          type: "Int"
         User Boolean:
           type: "Bool"
         User Date:
@@ -173,7 +173,7 @@ files:
       - "UIInterfaceOrientationLandscapeRight"
       - "UIInterfaceOrientationPortraitUpsideDown"
       - "UIInterfaceOrientationPortrait"
-      User Ambiguous Integer: true
+      User Ambiguous Integer: 1
       User Boolean: false
       User Date: 2018-05-05T03:39:26Z
       User Float: 3.14e+0
@@ -253,7 +253,7 @@ files:
             type: "String"
           type: "Array"
         User Ambiguous Integer:
-          type: "Bool"
+          type: "Int"
         User Boolean:
           type: "Bool"
         User Date:

--- a/Tests/Fixtures/StencilContexts/Plist/info.yaml
+++ b/Tests/Fixtures/StencilContexts/Plist/info.yaml
@@ -41,7 +41,7 @@ files:
       - "UIInterfaceOrientationLandscapeRight"
       - "UIInterfaceOrientationPortraitUpsideDown"
       - "UIInterfaceOrientationPortrait"
-      User Ambiguous Integer: true
+      User Ambiguous Integer: 1
       User Boolean: false
       User Date: 2018-05-05T03:39:26Z
       User Float: 3.14e+0
@@ -121,7 +121,7 @@ files:
             type: "String"
           type: "Array"
         User Ambiguous Integer:
-          type: "Bool"
+          type: "Int"
         User Boolean:
           type: "Bool"
         User Date:
@@ -173,7 +173,7 @@ files:
       - "UIInterfaceOrientationLandscapeRight"
       - "UIInterfaceOrientationPortraitUpsideDown"
       - "UIInterfaceOrientationPortrait"
-      User Ambiguous Integer: true
+      User Ambiguous Integer: 1
       User Boolean: false
       User Date: 2018-05-05T03:39:26Z
       User Float: 3.14e+0
@@ -253,7 +253,7 @@ files:
             type: "String"
           type: "Array"
         User Ambiguous Integer:
-          type: "Bool"
+          type: "Int"
         User Boolean:
           type: "Bool"
         User Date:

--- a/templates/plist/inline-swift4.stencil
+++ b/templates/plist/inline-swift4.stencil
@@ -57,6 +57,8 @@ import Foundation
     {% empty %}
       :
     {% endfor %}]
+  {% elif metadata.type == "Bool" %}
+    Bool(truncating: {{ value }})
   {% else %}
     {{ value }}
   {% endif %}

--- a/templates/plist/inline-swift4.stencil
+++ b/templates/plist/inline-swift4.stencil
@@ -58,7 +58,7 @@ import Foundation
       :
     {% endfor %}]
   {% elif metadata.type == "Bool" %}
-    Bool(truncating: {{ value }})
+    {% if value %}true{% else %}false{% endif %}
   {% else %}
     {{ value }}
   {% endif %}

--- a/templates/plist/inline-swift5.stencil
+++ b/templates/plist/inline-swift5.stencil
@@ -57,6 +57,8 @@ import Foundation
     {% empty %}
       :
     {% endfor %}]
+  {% elif metadata.type == "Bool" %}
+    Bool(truncating: {{ value }})
   {% else %}
     {{ value }}
   {% endif %}

--- a/templates/plist/inline-swift5.stencil
+++ b/templates/plist/inline-swift5.stencil
@@ -58,7 +58,7 @@ import Foundation
       :
     {% endfor %}]
   {% elif metadata.type == "Bool" %}
-    Bool(truncating: {{ value }})
+    {% if value %}true{% else %}false{% endif %}
   {% else %}
     {{ value }}
   {% endif %}


### PR DESCRIPTION
Resolves https://github.com/SwiftGen/SwiftGen/issues/775

---

* [x] I've started my branch from the `develop` branch (gitflow)
  * [x] And I've selected `develop` as the "base" branch for this Pull Request I'm about to create
* [x] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself  
      _(or added `#trivial` to the PR title if I think it doesn't warrant a mention in the CHANGELOG)_
  * [x] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
  * [x] Add a period and 2 spaces at the end of your short entry description
  * [x] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

The problem is well-described in the added issue. The fix is simple - convert `Int` to `Bool` 

I am not sure how to catch this in the tests, so if there is away, I'd appreciate some quick pointer, so we can ensure there won't be any regression regarding this in the future.
