### PR TITLE
JSON: fix 0/1 integer parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ _None_
 * JSON/YAML: the `inline` templates incorrectly generated `1`/`0` as values, instead of `true`/`false` as expected.  
   [David Jennes](https://github.com/djbe)
   [#783](https://github.com/SwiftGen/SwiftGen/pull/783)
+* JSON: the parser now correctly recognizes `0` and `1` as `Int` (instead of `Bool`).  
+  [David Jennes](https://github.com/djbe)
+  [#786](https://github.com/SwiftGen/SwiftGen/pull/786)
 
 ### Internal Changes
 

--- a/Sources/SwiftGenKit/Utils/YamsSerialization.swift
+++ b/Sources/SwiftGenKit/Utils/YamsSerialization.swift
@@ -54,14 +54,29 @@ extension NSData: ScalarRepresentable {
 
 extension NSNumber: ScalarRepresentable {
   public func represented() -> Node.Scalar {
-    if let value = Bool(exactly: self) {
-      return value.represented()
-    } else if let value = Double(exactly: self), floor(value) != value {
-      return value.represented()
-    } else if let value = Int(exactly: self) {
-      return value.represented()
+    if CFGetTypeID(self) == CFBooleanGetTypeID() {
+      return boolValue.represented()
     } else {
-      return Double.nan.represented()
+      switch CFNumberGetType(self) {
+      case .sInt8Type:
+        return int8Value.represented()
+      case .sInt16Type:
+        return int16Value.represented()
+      case .sInt32Type:
+        return int32Value.represented()
+      case .sInt64Type:
+        return int64Value.represented()
+      case .charType:
+        return uint8Value.represented()
+      case .intType, .longType, .longLongType, .nsIntegerType:
+        return intValue.represented()
+      case .float32Type, .floatType:
+        return floatValue.represented()
+      case .float64Type, .doubleType, .cgFloatType:
+        return doubleValue.represented()
+      default:
+        return Double.nan.represented()
+      }
     }
   }
 }

--- a/Tests/Fixtures/Generated/JSON/inline-swift4/all-customName.swift
+++ b/Tests/Fixtures/Generated/JSON/inline-swift4/all-customName.swift
@@ -16,10 +16,17 @@ internal enum CustomJSON {
   internal enum Configuration {
     internal static let apiVersion: String = "2"
     internal static let country: Any? = nil
+    internal static let doors: Int = 5
     internal static let environment: String = "staging"
+    internal static let flags: [Bool] = [true, false, true]
+    internal static let mixed: [Any] = ["one", 2, true]
+    internal static let mixed2: [Double] = [0.1, 2, true]
     internal static let newLayout: Bool = true
+    internal static let one: Int = 1
     internal static let options: [String: Any] = ["screen-order": ["1", "2", "3"]]
+    internal static let primes: [Int] = [2, 3, 5, 7]
     internal static let quickSearch: Bool = false
+    internal static let zero: Int = 0
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length

--- a/Tests/Fixtures/Generated/JSON/inline-swift4/all-customName.swift
+++ b/Tests/Fixtures/Generated/JSON/inline-swift4/all-customName.swift
@@ -20,7 +20,7 @@ internal enum CustomJSON {
     internal static let environment: String = "staging"
     internal static let flags: [Bool] = [true, false, true]
     internal static let mixed: [Any] = ["one", 2, true]
-    internal static let mixed2: [Double] = [0.1, 2, true]
+    internal static let mixed2: [Any] = [0.1, 2, true]
     internal static let newLayout: Bool = true
     internal static let one: Int = 1
     internal static let options: [String: Any] = ["screen-order": ["1", "2", "3"]]

--- a/Tests/Fixtures/Generated/JSON/inline-swift4/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/JSON/inline-swift4/all-forceFileNameEnum.swift
@@ -20,7 +20,7 @@ internal enum JSONFiles {
     internal static let environment: String = "staging"
     internal static let flags: [Bool] = [true, false, true]
     internal static let mixed: [Any] = ["one", 2, true]
-    internal static let mixed2: [Double] = [0.1, 2, true]
+    internal static let mixed2: [Any] = [0.1, 2, true]
     internal static let newLayout: Bool = true
     internal static let one: Int = 1
     internal static let options: [String: Any] = ["screen-order": ["1", "2", "3"]]

--- a/Tests/Fixtures/Generated/JSON/inline-swift4/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/JSON/inline-swift4/all-forceFileNameEnum.swift
@@ -16,10 +16,17 @@ internal enum JSONFiles {
   internal enum Configuration {
     internal static let apiVersion: String = "2"
     internal static let country: Any? = nil
+    internal static let doors: Int = 5
     internal static let environment: String = "staging"
+    internal static let flags: [Bool] = [true, false, true]
+    internal static let mixed: [Any] = ["one", 2, true]
+    internal static let mixed2: [Double] = [0.1, 2, true]
     internal static let newLayout: Bool = true
+    internal static let one: Int = 1
     internal static let options: [String: Any] = ["screen-order": ["1", "2", "3"]]
+    internal static let primes: [Int] = [2, 3, 5, 7]
     internal static let quickSearch: Bool = false
+    internal static let zero: Int = 0
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length

--- a/Tests/Fixtures/Generated/JSON/inline-swift4/all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/JSON/inline-swift4/all-publicAccess.swift
@@ -20,7 +20,7 @@ public enum JSONFiles {
     public static let environment: String = "staging"
     public static let flags: [Bool] = [true, false, true]
     public static let mixed: [Any] = ["one", 2, true]
-    public static let mixed2: [Double] = [0.1, 2, true]
+    public static let mixed2: [Any] = [0.1, 2, true]
     public static let newLayout: Bool = true
     public static let one: Int = 1
     public static let options: [String: Any] = ["screen-order": ["1", "2", "3"]]

--- a/Tests/Fixtures/Generated/JSON/inline-swift4/all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/JSON/inline-swift4/all-publicAccess.swift
@@ -16,10 +16,17 @@ public enum JSONFiles {
   public enum Configuration {
     public static let apiVersion: String = "2"
     public static let country: Any? = nil
+    public static let doors: Int = 5
     public static let environment: String = "staging"
+    public static let flags: [Bool] = [true, false, true]
+    public static let mixed: [Any] = ["one", 2, true]
+    public static let mixed2: [Double] = [0.1, 2, true]
     public static let newLayout: Bool = true
+    public static let one: Int = 1
     public static let options: [String: Any] = ["screen-order": ["1", "2", "3"]]
+    public static let primes: [Int] = [2, 3, 5, 7]
     public static let quickSearch: Bool = false
+    public static let zero: Int = 0
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length

--- a/Tests/Fixtures/Generated/JSON/inline-swift4/all.swift
+++ b/Tests/Fixtures/Generated/JSON/inline-swift4/all.swift
@@ -20,7 +20,7 @@ internal enum JSONFiles {
     internal static let environment: String = "staging"
     internal static let flags: [Bool] = [true, false, true]
     internal static let mixed: [Any] = ["one", 2, true]
-    internal static let mixed2: [Double] = [0.1, 2, true]
+    internal static let mixed2: [Any] = [0.1, 2, true]
     internal static let newLayout: Bool = true
     internal static let one: Int = 1
     internal static let options: [String: Any] = ["screen-order": ["1", "2", "3"]]

--- a/Tests/Fixtures/Generated/JSON/inline-swift4/all.swift
+++ b/Tests/Fixtures/Generated/JSON/inline-swift4/all.swift
@@ -16,10 +16,17 @@ internal enum JSONFiles {
   internal enum Configuration {
     internal static let apiVersion: String = "2"
     internal static let country: Any? = nil
+    internal static let doors: Int = 5
     internal static let environment: String = "staging"
+    internal static let flags: [Bool] = [true, false, true]
+    internal static let mixed: [Any] = ["one", 2, true]
+    internal static let mixed2: [Double] = [0.1, 2, true]
     internal static let newLayout: Bool = true
+    internal static let one: Int = 1
     internal static let options: [String: Any] = ["screen-order": ["1", "2", "3"]]
+    internal static let primes: [Int] = [2, 3, 5, 7]
     internal static let quickSearch: Bool = false
+    internal static let zero: Int = 0
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length

--- a/Tests/Fixtures/Generated/JSON/inline-swift5/all-customName.swift
+++ b/Tests/Fixtures/Generated/JSON/inline-swift5/all-customName.swift
@@ -16,10 +16,17 @@ internal enum CustomJSON {
   internal enum Configuration {
     internal static let apiVersion: String = "2"
     internal static let country: Any? = nil
+    internal static let doors: Int = 5
     internal static let environment: String = "staging"
+    internal static let flags: [Bool] = [true, false, true]
+    internal static let mixed: [Any] = ["one", 2, true]
+    internal static let mixed2: [Double] = [0.1, 2, true]
     internal static let newLayout: Bool = true
+    internal static let one: Int = 1
     internal static let options: [String: Any] = ["screen-order": ["1", "2", "3"]]
+    internal static let primes: [Int] = [2, 3, 5, 7]
     internal static let quickSearch: Bool = false
+    internal static let zero: Int = 0
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length

--- a/Tests/Fixtures/Generated/JSON/inline-swift5/all-customName.swift
+++ b/Tests/Fixtures/Generated/JSON/inline-swift5/all-customName.swift
@@ -20,7 +20,7 @@ internal enum CustomJSON {
     internal static let environment: String = "staging"
     internal static let flags: [Bool] = [true, false, true]
     internal static let mixed: [Any] = ["one", 2, true]
-    internal static let mixed2: [Double] = [0.1, 2, true]
+    internal static let mixed2: [Any] = [0.1, 2, true]
     internal static let newLayout: Bool = true
     internal static let one: Int = 1
     internal static let options: [String: Any] = ["screen-order": ["1", "2", "3"]]

--- a/Tests/Fixtures/Generated/JSON/inline-swift5/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/JSON/inline-swift5/all-forceFileNameEnum.swift
@@ -20,7 +20,7 @@ internal enum JSONFiles {
     internal static let environment: String = "staging"
     internal static let flags: [Bool] = [true, false, true]
     internal static let mixed: [Any] = ["one", 2, true]
-    internal static let mixed2: [Double] = [0.1, 2, true]
+    internal static let mixed2: [Any] = [0.1, 2, true]
     internal static let newLayout: Bool = true
     internal static let one: Int = 1
     internal static let options: [String: Any] = ["screen-order": ["1", "2", "3"]]

--- a/Tests/Fixtures/Generated/JSON/inline-swift5/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/JSON/inline-swift5/all-forceFileNameEnum.swift
@@ -16,10 +16,17 @@ internal enum JSONFiles {
   internal enum Configuration {
     internal static let apiVersion: String = "2"
     internal static let country: Any? = nil
+    internal static let doors: Int = 5
     internal static let environment: String = "staging"
+    internal static let flags: [Bool] = [true, false, true]
+    internal static let mixed: [Any] = ["one", 2, true]
+    internal static let mixed2: [Double] = [0.1, 2, true]
     internal static let newLayout: Bool = true
+    internal static let one: Int = 1
     internal static let options: [String: Any] = ["screen-order": ["1", "2", "3"]]
+    internal static let primes: [Int] = [2, 3, 5, 7]
     internal static let quickSearch: Bool = false
+    internal static let zero: Int = 0
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length

--- a/Tests/Fixtures/Generated/JSON/inline-swift5/all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/JSON/inline-swift5/all-publicAccess.swift
@@ -20,7 +20,7 @@ public enum JSONFiles {
     public static let environment: String = "staging"
     public static let flags: [Bool] = [true, false, true]
     public static let mixed: [Any] = ["one", 2, true]
-    public static let mixed2: [Double] = [0.1, 2, true]
+    public static let mixed2: [Any] = [0.1, 2, true]
     public static let newLayout: Bool = true
     public static let one: Int = 1
     public static let options: [String: Any] = ["screen-order": ["1", "2", "3"]]

--- a/Tests/Fixtures/Generated/JSON/inline-swift5/all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/JSON/inline-swift5/all-publicAccess.swift
@@ -16,10 +16,17 @@ public enum JSONFiles {
   public enum Configuration {
     public static let apiVersion: String = "2"
     public static let country: Any? = nil
+    public static let doors: Int = 5
     public static let environment: String = "staging"
+    public static let flags: [Bool] = [true, false, true]
+    public static let mixed: [Any] = ["one", 2, true]
+    public static let mixed2: [Double] = [0.1, 2, true]
     public static let newLayout: Bool = true
+    public static let one: Int = 1
     public static let options: [String: Any] = ["screen-order": ["1", "2", "3"]]
+    public static let primes: [Int] = [2, 3, 5, 7]
     public static let quickSearch: Bool = false
+    public static let zero: Int = 0
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length

--- a/Tests/Fixtures/Generated/JSON/inline-swift5/all.swift
+++ b/Tests/Fixtures/Generated/JSON/inline-swift5/all.swift
@@ -20,7 +20,7 @@ internal enum JSONFiles {
     internal static let environment: String = "staging"
     internal static let flags: [Bool] = [true, false, true]
     internal static let mixed: [Any] = ["one", 2, true]
-    internal static let mixed2: [Double] = [0.1, 2, true]
+    internal static let mixed2: [Any] = [0.1, 2, true]
     internal static let newLayout: Bool = true
     internal static let one: Int = 1
     internal static let options: [String: Any] = ["screen-order": ["1", "2", "3"]]

--- a/Tests/Fixtures/Generated/JSON/inline-swift5/all.swift
+++ b/Tests/Fixtures/Generated/JSON/inline-swift5/all.swift
@@ -16,10 +16,17 @@ internal enum JSONFiles {
   internal enum Configuration {
     internal static let apiVersion: String = "2"
     internal static let country: Any? = nil
+    internal static let doors: Int = 5
     internal static let environment: String = "staging"
+    internal static let flags: [Bool] = [true, false, true]
+    internal static let mixed: [Any] = ["one", 2, true]
+    internal static let mixed2: [Double] = [0.1, 2, true]
     internal static let newLayout: Bool = true
+    internal static let one: Int = 1
     internal static let options: [String: Any] = ["screen-order": ["1", "2", "3"]]
+    internal static let primes: [Int] = [2, 3, 5, 7]
     internal static let quickSearch: Bool = false
+    internal static let zero: Int = 0
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length

--- a/Tests/Fixtures/Generated/JSON/runtime-swift4/all-customBundle.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift4/all-customBundle.swift
@@ -17,10 +17,17 @@ internal enum JSONFiles {
     private static let _document = JSONDocument(path: "configuration.json")
     internal static let apiVersion: String = _document["api-version"]
     internal static let country: Any? = _document["country"]
+    internal static let doors: Int = _document["doors"]
     internal static let environment: String = _document["environment"]
+    internal static let flags: [Bool] = _document["flags"]
+    internal static let mixed: [Any] = _document["mixed"]
+    internal static let mixed2: [Double] = _document["mixed2"]
     internal static let newLayout: Bool = _document["new-layout"]
+    internal static let one: Int = _document["one"]
     internal static let options: [String: Any] = _document["options"]
+    internal static let primes: [Int] = _document["primes"]
     internal static let quickSearch: Bool = _document["quick-search"]
+    internal static let zero: Int = _document["zero"]
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length

--- a/Tests/Fixtures/Generated/JSON/runtime-swift4/all-customBundle.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift4/all-customBundle.swift
@@ -21,7 +21,7 @@ internal enum JSONFiles {
     internal static let environment: String = _document["environment"]
     internal static let flags: [Bool] = _document["flags"]
     internal static let mixed: [Any] = _document["mixed"]
-    internal static let mixed2: [Double] = _document["mixed2"]
+    internal static let mixed2: [Any] = _document["mixed2"]
     internal static let newLayout: Bool = _document["new-layout"]
     internal static let one: Int = _document["one"]
     internal static let options: [String: Any] = _document["options"]

--- a/Tests/Fixtures/Generated/JSON/runtime-swift4/all-customname.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift4/all-customname.swift
@@ -21,7 +21,7 @@ internal enum CustomJSON {
     internal static let environment: String = _document["environment"]
     internal static let flags: [Bool] = _document["flags"]
     internal static let mixed: [Any] = _document["mixed"]
-    internal static let mixed2: [Double] = _document["mixed2"]
+    internal static let mixed2: [Any] = _document["mixed2"]
     internal static let newLayout: Bool = _document["new-layout"]
     internal static let one: Int = _document["one"]
     internal static let options: [String: Any] = _document["options"]

--- a/Tests/Fixtures/Generated/JSON/runtime-swift4/all-customname.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift4/all-customname.swift
@@ -17,10 +17,17 @@ internal enum CustomJSON {
     private static let _document = JSONDocument(path: "configuration.json")
     internal static let apiVersion: String = _document["api-version"]
     internal static let country: Any? = _document["country"]
+    internal static let doors: Int = _document["doors"]
     internal static let environment: String = _document["environment"]
+    internal static let flags: [Bool] = _document["flags"]
+    internal static let mixed: [Any] = _document["mixed"]
+    internal static let mixed2: [Double] = _document["mixed2"]
     internal static let newLayout: Bool = _document["new-layout"]
+    internal static let one: Int = _document["one"]
     internal static let options: [String: Any] = _document["options"]
+    internal static let primes: [Int] = _document["primes"]
     internal static let quickSearch: Bool = _document["quick-search"]
+    internal static let zero: Int = _document["zero"]
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length

--- a/Tests/Fixtures/Generated/JSON/runtime-swift4/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift4/all-forceFileNameEnum.swift
@@ -17,10 +17,17 @@ internal enum JSONFiles {
     private static let _document = JSONDocument(path: "configuration.json")
     internal static let apiVersion: String = _document["api-version"]
     internal static let country: Any? = _document["country"]
+    internal static let doors: Int = _document["doors"]
     internal static let environment: String = _document["environment"]
+    internal static let flags: [Bool] = _document["flags"]
+    internal static let mixed: [Any] = _document["mixed"]
+    internal static let mixed2: [Double] = _document["mixed2"]
     internal static let newLayout: Bool = _document["new-layout"]
+    internal static let one: Int = _document["one"]
     internal static let options: [String: Any] = _document["options"]
+    internal static let primes: [Int] = _document["primes"]
     internal static let quickSearch: Bool = _document["quick-search"]
+    internal static let zero: Int = _document["zero"]
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length

--- a/Tests/Fixtures/Generated/JSON/runtime-swift4/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift4/all-forceFileNameEnum.swift
@@ -21,7 +21,7 @@ internal enum JSONFiles {
     internal static let environment: String = _document["environment"]
     internal static let flags: [Bool] = _document["flags"]
     internal static let mixed: [Any] = _document["mixed"]
-    internal static let mixed2: [Double] = _document["mixed2"]
+    internal static let mixed2: [Any] = _document["mixed2"]
     internal static let newLayout: Bool = _document["new-layout"]
     internal static let one: Int = _document["one"]
     internal static let options: [String: Any] = _document["options"]

--- a/Tests/Fixtures/Generated/JSON/runtime-swift4/all-lookupFunction.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift4/all-lookupFunction.swift
@@ -17,10 +17,17 @@ internal enum JSONFiles {
     private static let _document = JSONDocument(path: "configuration.json")
     internal static let apiVersion: String = _document["api-version"]
     internal static let country: Any? = _document["country"]
+    internal static let doors: Int = _document["doors"]
     internal static let environment: String = _document["environment"]
+    internal static let flags: [Bool] = _document["flags"]
+    internal static let mixed: [Any] = _document["mixed"]
+    internal static let mixed2: [Double] = _document["mixed2"]
     internal static let newLayout: Bool = _document["new-layout"]
+    internal static let one: Int = _document["one"]
     internal static let options: [String: Any] = _document["options"]
+    internal static let primes: [Int] = _document["primes"]
     internal static let quickSearch: Bool = _document["quick-search"]
+    internal static let zero: Int = _document["zero"]
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length

--- a/Tests/Fixtures/Generated/JSON/runtime-swift4/all-lookupFunction.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift4/all-lookupFunction.swift
@@ -21,7 +21,7 @@ internal enum JSONFiles {
     internal static let environment: String = _document["environment"]
     internal static let flags: [Bool] = _document["flags"]
     internal static let mixed: [Any] = _document["mixed"]
-    internal static let mixed2: [Double] = _document["mixed2"]
+    internal static let mixed2: [Any] = _document["mixed2"]
     internal static let newLayout: Bool = _document["new-layout"]
     internal static let one: Int = _document["one"]
     internal static let options: [String: Any] = _document["options"]

--- a/Tests/Fixtures/Generated/JSON/runtime-swift4/all-preservePath.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift4/all-preservePath.swift
@@ -17,10 +17,17 @@ internal enum JSONFiles {
     private static let _document = JSONDocument(path: "configuration.json")
     internal static let apiVersion: String = _document["api-version"]
     internal static let country: Any? = _document["country"]
+    internal static let doors: Int = _document["doors"]
     internal static let environment: String = _document["environment"]
+    internal static let flags: [Bool] = _document["flags"]
+    internal static let mixed: [Any] = _document["mixed"]
+    internal static let mixed2: [Double] = _document["mixed2"]
     internal static let newLayout: Bool = _document["new-layout"]
+    internal static let one: Int = _document["one"]
     internal static let options: [String: Any] = _document["options"]
+    internal static let primes: [Int] = _document["primes"]
     internal static let quickSearch: Bool = _document["quick-search"]
+    internal static let zero: Int = _document["zero"]
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length

--- a/Tests/Fixtures/Generated/JSON/runtime-swift4/all-preservePath.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift4/all-preservePath.swift
@@ -21,7 +21,7 @@ internal enum JSONFiles {
     internal static let environment: String = _document["environment"]
     internal static let flags: [Bool] = _document["flags"]
     internal static let mixed: [Any] = _document["mixed"]
-    internal static let mixed2: [Double] = _document["mixed2"]
+    internal static let mixed2: [Any] = _document["mixed2"]
     internal static let newLayout: Bool = _document["new-layout"]
     internal static let one: Int = _document["one"]
     internal static let options: [String: Any] = _document["options"]

--- a/Tests/Fixtures/Generated/JSON/runtime-swift4/all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift4/all-publicAccess.swift
@@ -17,10 +17,17 @@ public enum JSONFiles {
     private static let _document = JSONDocument(path: "configuration.json")
     public static let apiVersion: String = _document["api-version"]
     public static let country: Any? = _document["country"]
+    public static let doors: Int = _document["doors"]
     public static let environment: String = _document["environment"]
+    public static let flags: [Bool] = _document["flags"]
+    public static let mixed: [Any] = _document["mixed"]
+    public static let mixed2: [Double] = _document["mixed2"]
     public static let newLayout: Bool = _document["new-layout"]
+    public static let one: Int = _document["one"]
     public static let options: [String: Any] = _document["options"]
+    public static let primes: [Int] = _document["primes"]
     public static let quickSearch: Bool = _document["quick-search"]
+    public static let zero: Int = _document["zero"]
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length

--- a/Tests/Fixtures/Generated/JSON/runtime-swift4/all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift4/all-publicAccess.swift
@@ -21,7 +21,7 @@ public enum JSONFiles {
     public static let environment: String = _document["environment"]
     public static let flags: [Bool] = _document["flags"]
     public static let mixed: [Any] = _document["mixed"]
-    public static let mixed2: [Double] = _document["mixed2"]
+    public static let mixed2: [Any] = _document["mixed2"]
     public static let newLayout: Bool = _document["new-layout"]
     public static let one: Int = _document["one"]
     public static let options: [String: Any] = _document["options"]

--- a/Tests/Fixtures/Generated/JSON/runtime-swift4/all.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift4/all.swift
@@ -17,10 +17,17 @@ internal enum JSONFiles {
     private static let _document = JSONDocument(path: "configuration.json")
     internal static let apiVersion: String = _document["api-version"]
     internal static let country: Any? = _document["country"]
+    internal static let doors: Int = _document["doors"]
     internal static let environment: String = _document["environment"]
+    internal static let flags: [Bool] = _document["flags"]
+    internal static let mixed: [Any] = _document["mixed"]
+    internal static let mixed2: [Double] = _document["mixed2"]
     internal static let newLayout: Bool = _document["new-layout"]
+    internal static let one: Int = _document["one"]
     internal static let options: [String: Any] = _document["options"]
+    internal static let primes: [Int] = _document["primes"]
     internal static let quickSearch: Bool = _document["quick-search"]
+    internal static let zero: Int = _document["zero"]
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length

--- a/Tests/Fixtures/Generated/JSON/runtime-swift4/all.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift4/all.swift
@@ -21,7 +21,7 @@ internal enum JSONFiles {
     internal static let environment: String = _document["environment"]
     internal static let flags: [Bool] = _document["flags"]
     internal static let mixed: [Any] = _document["mixed"]
-    internal static let mixed2: [Double] = _document["mixed2"]
+    internal static let mixed2: [Any] = _document["mixed2"]
     internal static let newLayout: Bool = _document["new-layout"]
     internal static let one: Int = _document["one"]
     internal static let options: [String: Any] = _document["options"]

--- a/Tests/Fixtures/Generated/JSON/runtime-swift5/all-customBundle.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift5/all-customBundle.swift
@@ -17,10 +17,17 @@ internal enum JSONFiles {
     private static let _document = JSONDocument(path: "configuration.json")
     internal static let apiVersion: String = _document["api-version"]
     internal static let country: Any? = _document["country"]
+    internal static let doors: Int = _document["doors"]
     internal static let environment: String = _document["environment"]
+    internal static let flags: [Bool] = _document["flags"]
+    internal static let mixed: [Any] = _document["mixed"]
+    internal static let mixed2: [Double] = _document["mixed2"]
     internal static let newLayout: Bool = _document["new-layout"]
+    internal static let one: Int = _document["one"]
     internal static let options: [String: Any] = _document["options"]
+    internal static let primes: [Int] = _document["primes"]
     internal static let quickSearch: Bool = _document["quick-search"]
+    internal static let zero: Int = _document["zero"]
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length

--- a/Tests/Fixtures/Generated/JSON/runtime-swift5/all-customBundle.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift5/all-customBundle.swift
@@ -21,7 +21,7 @@ internal enum JSONFiles {
     internal static let environment: String = _document["environment"]
     internal static let flags: [Bool] = _document["flags"]
     internal static let mixed: [Any] = _document["mixed"]
-    internal static let mixed2: [Double] = _document["mixed2"]
+    internal static let mixed2: [Any] = _document["mixed2"]
     internal static let newLayout: Bool = _document["new-layout"]
     internal static let one: Int = _document["one"]
     internal static let options: [String: Any] = _document["options"]

--- a/Tests/Fixtures/Generated/JSON/runtime-swift5/all-customname.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift5/all-customname.swift
@@ -21,7 +21,7 @@ internal enum CustomJSON {
     internal static let environment: String = _document["environment"]
     internal static let flags: [Bool] = _document["flags"]
     internal static let mixed: [Any] = _document["mixed"]
-    internal static let mixed2: [Double] = _document["mixed2"]
+    internal static let mixed2: [Any] = _document["mixed2"]
     internal static let newLayout: Bool = _document["new-layout"]
     internal static let one: Int = _document["one"]
     internal static let options: [String: Any] = _document["options"]

--- a/Tests/Fixtures/Generated/JSON/runtime-swift5/all-customname.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift5/all-customname.swift
@@ -17,10 +17,17 @@ internal enum CustomJSON {
     private static let _document = JSONDocument(path: "configuration.json")
     internal static let apiVersion: String = _document["api-version"]
     internal static let country: Any? = _document["country"]
+    internal static let doors: Int = _document["doors"]
     internal static let environment: String = _document["environment"]
+    internal static let flags: [Bool] = _document["flags"]
+    internal static let mixed: [Any] = _document["mixed"]
+    internal static let mixed2: [Double] = _document["mixed2"]
     internal static let newLayout: Bool = _document["new-layout"]
+    internal static let one: Int = _document["one"]
     internal static let options: [String: Any] = _document["options"]
+    internal static let primes: [Int] = _document["primes"]
     internal static let quickSearch: Bool = _document["quick-search"]
+    internal static let zero: Int = _document["zero"]
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length

--- a/Tests/Fixtures/Generated/JSON/runtime-swift5/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift5/all-forceFileNameEnum.swift
@@ -17,10 +17,17 @@ internal enum JSONFiles {
     private static let _document = JSONDocument(path: "configuration.json")
     internal static let apiVersion: String = _document["api-version"]
     internal static let country: Any? = _document["country"]
+    internal static let doors: Int = _document["doors"]
     internal static let environment: String = _document["environment"]
+    internal static let flags: [Bool] = _document["flags"]
+    internal static let mixed: [Any] = _document["mixed"]
+    internal static let mixed2: [Double] = _document["mixed2"]
     internal static let newLayout: Bool = _document["new-layout"]
+    internal static let one: Int = _document["one"]
     internal static let options: [String: Any] = _document["options"]
+    internal static let primes: [Int] = _document["primes"]
     internal static let quickSearch: Bool = _document["quick-search"]
+    internal static let zero: Int = _document["zero"]
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length

--- a/Tests/Fixtures/Generated/JSON/runtime-swift5/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift5/all-forceFileNameEnum.swift
@@ -21,7 +21,7 @@ internal enum JSONFiles {
     internal static let environment: String = _document["environment"]
     internal static let flags: [Bool] = _document["flags"]
     internal static let mixed: [Any] = _document["mixed"]
-    internal static let mixed2: [Double] = _document["mixed2"]
+    internal static let mixed2: [Any] = _document["mixed2"]
     internal static let newLayout: Bool = _document["new-layout"]
     internal static let one: Int = _document["one"]
     internal static let options: [String: Any] = _document["options"]

--- a/Tests/Fixtures/Generated/JSON/runtime-swift5/all-lookupFunction.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift5/all-lookupFunction.swift
@@ -17,10 +17,17 @@ internal enum JSONFiles {
     private static let _document = JSONDocument(path: "configuration.json")
     internal static let apiVersion: String = _document["api-version"]
     internal static let country: Any? = _document["country"]
+    internal static let doors: Int = _document["doors"]
     internal static let environment: String = _document["environment"]
+    internal static let flags: [Bool] = _document["flags"]
+    internal static let mixed: [Any] = _document["mixed"]
+    internal static let mixed2: [Double] = _document["mixed2"]
     internal static let newLayout: Bool = _document["new-layout"]
+    internal static let one: Int = _document["one"]
     internal static let options: [String: Any] = _document["options"]
+    internal static let primes: [Int] = _document["primes"]
     internal static let quickSearch: Bool = _document["quick-search"]
+    internal static let zero: Int = _document["zero"]
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length

--- a/Tests/Fixtures/Generated/JSON/runtime-swift5/all-lookupFunction.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift5/all-lookupFunction.swift
@@ -21,7 +21,7 @@ internal enum JSONFiles {
     internal static let environment: String = _document["environment"]
     internal static let flags: [Bool] = _document["flags"]
     internal static let mixed: [Any] = _document["mixed"]
-    internal static let mixed2: [Double] = _document["mixed2"]
+    internal static let mixed2: [Any] = _document["mixed2"]
     internal static let newLayout: Bool = _document["new-layout"]
     internal static let one: Int = _document["one"]
     internal static let options: [String: Any] = _document["options"]

--- a/Tests/Fixtures/Generated/JSON/runtime-swift5/all-preservePath.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift5/all-preservePath.swift
@@ -17,10 +17,17 @@ internal enum JSONFiles {
     private static let _document = JSONDocument(path: "configuration.json")
     internal static let apiVersion: String = _document["api-version"]
     internal static let country: Any? = _document["country"]
+    internal static let doors: Int = _document["doors"]
     internal static let environment: String = _document["environment"]
+    internal static let flags: [Bool] = _document["flags"]
+    internal static let mixed: [Any] = _document["mixed"]
+    internal static let mixed2: [Double] = _document["mixed2"]
     internal static let newLayout: Bool = _document["new-layout"]
+    internal static let one: Int = _document["one"]
     internal static let options: [String: Any] = _document["options"]
+    internal static let primes: [Int] = _document["primes"]
     internal static let quickSearch: Bool = _document["quick-search"]
+    internal static let zero: Int = _document["zero"]
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length

--- a/Tests/Fixtures/Generated/JSON/runtime-swift5/all-preservePath.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift5/all-preservePath.swift
@@ -21,7 +21,7 @@ internal enum JSONFiles {
     internal static let environment: String = _document["environment"]
     internal static let flags: [Bool] = _document["flags"]
     internal static let mixed: [Any] = _document["mixed"]
-    internal static let mixed2: [Double] = _document["mixed2"]
+    internal static let mixed2: [Any] = _document["mixed2"]
     internal static let newLayout: Bool = _document["new-layout"]
     internal static let one: Int = _document["one"]
     internal static let options: [String: Any] = _document["options"]

--- a/Tests/Fixtures/Generated/JSON/runtime-swift5/all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift5/all-publicAccess.swift
@@ -17,10 +17,17 @@ public enum JSONFiles {
     private static let _document = JSONDocument(path: "configuration.json")
     public static let apiVersion: String = _document["api-version"]
     public static let country: Any? = _document["country"]
+    public static let doors: Int = _document["doors"]
     public static let environment: String = _document["environment"]
+    public static let flags: [Bool] = _document["flags"]
+    public static let mixed: [Any] = _document["mixed"]
+    public static let mixed2: [Double] = _document["mixed2"]
     public static let newLayout: Bool = _document["new-layout"]
+    public static let one: Int = _document["one"]
     public static let options: [String: Any] = _document["options"]
+    public static let primes: [Int] = _document["primes"]
     public static let quickSearch: Bool = _document["quick-search"]
+    public static let zero: Int = _document["zero"]
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length

--- a/Tests/Fixtures/Generated/JSON/runtime-swift5/all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift5/all-publicAccess.swift
@@ -21,7 +21,7 @@ public enum JSONFiles {
     public static let environment: String = _document["environment"]
     public static let flags: [Bool] = _document["flags"]
     public static let mixed: [Any] = _document["mixed"]
-    public static let mixed2: [Double] = _document["mixed2"]
+    public static let mixed2: [Any] = _document["mixed2"]
     public static let newLayout: Bool = _document["new-layout"]
     public static let one: Int = _document["one"]
     public static let options: [String: Any] = _document["options"]

--- a/Tests/Fixtures/Generated/JSON/runtime-swift5/all.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift5/all.swift
@@ -17,10 +17,17 @@ internal enum JSONFiles {
     private static let _document = JSONDocument(path: "configuration.json")
     internal static let apiVersion: String = _document["api-version"]
     internal static let country: Any? = _document["country"]
+    internal static let doors: Int = _document["doors"]
     internal static let environment: String = _document["environment"]
+    internal static let flags: [Bool] = _document["flags"]
+    internal static let mixed: [Any] = _document["mixed"]
+    internal static let mixed2: [Double] = _document["mixed2"]
     internal static let newLayout: Bool = _document["new-layout"]
+    internal static let one: Int = _document["one"]
     internal static let options: [String: Any] = _document["options"]
+    internal static let primes: [Int] = _document["primes"]
     internal static let quickSearch: Bool = _document["quick-search"]
+    internal static let zero: Int = _document["zero"]
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length

--- a/Tests/Fixtures/Generated/JSON/runtime-swift5/all.swift
+++ b/Tests/Fixtures/Generated/JSON/runtime-swift5/all.swift
@@ -21,7 +21,7 @@ internal enum JSONFiles {
     internal static let environment: String = _document["environment"]
     internal static let flags: [Bool] = _document["flags"]
     internal static let mixed: [Any] = _document["mixed"]
-    internal static let mixed2: [Double] = _document["mixed2"]
+    internal static let mixed2: [Any] = _document["mixed2"]
     internal static let newLayout: Bool = _document["new-layout"]
     internal static let one: Int = _document["one"]
     internal static let options: [String: Any] = _document["options"]

--- a/Tests/Fixtures/Generated/Plist/inline-swift4/all-customname.swift
+++ b/Tests/Fixtures/Generated/Plist/inline-swift4/all-customname.swift
@@ -43,8 +43,14 @@ internal enum CustomPlist {
   }
   internal enum Configuration {
     internal static let environment: String = "development"
+    internal static let flags: [Bool] = [true, false, true]
+    internal static let mixed: [Any] = ["One", 1, true]
+    internal static let mixed2: [Any] = [0.1, 1, true]
     internal static let names: [String] = ["John", "Peter", "Nick"]
+    internal static let one: Int = 1
     internal static let options: [String: Any] = ["Animation Style": "Party Mode"]
+    internal static let primes: [Int] = [2, 3, 5, 7]
+    internal static let zero: Int = 0
   }
   internal enum ShoppingList {
     internal static let items: [String] = ["Eggs", "Bread", "Milk"]

--- a/Tests/Fixtures/Generated/Plist/inline-swift4/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/Plist/inline-swift4/all-forceFileNameEnum.swift
@@ -43,8 +43,14 @@ internal enum PlistFiles {
   }
   internal enum Configuration {
     internal static let environment: String = "development"
+    internal static let flags: [Bool] = [true, false, true]
+    internal static let mixed: [Any] = ["One", 1, true]
+    internal static let mixed2: [Any] = [0.1, 1, true]
     internal static let names: [String] = ["John", "Peter", "Nick"]
+    internal static let one: Int = 1
     internal static let options: [String: Any] = ["Animation Style": "Party Mode"]
+    internal static let primes: [Int] = [2, 3, 5, 7]
+    internal static let zero: Int = 0
   }
   internal enum ShoppingList {
     internal static let items: [String] = ["Eggs", "Bread", "Milk"]

--- a/Tests/Fixtures/Generated/Plist/inline-swift4/all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Plist/inline-swift4/all-publicAccess.swift
@@ -43,8 +43,14 @@ public enum PlistFiles {
   }
   public enum Configuration {
     public static let environment: String = "development"
+    public static let flags: [Bool] = [true, false, true]
+    public static let mixed: [Any] = ["One", 1, true]
+    public static let mixed2: [Any] = [0.1, 1, true]
     public static let names: [String] = ["John", "Peter", "Nick"]
+    public static let one: Int = 1
     public static let options: [String: Any] = ["Animation Style": "Party Mode"]
+    public static let primes: [Int] = [2, 3, 5, 7]
+    public static let zero: Int = 0
   }
   public enum ShoppingList {
     public static let items: [String] = ["Eggs", "Bread", "Milk"]

--- a/Tests/Fixtures/Generated/Plist/inline-swift4/all.swift
+++ b/Tests/Fixtures/Generated/Plist/inline-swift4/all.swift
@@ -43,8 +43,14 @@ internal enum PlistFiles {
   }
   internal enum Configuration {
     internal static let environment: String = "development"
+    internal static let flags: [Bool] = [true, false, true]
+    internal static let mixed: [Any] = ["One", 1, true]
+    internal static let mixed2: [Any] = [0.1, 1, true]
     internal static let names: [String] = ["John", "Peter", "Nick"]
+    internal static let one: Int = 1
     internal static let options: [String: Any] = ["Animation Style": "Party Mode"]
+    internal static let primes: [Int] = [2, 3, 5, 7]
+    internal static let zero: Int = 0
   }
   internal enum ShoppingList {
     internal static let items: [String] = ["Eggs", "Bread", "Milk"]

--- a/Tests/Fixtures/Generated/Plist/inline-swift5/all-customname.swift
+++ b/Tests/Fixtures/Generated/Plist/inline-swift5/all-customname.swift
@@ -43,8 +43,14 @@ internal enum CustomPlist {
   }
   internal enum Configuration {
     internal static let environment: String = "development"
+    internal static let flags: [Bool] = [true, false, true]
+    internal static let mixed: [Any] = ["One", 1, true]
+    internal static let mixed2: [Any] = [0.1, 1, true]
     internal static let names: [String] = ["John", "Peter", "Nick"]
+    internal static let one: Int = 1
     internal static let options: [String: Any] = ["Animation Style": "Party Mode"]
+    internal static let primes: [Int] = [2, 3, 5, 7]
+    internal static let zero: Int = 0
   }
   internal enum ShoppingList {
     internal static let items: [String] = ["Eggs", "Bread", "Milk"]

--- a/Tests/Fixtures/Generated/Plist/inline-swift5/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/Plist/inline-swift5/all-forceFileNameEnum.swift
@@ -43,8 +43,14 @@ internal enum PlistFiles {
   }
   internal enum Configuration {
     internal static let environment: String = "development"
+    internal static let flags: [Bool] = [true, false, true]
+    internal static let mixed: [Any] = ["One", 1, true]
+    internal static let mixed2: [Any] = [0.1, 1, true]
     internal static let names: [String] = ["John", "Peter", "Nick"]
+    internal static let one: Int = 1
     internal static let options: [String: Any] = ["Animation Style": "Party Mode"]
+    internal static let primes: [Int] = [2, 3, 5, 7]
+    internal static let zero: Int = 0
   }
   internal enum ShoppingList {
     internal static let items: [String] = ["Eggs", "Bread", "Milk"]

--- a/Tests/Fixtures/Generated/Plist/inline-swift5/all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Plist/inline-swift5/all-publicAccess.swift
@@ -43,8 +43,14 @@ public enum PlistFiles {
   }
   public enum Configuration {
     public static let environment: String = "development"
+    public static let flags: [Bool] = [true, false, true]
+    public static let mixed: [Any] = ["One", 1, true]
+    public static let mixed2: [Any] = [0.1, 1, true]
     public static let names: [String] = ["John", "Peter", "Nick"]
+    public static let one: Int = 1
     public static let options: [String: Any] = ["Animation Style": "Party Mode"]
+    public static let primes: [Int] = [2, 3, 5, 7]
+    public static let zero: Int = 0
   }
   public enum ShoppingList {
     public static let items: [String] = ["Eggs", "Bread", "Milk"]

--- a/Tests/Fixtures/Generated/Plist/inline-swift5/all.swift
+++ b/Tests/Fixtures/Generated/Plist/inline-swift5/all.swift
@@ -43,8 +43,14 @@ internal enum PlistFiles {
   }
   internal enum Configuration {
     internal static let environment: String = "development"
+    internal static let flags: [Bool] = [true, false, true]
+    internal static let mixed: [Any] = ["One", 1, true]
+    internal static let mixed2: [Any] = [0.1, 1, true]
     internal static let names: [String] = ["John", "Peter", "Nick"]
+    internal static let one: Int = 1
     internal static let options: [String: Any] = ["Animation Style": "Party Mode"]
+    internal static let primes: [Int] = [2, 3, 5, 7]
+    internal static let zero: Int = 0
   }
   internal enum ShoppingList {
     internal static let items: [String] = ["Eggs", "Bread", "Milk"]

--- a/Tests/Fixtures/Generated/Plist/runtime-swift4/all-customBundle.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift4/all-customBundle.swift
@@ -45,8 +45,14 @@ internal enum PlistFiles {
   internal enum Configuration {
     private static let _document = PlistDocument(path: "configuration.plist")
     internal static let environment: String = _document["Environment"]
+    internal static let flags: [Bool] = _document["Flags"]
+    internal static let mixed: [Any] = _document["Mixed"]
+    internal static let mixed2: [Any] = _document["Mixed2"]
     internal static let names: [String] = _document["Names"]
+    internal static let one: Int = _document["One"]
     internal static let options: [String: Any] = _document["Options"]
+    internal static let primes: [Int] = _document["Primes"]
+    internal static let zero: Int = _document["Zero"]
   }
   internal enum ShoppingList {
     internal static let items: [String] = arrayFromPlist(at: "shopping-list.plist")

--- a/Tests/Fixtures/Generated/Plist/runtime-swift4/all-customName.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift4/all-customName.swift
@@ -45,8 +45,14 @@ internal enum CustomPlist {
   internal enum Configuration {
     private static let _document = PlistDocument(path: "configuration.plist")
     internal static let environment: String = _document["Environment"]
+    internal static let flags: [Bool] = _document["Flags"]
+    internal static let mixed: [Any] = _document["Mixed"]
+    internal static let mixed2: [Any] = _document["Mixed2"]
     internal static let names: [String] = _document["Names"]
+    internal static let one: Int = _document["One"]
     internal static let options: [String: Any] = _document["Options"]
+    internal static let primes: [Int] = _document["Primes"]
+    internal static let zero: Int = _document["Zero"]
   }
   internal enum ShoppingList {
     internal static let items: [String] = arrayFromPlist(at: "shopping-list.plist")

--- a/Tests/Fixtures/Generated/Plist/runtime-swift4/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift4/all-forceFileNameEnum.swift
@@ -45,8 +45,14 @@ internal enum PlistFiles {
   internal enum Configuration {
     private static let _document = PlistDocument(path: "configuration.plist")
     internal static let environment: String = _document["Environment"]
+    internal static let flags: [Bool] = _document["Flags"]
+    internal static let mixed: [Any] = _document["Mixed"]
+    internal static let mixed2: [Any] = _document["Mixed2"]
     internal static let names: [String] = _document["Names"]
+    internal static let one: Int = _document["One"]
     internal static let options: [String: Any] = _document["Options"]
+    internal static let primes: [Int] = _document["Primes"]
+    internal static let zero: Int = _document["Zero"]
   }
   internal enum ShoppingList {
     internal static let items: [String] = arrayFromPlist(at: "shopping-list.plist")

--- a/Tests/Fixtures/Generated/Plist/runtime-swift4/all-lookupFunction.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift4/all-lookupFunction.swift
@@ -45,8 +45,14 @@ internal enum PlistFiles {
   internal enum Configuration {
     private static let _document = PlistDocument(path: "configuration.plist")
     internal static let environment: String = _document["Environment"]
+    internal static let flags: [Bool] = _document["Flags"]
+    internal static let mixed: [Any] = _document["Mixed"]
+    internal static let mixed2: [Any] = _document["Mixed2"]
     internal static let names: [String] = _document["Names"]
+    internal static let one: Int = _document["One"]
     internal static let options: [String: Any] = _document["Options"]
+    internal static let primes: [Int] = _document["Primes"]
+    internal static let zero: Int = _document["Zero"]
   }
   internal enum ShoppingList {
     internal static let items: [String] = arrayFromPlist(at: "shopping-list.plist")

--- a/Tests/Fixtures/Generated/Plist/runtime-swift4/all-preservePath.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift4/all-preservePath.swift
@@ -45,8 +45,14 @@ internal enum PlistFiles {
   internal enum Configuration {
     private static let _document = PlistDocument(path: "configuration.plist")
     internal static let environment: String = _document["Environment"]
+    internal static let flags: [Bool] = _document["Flags"]
+    internal static let mixed: [Any] = _document["Mixed"]
+    internal static let mixed2: [Any] = _document["Mixed2"]
     internal static let names: [String] = _document["Names"]
+    internal static let one: Int = _document["One"]
     internal static let options: [String: Any] = _document["Options"]
+    internal static let primes: [Int] = _document["Primes"]
+    internal static let zero: Int = _document["Zero"]
   }
   internal enum ShoppingList {
     internal static let items: [String] = arrayFromPlist(at: "shopping-list.plist")

--- a/Tests/Fixtures/Generated/Plist/runtime-swift4/all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift4/all-publicAccess.swift
@@ -45,8 +45,14 @@ public enum PlistFiles {
   public enum Configuration {
     private static let _document = PlistDocument(path: "configuration.plist")
     public static let environment: String = _document["Environment"]
+    public static let flags: [Bool] = _document["Flags"]
+    public static let mixed: [Any] = _document["Mixed"]
+    public static let mixed2: [Any] = _document["Mixed2"]
     public static let names: [String] = _document["Names"]
+    public static let one: Int = _document["One"]
     public static let options: [String: Any] = _document["Options"]
+    public static let primes: [Int] = _document["Primes"]
+    public static let zero: Int = _document["Zero"]
   }
   public enum ShoppingList {
     public static let items: [String] = arrayFromPlist(at: "shopping-list.plist")

--- a/Tests/Fixtures/Generated/Plist/runtime-swift4/all.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift4/all.swift
@@ -45,8 +45,14 @@ internal enum PlistFiles {
   internal enum Configuration {
     private static let _document = PlistDocument(path: "configuration.plist")
     internal static let environment: String = _document["Environment"]
+    internal static let flags: [Bool] = _document["Flags"]
+    internal static let mixed: [Any] = _document["Mixed"]
+    internal static let mixed2: [Any] = _document["Mixed2"]
     internal static let names: [String] = _document["Names"]
+    internal static let one: Int = _document["One"]
     internal static let options: [String: Any] = _document["Options"]
+    internal static let primes: [Int] = _document["Primes"]
+    internal static let zero: Int = _document["Zero"]
   }
   internal enum ShoppingList {
     internal static let items: [String] = arrayFromPlist(at: "shopping-list.plist")

--- a/Tests/Fixtures/Generated/Plist/runtime-swift5/all-customBundle.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift5/all-customBundle.swift
@@ -45,8 +45,14 @@ internal enum PlistFiles {
   internal enum Configuration {
     private static let _document = PlistDocument(path: "configuration.plist")
     internal static let environment: String = _document["Environment"]
+    internal static let flags: [Bool] = _document["Flags"]
+    internal static let mixed: [Any] = _document["Mixed"]
+    internal static let mixed2: [Any] = _document["Mixed2"]
     internal static let names: [String] = _document["Names"]
+    internal static let one: Int = _document["One"]
     internal static let options: [String: Any] = _document["Options"]
+    internal static let primes: [Int] = _document["Primes"]
+    internal static let zero: Int = _document["Zero"]
   }
   internal enum ShoppingList {
     internal static let items: [String] = arrayFromPlist(at: "shopping-list.plist")

--- a/Tests/Fixtures/Generated/Plist/runtime-swift5/all-customName.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift5/all-customName.swift
@@ -45,8 +45,14 @@ internal enum CustomPlist {
   internal enum Configuration {
     private static let _document = PlistDocument(path: "configuration.plist")
     internal static let environment: String = _document["Environment"]
+    internal static let flags: [Bool] = _document["Flags"]
+    internal static let mixed: [Any] = _document["Mixed"]
+    internal static let mixed2: [Any] = _document["Mixed2"]
     internal static let names: [String] = _document["Names"]
+    internal static let one: Int = _document["One"]
     internal static let options: [String: Any] = _document["Options"]
+    internal static let primes: [Int] = _document["Primes"]
+    internal static let zero: Int = _document["Zero"]
   }
   internal enum ShoppingList {
     internal static let items: [String] = arrayFromPlist(at: "shopping-list.plist")

--- a/Tests/Fixtures/Generated/Plist/runtime-swift5/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift5/all-forceFileNameEnum.swift
@@ -45,8 +45,14 @@ internal enum PlistFiles {
   internal enum Configuration {
     private static let _document = PlistDocument(path: "configuration.plist")
     internal static let environment: String = _document["Environment"]
+    internal static let flags: [Bool] = _document["Flags"]
+    internal static let mixed: [Any] = _document["Mixed"]
+    internal static let mixed2: [Any] = _document["Mixed2"]
     internal static let names: [String] = _document["Names"]
+    internal static let one: Int = _document["One"]
     internal static let options: [String: Any] = _document["Options"]
+    internal static let primes: [Int] = _document["Primes"]
+    internal static let zero: Int = _document["Zero"]
   }
   internal enum ShoppingList {
     internal static let items: [String] = arrayFromPlist(at: "shopping-list.plist")

--- a/Tests/Fixtures/Generated/Plist/runtime-swift5/all-lookupFunction.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift5/all-lookupFunction.swift
@@ -45,8 +45,14 @@ internal enum PlistFiles {
   internal enum Configuration {
     private static let _document = PlistDocument(path: "configuration.plist")
     internal static let environment: String = _document["Environment"]
+    internal static let flags: [Bool] = _document["Flags"]
+    internal static let mixed: [Any] = _document["Mixed"]
+    internal static let mixed2: [Any] = _document["Mixed2"]
     internal static let names: [String] = _document["Names"]
+    internal static let one: Int = _document["One"]
     internal static let options: [String: Any] = _document["Options"]
+    internal static let primes: [Int] = _document["Primes"]
+    internal static let zero: Int = _document["Zero"]
   }
   internal enum ShoppingList {
     internal static let items: [String] = arrayFromPlist(at: "shopping-list.plist")

--- a/Tests/Fixtures/Generated/Plist/runtime-swift5/all-preservePath.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift5/all-preservePath.swift
@@ -45,8 +45,14 @@ internal enum PlistFiles {
   internal enum Configuration {
     private static let _document = PlistDocument(path: "configuration.plist")
     internal static let environment: String = _document["Environment"]
+    internal static let flags: [Bool] = _document["Flags"]
+    internal static let mixed: [Any] = _document["Mixed"]
+    internal static let mixed2: [Any] = _document["Mixed2"]
     internal static let names: [String] = _document["Names"]
+    internal static let one: Int = _document["One"]
     internal static let options: [String: Any] = _document["Options"]
+    internal static let primes: [Int] = _document["Primes"]
+    internal static let zero: Int = _document["Zero"]
   }
   internal enum ShoppingList {
     internal static let items: [String] = arrayFromPlist(at: "shopping-list.plist")

--- a/Tests/Fixtures/Generated/Plist/runtime-swift5/all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift5/all-publicAccess.swift
@@ -45,8 +45,14 @@ public enum PlistFiles {
   public enum Configuration {
     private static let _document = PlistDocument(path: "configuration.plist")
     public static let environment: String = _document["Environment"]
+    public static let flags: [Bool] = _document["Flags"]
+    public static let mixed: [Any] = _document["Mixed"]
+    public static let mixed2: [Any] = _document["Mixed2"]
     public static let names: [String] = _document["Names"]
+    public static let one: Int = _document["One"]
     public static let options: [String: Any] = _document["Options"]
+    public static let primes: [Int] = _document["Primes"]
+    public static let zero: Int = _document["Zero"]
   }
   public enum ShoppingList {
     public static let items: [String] = arrayFromPlist(at: "shopping-list.plist")

--- a/Tests/Fixtures/Generated/Plist/runtime-swift5/all.swift
+++ b/Tests/Fixtures/Generated/Plist/runtime-swift5/all.swift
@@ -45,8 +45,14 @@ internal enum PlistFiles {
   internal enum Configuration {
     private static let _document = PlistDocument(path: "configuration.plist")
     internal static let environment: String = _document["Environment"]
+    internal static let flags: [Bool] = _document["Flags"]
+    internal static let mixed: [Any] = _document["Mixed"]
+    internal static let mixed2: [Any] = _document["Mixed2"]
     internal static let names: [String] = _document["Names"]
+    internal static let one: Int = _document["One"]
     internal static let options: [String: Any] = _document["Options"]
+    internal static let primes: [Int] = _document["Primes"]
+    internal static let zero: Int = _document["Zero"]
   }
   internal enum ShoppingList {
     internal static let items: [String] = arrayFromPlist(at: "shopping-list.plist")

--- a/Tests/Fixtures/Generated/YAML/inline-swift4/all-customName.swift
+++ b/Tests/Fixtures/Generated/YAML/inline-swift4/all-customName.swift
@@ -23,12 +23,19 @@ internal enum CustomYAML {
   }
   internal enum Mapping {
     internal static let car: Any? = nil
+    internal static let doors: Int = 5
+    internal static let flags: [Bool] = [true, false, true]
     internal static let foo: [String: Any] = ["bar": "banana", "baz": "orange"]
     internal static let hello: String = "world"
+    internal static let mixed: [Any] = ["one", 2, true]
+    internal static let mixed2: [Any] = [0.1, 2, true]
     internal static let names: [String] = ["John", "Peter", "Nick"]
     internal static let newLayout: Bool = true
+    internal static let one: Int = 1
+    internal static let primes: [Int] = [2, 3, 5, 7]
     internal static let quickSearch: Bool = false
     internal static let weight: Double = 33.3
+    internal static let zero: Int = 0
   }
   internal enum Version {
     internal static let value: String = "1.2.3.beta.4"

--- a/Tests/Fixtures/Generated/YAML/inline-swift4/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/YAML/inline-swift4/all-forceFileNameEnum.swift
@@ -23,12 +23,19 @@ internal enum YAMLFiles {
   }
   internal enum Mapping {
     internal static let car: Any? = nil
+    internal static let doors: Int = 5
+    internal static let flags: [Bool] = [true, false, true]
     internal static let foo: [String: Any] = ["bar": "banana", "baz": "orange"]
     internal static let hello: String = "world"
+    internal static let mixed: [Any] = ["one", 2, true]
+    internal static let mixed2: [Any] = [0.1, 2, true]
     internal static let names: [String] = ["John", "Peter", "Nick"]
     internal static let newLayout: Bool = true
+    internal static let one: Int = 1
+    internal static let primes: [Int] = [2, 3, 5, 7]
     internal static let quickSearch: Bool = false
     internal static let weight: Double = 33.3
+    internal static let zero: Int = 0
   }
   internal enum Version {
     internal static let value: String = "1.2.3.beta.4"

--- a/Tests/Fixtures/Generated/YAML/inline-swift4/all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/YAML/inline-swift4/all-publicAccess.swift
@@ -23,12 +23,19 @@ public enum YAMLFiles {
   }
   public enum Mapping {
     public static let car: Any? = nil
+    public static let doors: Int = 5
+    public static let flags: [Bool] = [true, false, true]
     public static let foo: [String: Any] = ["bar": "banana", "baz": "orange"]
     public static let hello: String = "world"
+    public static let mixed: [Any] = ["one", 2, true]
+    public static let mixed2: [Any] = [0.1, 2, true]
     public static let names: [String] = ["John", "Peter", "Nick"]
     public static let newLayout: Bool = true
+    public static let one: Int = 1
+    public static let primes: [Int] = [2, 3, 5, 7]
     public static let quickSearch: Bool = false
     public static let weight: Double = 33.3
+    public static let zero: Int = 0
   }
   public enum Version {
     public static let value: String = "1.2.3.beta.4"

--- a/Tests/Fixtures/Generated/YAML/inline-swift4/all.swift
+++ b/Tests/Fixtures/Generated/YAML/inline-swift4/all.swift
@@ -23,12 +23,19 @@ internal enum YAMLFiles {
   }
   internal enum Mapping {
     internal static let car: Any? = nil
+    internal static let doors: Int = 5
+    internal static let flags: [Bool] = [true, false, true]
     internal static let foo: [String: Any] = ["bar": "banana", "baz": "orange"]
     internal static let hello: String = "world"
+    internal static let mixed: [Any] = ["one", 2, true]
+    internal static let mixed2: [Any] = [0.1, 2, true]
     internal static let names: [String] = ["John", "Peter", "Nick"]
     internal static let newLayout: Bool = true
+    internal static let one: Int = 1
+    internal static let primes: [Int] = [2, 3, 5, 7]
     internal static let quickSearch: Bool = false
     internal static let weight: Double = 33.3
+    internal static let zero: Int = 0
   }
   internal enum Version {
     internal static let value: String = "1.2.3.beta.4"

--- a/Tests/Fixtures/Generated/YAML/inline-swift5/all-customName.swift
+++ b/Tests/Fixtures/Generated/YAML/inline-swift5/all-customName.swift
@@ -23,12 +23,19 @@ internal enum CustomYAML {
   }
   internal enum Mapping {
     internal static let car: Any? = nil
+    internal static let doors: Int = 5
+    internal static let flags: [Bool] = [true, false, true]
     internal static let foo: [String: Any] = ["bar": "banana", "baz": "orange"]
     internal static let hello: String = "world"
+    internal static let mixed: [Any] = ["one", 2, true]
+    internal static let mixed2: [Any] = [0.1, 2, true]
     internal static let names: [String] = ["John", "Peter", "Nick"]
     internal static let newLayout: Bool = true
+    internal static let one: Int = 1
+    internal static let primes: [Int] = [2, 3, 5, 7]
     internal static let quickSearch: Bool = false
     internal static let weight: Double = 33.3
+    internal static let zero: Int = 0
   }
   internal enum Version {
     internal static let value: String = "1.2.3.beta.4"

--- a/Tests/Fixtures/Generated/YAML/inline-swift5/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/YAML/inline-swift5/all-forceFileNameEnum.swift
@@ -23,12 +23,19 @@ internal enum YAMLFiles {
   }
   internal enum Mapping {
     internal static let car: Any? = nil
+    internal static let doors: Int = 5
+    internal static let flags: [Bool] = [true, false, true]
     internal static let foo: [String: Any] = ["bar": "banana", "baz": "orange"]
     internal static let hello: String = "world"
+    internal static let mixed: [Any] = ["one", 2, true]
+    internal static let mixed2: [Any] = [0.1, 2, true]
     internal static let names: [String] = ["John", "Peter", "Nick"]
     internal static let newLayout: Bool = true
+    internal static let one: Int = 1
+    internal static let primes: [Int] = [2, 3, 5, 7]
     internal static let quickSearch: Bool = false
     internal static let weight: Double = 33.3
+    internal static let zero: Int = 0
   }
   internal enum Version {
     internal static let value: String = "1.2.3.beta.4"

--- a/Tests/Fixtures/Generated/YAML/inline-swift5/all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/YAML/inline-swift5/all-publicAccess.swift
@@ -23,12 +23,19 @@ public enum YAMLFiles {
   }
   public enum Mapping {
     public static let car: Any? = nil
+    public static let doors: Int = 5
+    public static let flags: [Bool] = [true, false, true]
     public static let foo: [String: Any] = ["bar": "banana", "baz": "orange"]
     public static let hello: String = "world"
+    public static let mixed: [Any] = ["one", 2, true]
+    public static let mixed2: [Any] = [0.1, 2, true]
     public static let names: [String] = ["John", "Peter", "Nick"]
     public static let newLayout: Bool = true
+    public static let one: Int = 1
+    public static let primes: [Int] = [2, 3, 5, 7]
     public static let quickSearch: Bool = false
     public static let weight: Double = 33.3
+    public static let zero: Int = 0
   }
   public enum Version {
     public static let value: String = "1.2.3.beta.4"

--- a/Tests/Fixtures/Generated/YAML/inline-swift5/all.swift
+++ b/Tests/Fixtures/Generated/YAML/inline-swift5/all.swift
@@ -23,12 +23,19 @@ internal enum YAMLFiles {
   }
   internal enum Mapping {
     internal static let car: Any? = nil
+    internal static let doors: Int = 5
+    internal static let flags: [Bool] = [true, false, true]
     internal static let foo: [String: Any] = ["bar": "banana", "baz": "orange"]
     internal static let hello: String = "world"
+    internal static let mixed: [Any] = ["one", 2, true]
+    internal static let mixed2: [Any] = [0.1, 2, true]
     internal static let names: [String] = ["John", "Peter", "Nick"]
     internal static let newLayout: Bool = true
+    internal static let one: Int = 1
+    internal static let primes: [Int] = [2, 3, 5, 7]
     internal static let quickSearch: Bool = false
     internal static let weight: Double = 33.3
+    internal static let zero: Int = 0
   }
   internal enum Version {
     internal static let value: String = "1.2.3.beta.4"

--- a/Tests/Fixtures/Resources/JSON/configuration.json
+++ b/Tests/Fixtures/Resources/JSON/configuration.json
@@ -1,10 +1,17 @@
 {
-  "environment": "staging",
   "api-version": "2",
+  "country": null,
+  "doors": 5,
+  "environment": "staging",
+  "flags": [true, false, true],
+  "mixed": ["one", 2, true],
+  "mixed2": [0.1, 2, true],
+  "new-layout": true,
   "options": {
     "screen-order": ["1", "2", "3"]
   },
-  "country": null,
-  "new-layout": true,
-  "quick-search": false
+  "one": 1,
+  "primes": [2, 3, 5, 7],
+  "quick-search": false,
+  "zero": 0
 }

--- a/Tests/Fixtures/Resources/Plist/good/configuration.plist
+++ b/Tests/Fixtures/Resources/Plist/good/configuration.plist
@@ -4,16 +4,45 @@
 <dict>
 	<key>Environment</key>
 	<string>development</string>
-	<key>Options</key>
-	<dict>
-		<key>Animation Style</key>
-		<string>Party Mode</string>
-	</dict>
+	<key>Flags</key>
+	<array>
+		<true/>
+		<false/>
+		<true/>
+	</array>
+	<key>Mixed</key>
+	<array>
+		<string>One</string>
+		<integer>1</integer>
+		<true/>
+	</array>
+	<key>Mixed2</key>
+	<array>
+		<real>0.1</real>
+		<integer>1</integer>
+		<true/>
+	</array>
 	<key>Names</key>
 	<array>
 		<string>John</string>
 		<string>Peter</string>
 		<string>Nick</string>
 	</array>
+	<key>One</key>
+	<integer>1</integer>
+	<key>Options</key>
+	<dict>
+		<key>Animation Style</key>
+		<string>Party Mode</string>
+	</dict>
+	<key>Primes</key>
+	<array>
+		<integer>2</integer>
+		<integer>3</integer>
+		<integer>5</integer>
+		<integer>7</integer>
+	</array>
+	<key>Zero</key>
+	<integer>0</integer>
 </dict>
 </plist>

--- a/Tests/Fixtures/Resources/YAML/good/mapping.yaml
+++ b/Tests/Fixtures/Resources/YAML/good/mapping.yaml
@@ -1,12 +1,32 @@
-hello: world
-weight: 33.3
+car: null
+doors: 5
+flags:
+  - true
+  - false
+  - true
 foo:
   bar: banana
   baz: orange
-car: null
-newLayout: true
-quickSearch: false
+hello: world
+mixed:
+  - one
+  - 2
+  - true
+mixed2:
+  - 0.1
+  - 2
+  - true
 names:
   - John
   - Peter
   - Nick
+newLayout: true
+one: 1
+primes:
+  - 2
+  - 3
+  - 5
+  - 7
+quickSearch: false
+weight: 33.3
+zero: 0

--- a/Tests/Fixtures/StencilContexts/JSON/all.yaml
+++ b/Tests/Fixtures/StencilContexts/JSON/all.yaml
@@ -21,23 +21,63 @@ files:
     data:
       api-version: "2"
       country: null
+      doors: 5
       environment: "staging"
+      flags:
+      - true
+      - false
+      - true
+      mixed:
+      - "one"
+      - 2
+      - true
+      mixed2:
+      - 1e-1
+      - 2
+      - true
       new-layout: true
+      one: 1
       options:
         screen-order:
         - "1"
         - "2"
         - "3"
+      primes:
+      - 2
+      - 3
+      - 5
+      - 7
       quick-search: false
+      zero: 0
     metadata:
       properties:
         api-version:
           type: "String"
         country:
           type: "Optional"
+        doors:
+          type: "Int"
         environment:
           type: "String"
+        flags:
+          element:
+            type: "Bool"
+          type: "Array"
+        mixed:
+          element:
+            items:
+            - type: "String"
+            - type: "Int"
+            - type: "Bool"
+            type: "Any"
+          type: "Array"
+        mixed2:
+          element:
+            type: "Double"
+          type: "Array"
         new-layout:
+          type: "Bool"
+        one:
           type: "Bool"
         options:
           properties:
@@ -46,30 +86,76 @@ files:
                 type: "String"
               type: "Array"
           type: "Dictionary"
+        primes:
+          element:
+            type: "Int"
+          type: "Array"
         quick-search:
+          type: "Bool"
+        zero:
           type: "Bool"
       type: "Dictionary"
   documents:
   - data:
       api-version: "2"
       country: null
+      doors: 5
       environment: "staging"
+      flags:
+      - true
+      - false
+      - true
+      mixed:
+      - "one"
+      - 2
+      - true
+      mixed2:
+      - 1e-1
+      - 2
+      - true
       new-layout: true
+      one: 1
       options:
         screen-order:
         - "1"
         - "2"
         - "3"
+      primes:
+      - 2
+      - 3
+      - 5
+      - 7
       quick-search: false
+      zero: 0
     metadata:
       properties:
         api-version:
           type: "String"
         country:
           type: "Optional"
+        doors:
+          type: "Int"
         environment:
           type: "String"
+        flags:
+          element:
+            type: "Bool"
+          type: "Array"
+        mixed:
+          element:
+            items:
+            - type: "String"
+            - type: "Int"
+            - type: "Bool"
+            type: "Any"
+          type: "Array"
+        mixed2:
+          element:
+            type: "Double"
+          type: "Array"
         new-layout:
+          type: "Bool"
+        one:
           type: "Bool"
         options:
           properties:
@@ -78,7 +164,13 @@ files:
                 type: "String"
               type: "Array"
           type: "Dictionary"
+        primes:
+          element:
+            type: "Int"
+          type: "Array"
         quick-search:
+          type: "Bool"
+        zero:
           type: "Bool"
       type: "Dictionary"
   name: "configuration"

--- a/Tests/Fixtures/StencilContexts/JSON/all.yaml
+++ b/Tests/Fixtures/StencilContexts/JSON/all.yaml
@@ -78,7 +78,7 @@ files:
         new-layout:
           type: "Bool"
         one:
-          type: "Bool"
+          type: "Int"
         options:
           properties:
             screen-order:
@@ -93,7 +93,7 @@ files:
         quick-search:
           type: "Bool"
         zero:
-          type: "Bool"
+          type: "Int"
       type: "Dictionary"
   documents:
   - data:
@@ -156,7 +156,7 @@ files:
         new-layout:
           type: "Bool"
         one:
-          type: "Bool"
+          type: "Int"
         options:
           properties:
             screen-order:
@@ -171,7 +171,7 @@ files:
         quick-search:
           type: "Bool"
         zero:
-          type: "Bool"
+          type: "Int"
       type: "Dictionary"
   name: "configuration"
   path: "configuration.json"

--- a/Tests/Fixtures/StencilContexts/JSON/all.yaml
+++ b/Tests/Fixtures/StencilContexts/JSON/all.yaml
@@ -73,7 +73,11 @@ files:
           type: "Array"
         mixed2:
           element:
-            type: "Double"
+            items:
+            - type: "Double"
+            - type: "Int"
+            - type: "Bool"
+            type: "Any"
           type: "Array"
         new-layout:
           type: "Bool"
@@ -151,7 +155,11 @@ files:
           type: "Array"
         mixed2:
           element:
-            type: "Double"
+            items:
+            - type: "Double"
+            - type: "Int"
+            - type: "Bool"
+            type: "Any"
           type: "Array"
         new-layout:
           type: "Bool"

--- a/Tests/Fixtures/StencilContexts/JSON/configuration.yaml
+++ b/Tests/Fixtures/StencilContexts/JSON/configuration.yaml
@@ -55,7 +55,11 @@ files:
           type: "Array"
         mixed2:
           element:
-            type: "Double"
+            items:
+            - type: "Double"
+            - type: "Int"
+            - type: "Bool"
+            type: "Any"
           type: "Array"
         new-layout:
           type: "Bool"
@@ -133,7 +137,11 @@ files:
           type: "Array"
         mixed2:
           element:
-            type: "Double"
+            items:
+            - type: "Double"
+            - type: "Int"
+            - type: "Bool"
+            type: "Any"
           type: "Array"
         new-layout:
           type: "Bool"

--- a/Tests/Fixtures/StencilContexts/JSON/configuration.yaml
+++ b/Tests/Fixtures/StencilContexts/JSON/configuration.yaml
@@ -60,7 +60,7 @@ files:
         new-layout:
           type: "Bool"
         one:
-          type: "Bool"
+          type: "Int"
         options:
           properties:
             screen-order:
@@ -75,7 +75,7 @@ files:
         quick-search:
           type: "Bool"
         zero:
-          type: "Bool"
+          type: "Int"
       type: "Dictionary"
   documents:
   - data:
@@ -138,7 +138,7 @@ files:
         new-layout:
           type: "Bool"
         one:
-          type: "Bool"
+          type: "Int"
         options:
           properties:
             screen-order:
@@ -153,7 +153,7 @@ files:
         quick-search:
           type: "Bool"
         zero:
-          type: "Bool"
+          type: "Int"
       type: "Dictionary"
   name: "configuration"
   path: "configuration.json"

--- a/Tests/Fixtures/StencilContexts/JSON/configuration.yaml
+++ b/Tests/Fixtures/StencilContexts/JSON/configuration.yaml
@@ -3,23 +3,63 @@ files:
     data:
       api-version: "2"
       country: null
+      doors: 5
       environment: "staging"
+      flags:
+      - true
+      - false
+      - true
+      mixed:
+      - "one"
+      - 2
+      - true
+      mixed2:
+      - 1e-1
+      - 2
+      - true
       new-layout: true
+      one: 1
       options:
         screen-order:
         - "1"
         - "2"
         - "3"
+      primes:
+      - 2
+      - 3
+      - 5
+      - 7
       quick-search: false
+      zero: 0
     metadata:
       properties:
         api-version:
           type: "String"
         country:
           type: "Optional"
+        doors:
+          type: "Int"
         environment:
           type: "String"
+        flags:
+          element:
+            type: "Bool"
+          type: "Array"
+        mixed:
+          element:
+            items:
+            - type: "String"
+            - type: "Int"
+            - type: "Bool"
+            type: "Any"
+          type: "Array"
+        mixed2:
+          element:
+            type: "Double"
+          type: "Array"
         new-layout:
+          type: "Bool"
+        one:
           type: "Bool"
         options:
           properties:
@@ -28,30 +68,76 @@ files:
                 type: "String"
               type: "Array"
           type: "Dictionary"
+        primes:
+          element:
+            type: "Int"
+          type: "Array"
         quick-search:
+          type: "Bool"
+        zero:
           type: "Bool"
       type: "Dictionary"
   documents:
   - data:
       api-version: "2"
       country: null
+      doors: 5
       environment: "staging"
+      flags:
+      - true
+      - false
+      - true
+      mixed:
+      - "one"
+      - 2
+      - true
+      mixed2:
+      - 1e-1
+      - 2
+      - true
       new-layout: true
+      one: 1
       options:
         screen-order:
         - "1"
         - "2"
         - "3"
+      primes:
+      - 2
+      - 3
+      - 5
+      - 7
       quick-search: false
+      zero: 0
     metadata:
       properties:
         api-version:
           type: "String"
         country:
           type: "Optional"
+        doors:
+          type: "Int"
         environment:
           type: "String"
+        flags:
+          element:
+            type: "Bool"
+          type: "Array"
+        mixed:
+          element:
+            items:
+            - type: "String"
+            - type: "Int"
+            - type: "Bool"
+            type: "Any"
+          type: "Array"
+        mixed2:
+          element:
+            type: "Double"
+          type: "Array"
         new-layout:
+          type: "Bool"
+        one:
           type: "Bool"
         options:
           properties:
@@ -60,7 +146,13 @@ files:
                 type: "String"
               type: "Array"
           type: "Dictionary"
+        primes:
+          element:
+            type: "Int"
+          type: "Array"
         quick-search:
+          type: "Bool"
+        zero:
           type: "Bool"
       type: "Dictionary"
   name: "configuration"

--- a/Tests/Fixtures/StencilContexts/Plist/all.yaml
+++ b/Tests/Fixtures/StencilContexts/Plist/all.yaml
@@ -268,48 +268,142 @@ files:
 - document:
     data:
       Environment: "development"
+      Flags:
+      - true
+      - false
+      - true
+      Mixed:
+      - "One"
+      - 1
+      - true
+      Mixed2:
+      - 1e-1
+      - 1
+      - true
       Names:
       - "John"
       - "Peter"
       - "Nick"
+      One: 1
       Options:
         Animation Style: "Party Mode"
+      Primes:
+      - 2
+      - 3
+      - 5
+      - 7
+      Zero: 0
     metadata:
       properties:
         Environment:
           type: "String"
+        Flags:
+          element:
+            type: "Bool"
+          type: "Array"
+        Mixed:
+          element:
+            items:
+            - type: "String"
+            - type: "Int"
+            - type: "Bool"
+            type: "Any"
+          type: "Array"
+        Mixed2:
+          element:
+            items:
+            - type: "Double"
+            - type: "Int"
+            - type: "Bool"
+            type: "Any"
+          type: "Array"
         Names:
           element:
             type: "String"
           type: "Array"
+        One:
+          type: "Int"
         Options:
           properties:
             Animation Style:
               type: "String"
           type: "Dictionary"
+        Primes:
+          element:
+            type: "Int"
+          type: "Array"
+        Zero:
+          type: "Int"
       type: "Dictionary"
   documents:
   - data:
       Environment: "development"
+      Flags:
+      - true
+      - false
+      - true
+      Mixed:
+      - "One"
+      - 1
+      - true
+      Mixed2:
+      - 1e-1
+      - 1
+      - true
       Names:
       - "John"
       - "Peter"
       - "Nick"
+      One: 1
       Options:
         Animation Style: "Party Mode"
+      Primes:
+      - 2
+      - 3
+      - 5
+      - 7
+      Zero: 0
     metadata:
       properties:
         Environment:
           type: "String"
+        Flags:
+          element:
+            type: "Bool"
+          type: "Array"
+        Mixed:
+          element:
+            items:
+            - type: "String"
+            - type: "Int"
+            - type: "Bool"
+            type: "Any"
+          type: "Array"
+        Mixed2:
+          element:
+            items:
+            - type: "Double"
+            - type: "Int"
+            - type: "Bool"
+            type: "Any"
+          type: "Array"
         Names:
           element:
             type: "String"
           type: "Array"
+        One:
+          type: "Int"
         Options:
           properties:
             Animation Style:
               type: "String"
           type: "Dictionary"
+        Primes:
+          element:
+            type: "Int"
+          type: "Array"
+        Zero:
+          type: "Int"
       type: "Dictionary"
   name: "configuration"
   path: "configuration.plist"

--- a/Tests/Fixtures/StencilContexts/Plist/configuration.yaml
+++ b/Tests/Fixtures/StencilContexts/Plist/configuration.yaml
@@ -2,48 +2,142 @@ files:
 - document:
     data:
       Environment: "development"
+      Flags:
+      - true
+      - false
+      - true
+      Mixed:
+      - "One"
+      - 1
+      - true
+      Mixed2:
+      - 1e-1
+      - 1
+      - true
       Names:
       - "John"
       - "Peter"
       - "Nick"
+      One: 1
       Options:
         Animation Style: "Party Mode"
+      Primes:
+      - 2
+      - 3
+      - 5
+      - 7
+      Zero: 0
     metadata:
       properties:
         Environment:
           type: "String"
+        Flags:
+          element:
+            type: "Bool"
+          type: "Array"
+        Mixed:
+          element:
+            items:
+            - type: "String"
+            - type: "Int"
+            - type: "Bool"
+            type: "Any"
+          type: "Array"
+        Mixed2:
+          element:
+            items:
+            - type: "Double"
+            - type: "Int"
+            - type: "Bool"
+            type: "Any"
+          type: "Array"
         Names:
           element:
             type: "String"
           type: "Array"
+        One:
+          type: "Int"
         Options:
           properties:
             Animation Style:
               type: "String"
           type: "Dictionary"
+        Primes:
+          element:
+            type: "Int"
+          type: "Array"
+        Zero:
+          type: "Int"
       type: "Dictionary"
   documents:
   - data:
       Environment: "development"
+      Flags:
+      - true
+      - false
+      - true
+      Mixed:
+      - "One"
+      - 1
+      - true
+      Mixed2:
+      - 1e-1
+      - 1
+      - true
       Names:
       - "John"
       - "Peter"
       - "Nick"
+      One: 1
       Options:
         Animation Style: "Party Mode"
+      Primes:
+      - 2
+      - 3
+      - 5
+      - 7
+      Zero: 0
     metadata:
       properties:
         Environment:
           type: "String"
+        Flags:
+          element:
+            type: "Bool"
+          type: "Array"
+        Mixed:
+          element:
+            items:
+            - type: "String"
+            - type: "Int"
+            - type: "Bool"
+            type: "Any"
+          type: "Array"
+        Mixed2:
+          element:
+            items:
+            - type: "Double"
+            - type: "Int"
+            - type: "Bool"
+            type: "Any"
+          type: "Array"
         Names:
           element:
             type: "String"
           type: "Array"
+        One:
+          type: "Int"
         Options:
           properties:
             Animation Style:
               type: "String"
           type: "Dictionary"
+        Primes:
+          element:
+            type: "Int"
+          type: "Array"
+        Zero:
+          type: "Int"
       type: "Dictionary"
   name: "configuration"
   path: "configuration.plist"

--- a/Tests/Fixtures/StencilContexts/Yaml/all.yaml
+++ b/Tests/Fixtures/StencilContexts/Yaml/all.yaml
@@ -31,21 +31,47 @@ files:
 - documents:
   - data:
       car: null
+      doors: 5
+      flags:
+      - true
+      - false
+      - true
       foo:
         bar: "banana"
         baz: "orange"
       hello: "world"
+      mixed:
+      - "one"
+      - 2
+      - true
+      mixed2:
+      - 1e-1
+      - 2
+      - true
       names:
       - "John"
       - "Peter"
       - "Nick"
       newLayout: true
+      one: 1
+      primes:
+      - 2
+      - 3
+      - 5
+      - 7
       quickSearch: false
       weight: 3.33e+1
+      zero: 0
     metadata:
       properties:
         car:
           type: "Optional"
+        doors:
+          type: "Int"
+        flags:
+          element:
+            type: "Bool"
+          type: "Array"
         foo:
           properties:
             bar:
@@ -55,16 +81,40 @@ files:
           type: "Dictionary"
         hello:
           type: "String"
+        mixed:
+          element:
+            items:
+            - type: "String"
+            - type: "Int"
+            - type: "Bool"
+            type: "Any"
+          type: "Array"
+        mixed2:
+          element:
+            items:
+            - type: "Double"
+            - type: "Int"
+            - type: "Bool"
+            type: "Any"
+          type: "Array"
         names:
           element:
             type: "String"
           type: "Array"
         newLayout:
           type: "Bool"
+        one:
+          type: "Int"
+        primes:
+          element:
+            type: "Int"
+          type: "Array"
         quickSearch:
           type: "Bool"
         weight:
           type: "Double"
+        zero:
+          type: "Int"
       type: "Dictionary"
   name: "mapping"
   path: "mapping.yaml"

--- a/Tests/Fixtures/StencilContexts/Yaml/mapping.yaml
+++ b/Tests/Fixtures/StencilContexts/Yaml/mapping.yaml
@@ -2,21 +2,47 @@ files:
 - documents:
   - data:
       car: null
+      doors: 5
+      flags:
+      - true
+      - false
+      - true
       foo:
         bar: "banana"
         baz: "orange"
       hello: "world"
+      mixed:
+      - "one"
+      - 2
+      - true
+      mixed2:
+      - 1e-1
+      - 2
+      - true
       names:
       - "John"
       - "Peter"
       - "Nick"
       newLayout: true
+      one: 1
+      primes:
+      - 2
+      - 3
+      - 5
+      - 7
       quickSearch: false
       weight: 3.33e+1
+      zero: 0
     metadata:
       properties:
         car:
           type: "Optional"
+        doors:
+          type: "Int"
+        flags:
+          element:
+            type: "Bool"
+          type: "Array"
         foo:
           properties:
             bar:
@@ -26,16 +52,40 @@ files:
           type: "Dictionary"
         hello:
           type: "String"
+        mixed:
+          element:
+            items:
+            - type: "String"
+            - type: "Int"
+            - type: "Bool"
+            type: "Any"
+          type: "Array"
+        mixed2:
+          element:
+            items:
+            - type: "Double"
+            - type: "Int"
+            - type: "Bool"
+            type: "Any"
+          type: "Array"
         names:
           element:
             type: "String"
           type: "Array"
         newLayout:
           type: "Bool"
+        one:
+          type: "Int"
+        primes:
+          element:
+            type: "Int"
+          type: "Array"
         quickSearch:
           type: "Bool"
         weight:
           type: "Double"
+        zero:
+          type: "Int"
       type: "Dictionary"
   name: "mapping"
   path: "mapping.yaml"


### PR DESCRIPTION
Fixes #781 

With JSONSerialization, 0 and 1 are parsed as `NSNumber`s. The issue is that these values are considered valid boolean values, so the `is Bool` or `is [Bool]` tests succeed.

This PR addresses the issue using runtime introspection.

## Implementation

There is no "simple" check to see what's actually inside an `NSNumber` instance. We first have to check if it's a boolean, and if not, get the internal type of the number. We then map these to the info we actually want.

The fix for `Array`s is a bit more involved, because `[NSNumber]` is tool free bridged to `[Int]`, `[Bool]`, etc... And the same applies to the inverse (a `[Bool]` is bridged to `[NSNumber]`). When we just check if something is `[NSNumber]` (and sometimes bridge it), we lose the easy check to see if all the elements in an array have the same type. We'd have to go through each element and check their type.

Without this extra array inspection (see commit b12aaa3da413d68d4b397a70f142afacd1d68806), things break. In the old method, `[0.1, 2, true]` is considered a `[Double]` array (see `mixed2` in the tests). This generates wrong Swift code, which causes compilation to fail:
```swift
static let mixed2: [Double] = [0.1, 2, true]
```

## Note

This issue **does not** appear in the YAML or Plist parsers. I've added a bunch of tests for all 3 parsers to verify some scenarios.