### PR TITLE
Fix `cli:install` failing for first-time builds #trivial

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -50,7 +50,7 @@ namespace :cli do
     Utils.print_header 'Building Binary'
     plist_file = (Pathname.new(BUILD_DIR) + "Build/Products/#{RELEASE_CONFIGURATION}/swiftgen.app/Contents/Info.plist").to_s
 
-    # Ensure we have an Info.plist at the destination (Xcode 12 bug/feature?)
+    # Ensure we have an Info.plist at the destination (Xcode 12 new build system's circular build dependencies detection seems to require this)
     FileUtils.mkdir_p File.dirname(plist_file)
     FileUtils.touch plist_file
 
@@ -117,4 +117,3 @@ namespace :cli do
 end
 
 task :default => 'cli:build'
-

--- a/Rakefile
+++ b/Rakefile
@@ -49,6 +49,11 @@ namespace :cli do
 
     Utils.print_header 'Building Binary'
     plist_file = (Pathname.new(BUILD_DIR) + "Build/Products/#{RELEASE_CONFIGURATION}/swiftgen.app/Contents/Info.plist").to_s
+
+    # Ensure we have an Info.plist at the destination (Xcode 12 bug/feature?)
+    FileUtils.mkdir_p File.dirname(plist_file)
+    FileUtils.touch plist_file
+
     Utils.run(
       %(xcodebuild -workspace "#{WORKSPACE}.xcworkspace" -scheme "#{SCHEME_NAME}" -configuration "#{RELEASE_CONFIGURATION}") +
       %( -derivedDataPath "#{BUILD_DIR}" TEMPLATE_PATH="#{tpl_rel_path}") +


### PR DESCRIPTION
Installation via brew is failing because the destination `Info.plist` doesn't exist yet. This seems to be a recent change due to Xcode 12 (I think).