### PR TITLE
Add documentation for bundle on xcassets templates #trivial

### DIFF
--- a/Documentation/templates/xcassets/swift4.md
+++ b/Documentation/templates/xcassets/swift4.md
@@ -21,6 +21,7 @@ You can customize some elements of this template by overriding the following par
 
 | Parameter Name | Default Value | Description |
 | -------------- | ------------- | ----------- |
+| `bundle` | `BundleToken.bundle` | Allows you to set from which bundle strings are loaded from. By default, it'll point to the same bundle as where the generated code is. |
 | `allValues` | N/A | Setting this parameter will enable the generation of the `allColors`, `allImages` and other such constants. |
 | `arResourceGroupTypeName` | `ARResourceGroupAsset` | Allows you to change the name of the struct type representing an AR resource group. |
 | `colorTypeName` | `ColorAsset` | Allows you to change the name of the struct type representing a color. |

--- a/Documentation/templates/xcassets/swift5.md
+++ b/Documentation/templates/xcassets/swift5.md
@@ -21,6 +21,7 @@ You can customize some elements of this template by overriding the following par
 
 | Parameter Name | Default Value | Description |
 | -------------- | ------------- | ----------- |
+| `bundle` | `BundleToken.bundle` | Allows you to set from which bundle strings are loaded from. By default, it'll point to the same bundle as where the generated code is. |
 | `allValues` | N/A | Setting this parameter will enable the generation of the `allColors`, `allImages` and other such constants. |
 | `arResourceGroupTypeName` | `ARResourceGroupAsset` | Allows you to change the name of the struct type representing an AR resource group. |
 | `colorTypeName` | `ColorAsset` | Allows you to change the name of the struct type representing a color. |


### PR DESCRIPTION
* [x] I've started my branch from the `develop` branch (gitflow)
  * [x] And I've selected `develop` as the "base" branch for this Pull Request I'm about to create
* [x] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself  
      _(or added `#trivial` to the PR title if I think it doesn't warrant a mention in the CHANGELOG)_
  * [ ] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
  * [ ] Add a period and 2 spaces at the end of your short entry description
  * [ ] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

The xcassets templates documentation files didn't have an entry for the bundle parameter.
I am not sure if there are other places that need to be updated, but I think its only these.