### PR TITLE
Generate XCFileList: Adds `templatePath` to the inputs file list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ _None_
 * Strings: `objc-h` template now emits valid documentation comments.  
   [@szotp](https://github.com/szotp)
   [#822](https://github.com/SwiftGen/SwiftGen/pull/822)
+* Generate `xcfilelist`: Adds the template file path to the inputs `xcfilelist` (for custom templates).  
+  [Craig Siemens](https://github.com/CraigSiemens)
+  [#815](https://github.com/SwiftGen/SwiftGen/pull/815)
 
 ### Internal Changes
 

--- a/Sources/SwiftGenCLI/Config/Config+XCFileList.swift
+++ b/Sources/SwiftGenCLI/Config/Config+XCFileList.swift
@@ -12,12 +12,19 @@ extension Config {
   // MARK: Input XCFileList
   public func inputXCFileList() throws -> String {
     let inputPaths = try groupPathsByCommand { command, entry -> [Path] in
+      let templatePaths = entry.outputs.compactMap { output -> Path? in
+        guard case .path(let path) = output.template else { return nil }
+        return path
+      }
+
       let inputPaths = entry.inputs.map { (sourcePath + $0).absolute() }
       let filter = try Filter(pattern: entry.filter ?? command.parserType.defaultFilter)
 
-      return try command.parserType
+      let matchingInputPaths = try command.parserType
         .subpaths(in: inputPaths, matching: filter)
         .map { $0.path }
+
+      return templatePaths + matchingInputPaths
     }
 
     return xcFileList(for: inputPaths)

--- a/Sources/SwiftGenCLI/Config/Config+XCFileList.swift
+++ b/Sources/SwiftGenCLI/Config/Config+XCFileList.swift
@@ -70,8 +70,11 @@ extension Config {
           .map { $0.string.replacingOccurrences(of: Path.current.absolute().string, with: "$(SRCROOT)") }
           .joined(separator: "\n")
 
-        return "# \(commandName)\n\(formattedPaths)\n"
+        return """
+          # \(commandName)
+          \(formattedPaths)
+          """
       }
-      .joined(separator: "\n")
+      .joined(separator: "\n\n")
   }
 }

--- a/Tests/SwiftGenTests/ConfigGenerateFileListTests.swift
+++ b/Tests/SwiftGenTests/ConfigGenerateFileListTests.swift
@@ -1,0 +1,141 @@
+//
+// SwiftGen
+// Copyright © 2020 SwiftGen
+// MIT Licence
+//
+
+import PathKit
+@testable import SwiftGenCLI
+import TestUtils
+import XCTest
+
+final class ConfigGenerateFileListTests: XCTestCase {
+  private lazy var resourcesPath: Path = {
+    let resources = Fixtures.resourceDirectory().parent().string
+    let current = Path.current.string
+    return Path(String(resources.dropFirst(current.count + 1)))
+  }()
+
+  // MARK: - Inputs
+
+  func testGenerateInputs1() throws {
+    let file = Fixtures.config(for: "config-absolute-paths-direct")
+    do {
+      let config = try Config(file: file)
+      let fileList = try config.inputXCFileList()
+      XCTAssertEqual(fileList, """
+      # colors
+      /colors/templates.stencil
+
+      # fonts
+      /fonts/templates.stencil
+
+      # ib
+      /ib/templates.stencil
+
+      # strings
+      /strings/templates.stencil
+
+      # xcassets
+      /xcassets/templates.stencil
+      """)
+    } catch let error {
+      XCTFail("Error: \(error)")
+    }
+  }
+
+  func testGenerateInputs2() throws {
+    let file = Fixtures.config(for: "config-with-multi-entries")
+    do {
+      let config = try Config(file: file)
+      let fileList = try config.inputXCFileList()
+      XCTAssertEqual(fileList, """
+      # strings
+      $(SRCROOT)/\(resourcesPath)/Configs/Fixtures/Strings/Localizable.strings
+      templates/custom-swift5
+
+      # xcassets
+      $(SRCROOT)/\(resourcesPath)/Configs/Fixtures/XCAssets/Colors.xcassets
+      $(SRCROOT)/\(resourcesPath)/Configs/Fixtures/XCAssets/Images.xcassets
+      """)
+    } catch let error {
+      XCTFail("Error: \(error)")
+    }
+  }
+
+  func testGenerateInputs3() throws {
+    let file = Fixtures.config(for: "config-with-multi-outputs")
+    do {
+      let config = try Config(file: file)
+      let fileList = try config.inputXCFileList()
+      XCTAssertEqual(fileList, """
+      # ib
+
+      """)
+    } catch let error {
+      XCTFail("Error: \(error)")
+    }
+  }
+
+  // MARK: - Outputs
+
+  func testGenerateOutputs1() throws {
+    let file = Fixtures.config(for: "config-absolute-paths-direct")
+    do {
+      let config = try Config(file: file)
+      let fileList = try config.outputXCFileList()
+      XCTAssertEqual(fileList, """
+      # colors
+      /colors/out.swift
+
+      # fonts
+      /fonts/out.swift
+
+      # ib
+      /ib/out.swift
+
+      # strings
+      /strings/out.swift
+
+      # xcassets
+      /xcassets/out.swift
+      """)
+    } catch let error {
+      XCTFail("Error: \(error)")
+    }
+  }
+
+  func testGenerateOutputs2() throws {
+    let file = Fixtures.config(for: "config-with-multi-entries")
+    do {
+      let config = try Config(file: file)
+      let fileList = try config.outputXCFileList()
+      XCTAssertEqual(fileList, """
+      # strings
+      $(SRCROOT)/\(resourcesPath)/Configs/Generated/strings.swift
+
+      # xcassets
+      $(SRCROOT)/\(resourcesPath)/Configs/Generated/assets-all.swift
+      $(SRCROOT)/\(resourcesPath)/Configs/Generated/assets-colors.swift
+      $(SRCROOT)/\(resourcesPath)/Configs/Generated/assets-images.swift
+      """)
+    } catch let error {
+      XCTFail("Error: \(error)")
+    }
+  }
+
+  func testGenerateOutputs3() throws {
+    let file = Fixtures.config(for: "config-with-multi-outputs")
+    do {
+      let config = try Config(file: file)
+      let fileList = try config.outputXCFileList()
+      XCTAssertEqual(fileList, """
+      # ib
+      $(SRCROOT)/\(resourcesPath)/Configs/Generated/ib-scenes.swift
+      $(SRCROOT)/\(resourcesPath)/Configs/Generated/ib-segues.swift
+      """)
+    } catch let error {
+      XCTFail("Error: \(error)")
+    }
+  }
+}


### PR DESCRIPTION
This updates the generated input XCFileList to contain the path to the template file if one is used. This is so edits to the template file can trigger Xcode build phases using the input XCFileList.