### PR TITLE
Add  `--quiet` flag to suppress most log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ _None_
 
 ### New Features
 
-* Adding support for quiet log level.
+* Added support for `--quiet/-q` flag, to suppress all logs (except errors).  
   [Andre113](https://github.com/Andre113)
   [#562](https://github.com/SwiftGen/SwiftGen/issues/823)
   [#797](https://github.com/SwiftGen/SwiftGen/pull/846)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ _None_
   [David Jennes](https://github.com/djbe)
   [#562](https://github.com/SwiftGen/SwiftGen/issues/562)
   [#797](https://github.com/SwiftGen/SwiftGen/pull/797)
+<<<<<<< HEAD
 * Support M1 and Intel devices (universal binary).  
   [David Jennes](https://github.com/djbe)
   [#805](https://github.com/SwiftGen/SwiftGen/issues/805)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ _None_
 
 * Added support for `--quiet/-q` flag, to suppress all logs (except errors).  
   [Andre113](https://github.com/Andre113)
-  [#562](https://github.com/SwiftGen/SwiftGen/issues/823)
-  [#797](https://github.com/SwiftGen/SwiftGen/pull/846)
+  [#823](https://github.com/SwiftGen/SwiftGen/issues/823)
+  [#846](https://github.com/SwiftGen/SwiftGen/pull/846)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ _None_
 
 ### New Features
 
-_None_
+* Adding support for quiet log level.
+  [Andre113](https://github.com/Andre113)
+  [#562](https://github.com/SwiftGen/SwiftGen/issues/823)
+  [#797](https://github.com/SwiftGen/SwiftGen/pull/846)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,6 @@ _None_
   [David Jennes](https://github.com/djbe)
   [#562](https://github.com/SwiftGen/SwiftGen/issues/562)
   [#797](https://github.com/SwiftGen/SwiftGen/pull/797)
-<<<<<<< HEAD
 * Support M1 and Intel devices (universal binary).  
   [David Jennes](https://github.com/djbe)
   [#805](https://github.com/SwiftGen/SwiftGen/issues/805)

--- a/Documentation/ConfigFile.md
+++ b/Documentation/ConfigFile.md
@@ -132,13 +132,26 @@ If you need more control when using a configuration file, you can use some advan
   swiftgen config init --config tools/swiftgen/swiftgen-config.yml
   ```
   
-* Enable the verbose mode, which will print every command being executed when executing it, using the `--verbose` flag. This allows your to:
-  * control what is being run, by logging what happens during execution
-  * know the equivalent command to type if you were to run each swiftgen command manually instead of using the config file — which can be useful if you need to debug or tweak a particular command in isolation for example
+* Change the default log level. There are three options available. If no log level is specified, default will be used.
 
-  ```sh
-  swiftgen config run --verbose
-  ```
+  * Verbose mode, which will print every command being executed when executing it, using the `--verbose` flag. This allows your to:
+    * control what is being run, by logging what happens during execution
+    * know the equivalent command to type if you were to run each swiftgen command manually instead of using the config file — which can be useful if you need to debug or tweak a particular command in isolation for example
+
+      ```sh
+      swiftgen config run --logLevel verbose
+      ```
+  * Silent mode, which will silent every command being executed when executing it:
+
+      ```sh
+      swiftgen config run --logLevel silent
+      ```
+
+  * Default mode, which will print some of the commands being executed when executing it:
+
+    ```sh
+    swiftgen config run --logLevel default
+    ```
 
 ## Linting the configuration file
 

--- a/Documentation/ConfigFile.md
+++ b/Documentation/ConfigFile.md
@@ -141,7 +141,7 @@ If you need more control when using a configuration file, you can use some advan
       ```sh
       swiftgen config run --verbose
       ```
-  * Quiet mode (`--quiet` or `-q` flag), which will silent every command being executed when executing it (except for errors):
+  * Quiet mode (`--quiet` or `-q` flag), which will silence all logs (except for errors):
 
       ```sh
       swiftgen config run --quiet

--- a/Documentation/ConfigFile.md
+++ b/Documentation/ConfigFile.md
@@ -134,14 +134,14 @@ If you need more control when using a configuration file, you can use some advan
   
 * Change the default log level to quiet or verbose. If no log level is specified, default will be used.
 
-  * Verbose mode, which will print every command being executed when executing it, using the `--verbose` flag. This allows your to:
+  * Verbose mode (`--verbose` or `-v` flag), which will print every command being executed when executing it. This allows your to:
     * control what is being run, by logging what happens during execution
     * know the equivalent command to type if you were to run each swiftgen command manually instead of using the config file — which can be useful if you need to debug or tweak a particular command in isolation for example
 
       ```sh
       swiftgen config run --verbose
       ```
-  * Quiet mode, which will silent every command being executed when executing it (except for errors):
+  * Quiet mode (`--quiet` or `-q` flag), which will silent every command being executed when executing it (except for errors):
 
       ```sh
       swiftgen config run --quiet

--- a/Documentation/ConfigFile.md
+++ b/Documentation/ConfigFile.md
@@ -132,26 +132,20 @@ If you need more control when using a configuration file, you can use some advan
   swiftgen config init --config tools/swiftgen/swiftgen-config.yml
   ```
   
-* Change the default log level. There are three options available. If no log level is specified, default will be used.
+* Change the default log level to quiet or verbose. If no log level is specified, default will be used.
 
   * Verbose mode, which will print every command being executed when executing it, using the `--verbose` flag. This allows your to:
     * control what is being run, by logging what happens during execution
     * know the equivalent command to type if you were to run each swiftgen command manually instead of using the config file — which can be useful if you need to debug or tweak a particular command in isolation for example
 
       ```sh
-      swiftgen config run --logLevel verbose
+      swiftgen config run --verbose
       ```
-  * Silent mode, which will silent every command being executed when executing it:
+  * Quiet mode, which will silent every command being executed when executing it (except for errors):
 
       ```sh
-      swiftgen config run --logLevel silent
+      swiftgen config run --quiet
       ```
-
-  * Default mode, which will print some of the commands being executed when executing it:
-
-    ```sh
-    swiftgen config run --logLevel default
-    ```
 
 ## Linting the configuration file
 

--- a/Sources/SwiftGen/Commander/ConfigCommands.swift
+++ b/Sources/SwiftGen/Commander/ConfigCommands.swift
@@ -51,14 +51,15 @@ enum ConfigCLI {
         
         switch (quiet, verbose) {
         case (true, _):
-            commandLogLevel = .quiet
+          commandLogLevel = .quiet
         case (_, true):
-            commandLogLevel = .verbose
-            logMessage(.info, "Executing configuration file \(file)")
+          commandLogLevel = .verbose
         default:
-            commandLogLevel = .default
+          commandLogLevel = .default
         }
-          
+        
+        logMessage(.info, "Executing configuration file \(file)")
+        
         try file.parent().chdir {
           try config.runCommands(logLevel: commandLogLevel)
         }

--- a/Sources/SwiftGen/Commander/ConfigCommands.swift
+++ b/Sources/SwiftGen/Commander/ConfigCommands.swift
@@ -39,7 +39,7 @@ enum ConfigCLI {
   }
 
   // MARK: Run
-  
+
   static let run = command(
     CLIOption.configFile(),
     Flag("quiet", default: false, flag: "q", description: "Hide all non error logs"),
@@ -48,7 +48,7 @@ enum ConfigCLI {
     do {
       try ErrorPrettifier.execute {
         let config = try Config(file: file)
-        
+
         switch (quiet, verbose) {
         case (true, _):
           commandLogLevel = .quiet
@@ -57,9 +57,9 @@ enum ConfigCLI {
         default:
           commandLogLevel = .default
         }
-        
+
         logMessage(.info, "Executing configuration file \(file)")
-        
+
         try file.parent().chdir {
           try config.runCommands(logLevel: commandLogLevel)
         }

--- a/Sources/SwiftGen/Commander/ConfigCommands.swift
+++ b/Sources/SwiftGen/Commander/ConfigCommands.swift
@@ -44,7 +44,7 @@ enum ConfigCLI {
     CLIOption.configFile(),
     Flag("quiet", default: false, flag: "q", description: "Hide all non error logs"),
     Flag("verbose", default: false, flag: "v", description: "Print each command being executed")
-  ) { file, logLevel, verbose in
+  ) { file, quiet, verbose in
     do {
       try ErrorPrettifier.execute {
         let config = try Config(file: file)

--- a/Sources/SwiftGen/Commander/ConfigCommands.swift
+++ b/Sources/SwiftGen/Commander/ConfigCommands.swift
@@ -11,10 +11,6 @@ import StencilSwiftKit
 import SwiftGenCLI
 import SwiftGenKit
 
-enum CommandLogLevel: String {
-  case silent, `default`, verbose
-}
-
 // MARK: - Commands
 
 enum ConfigCLI {

--- a/Sources/SwiftGenCLI/Config/Config+Run.swift
+++ b/Sources/SwiftGenCLI/Config/Config+Run.swift
@@ -10,11 +10,7 @@ import StencilSwiftKit
 import SwiftGenKit
 
 extension Config {
-<<<<<<< HEAD:Sources/SwiftGenCLI/Config/Config+Run.swift
-  public func runCommands(verbose: Bool, logger: (LogLevel, String) -> Void = logMessage) throws {
-=======
-  func runCommands(logLevel: CommandLogLevel, logger: (LogLevel, String) -> Void = logMessage) throws {
->>>>>>> db0f5178... Adding silent mode:Sources/SwiftGen/Config/Config+Run.swift
+  public func runCommands(logLevel: CommandLogLevel, logger: (LogLevel, String) -> Void = logMessage) throws {
     let errors = commands.parallelCompactMap { cmd, entry -> Swift.Error? in
       do {
         try run(parserCommand: cmd, entry: entry, logLevel: logLevel, logger: logger)

--- a/Sources/SwiftGenCLI/Config/Config+Run.swift
+++ b/Sources/SwiftGenCLI/Config/Config+Run.swift
@@ -26,7 +26,7 @@ extension Config {
       throw Error.multipleErrors(errors)
     }
   }
-  
+
   private func run(
     parserCommand: ParserCLI,
     entry: ConfigEntry,

--- a/Sources/SwiftGenCLI/Config/Config+Run.swift
+++ b/Sources/SwiftGenCLI/Config/Config+Run.swift
@@ -10,10 +10,14 @@ import StencilSwiftKit
 import SwiftGenKit
 
 extension Config {
+<<<<<<< HEAD:Sources/SwiftGenCLI/Config/Config+Run.swift
   public func runCommands(verbose: Bool, logger: (LogLevel, String) -> Void = logMessage) throws {
+=======
+  func runCommands(logLevel: CommandLogLevel, logger: (LogLevel, String) -> Void = logMessage) throws {
+>>>>>>> db0f5178... Adding silent mode:Sources/SwiftGen/Config/Config+Run.swift
     let errors = commands.parallelCompactMap { cmd, entry -> Swift.Error? in
       do {
-        try run(parserCommand: cmd, entry: entry, verbose: verbose, logger: logger)
+        try run(parserCommand: cmd, entry: entry, logLevel: logLevel, logger: logger)
         return nil
       } catch {
         return error
@@ -26,17 +30,17 @@ extension Config {
       throw Error.multipleErrors(errors)
     }
   }
-
+  
   private func run(
     parserCommand: ParserCLI,
     entry: ConfigEntry,
-    verbose: Bool,
+    logLevel: CommandLogLevel,
     logger: (LogLevel, String) -> Void
   ) throws {
     var entry = entry
 
     entry.makeRelativeTo(inputDir: inputDir, outputDir: outputDir)
-    if verbose {
+    if logLevel == .verbose {
       for item in entry.commandLine(forCommand: parserCommand.name) {
         logger(.info, " $ \(item)")
       }

--- a/Sources/SwiftGenCLI/Logs.swift
+++ b/Sources/SwiftGenCLI/Logs.swift
@@ -47,15 +47,18 @@ enum ANSIColor: UInt8, CustomStringConvertible {
 
 // Based on https://github.com/realm/SwiftLint/blob/0.39.2/Source/SwiftLintFramework/Extensions/QueuedPrint.swift
 
-
 public func logMessage(_ level: LogLevel, _ string: CustomStringConvertible) {
   logQueue.async {
     switch level {
     case .info:
-      if commandLogLevel == .quiet { return }
+      if commandLogLevel == .quiet {
+        return
+      }
       fputs(ANSIColor.green.format("\(string)\n"), stdout)
     case .warning:
-      if commandLogLevel == .quiet { return }
+      if commandLogLevel == .quiet {
+        return
+      }
       fputs(ANSIColor.yellow.format("swiftgen: warning: \(string)\n"), stderr)
     case .error:
       fputs(ANSIColor.red.format("swiftgen: error: \(string)\n"), stderr)

--- a/Sources/SwiftGenCLI/Logs.swift
+++ b/Sources/SwiftGenCLI/Logs.swift
@@ -49,18 +49,16 @@ enum ANSIColor: UInt8, CustomStringConvertible {
 
 public func logMessage(_ level: LogLevel, _ string: CustomStringConvertible) {
   logQueue.async {
-    switch level {
-    case .info:
-      if commandLogLevel == .quiet {
-        return
-      }
+    switch (level, commandLogLevel) {
+    case (.info, .quiet):
+      break
+    case (.info, _):
       fputs(ANSIColor.green.format("\(string)\n"), stdout)
-    case .warning:
-      if commandLogLevel == .quiet {
-        return
-      }
+    case (.warning, .quiet):
+      break
+    case (.warning, _):
       fputs(ANSIColor.yellow.format("swiftgen: warning: \(string)\n"), stderr)
-    case .error:
+    case (.error, _):
       fputs(ANSIColor.red.format("swiftgen: error: \(string)\n"), stderr)
     }
   }

--- a/Sources/SwiftGenCLI/Logs.swift
+++ b/Sources/SwiftGenCLI/Logs.swift
@@ -8,7 +8,11 @@ import Foundation
 
 // MARK: Printing on stderr
 
-var commandLogLevel: CommandLogLevel = .default
+public enum CommandLogLevel: String {
+  case silent, `default`, verbose
+}
+
+public var commandLogLevel: CommandLogLevel = .default
 
 public enum LogLevel {
   case info, warning, error

--- a/Sources/SwiftGenCLI/Logs.swift
+++ b/Sources/SwiftGenCLI/Logs.swift
@@ -8,8 +8,8 @@ import Foundation
 
 // MARK: Printing on stderr
 
-public enum CommandLogLevel: String {
-  case silent, `default`, verbose
+public enum CommandLogLevel {
+  case quiet, `default`, verbose
 }
 
 public var commandLogLevel: CommandLogLevel = .default
@@ -49,7 +49,7 @@ enum ANSIColor: UInt8, CustomStringConvertible {
 
 
 public func logMessage(_ level: LogLevel, _ string: CustomStringConvertible) {
-  if commandLogLevel == .silent { return }
+  if commandLogLevel == .quiet { return }
   logQueue.async {
     switch level {
     case .info:

--- a/Sources/SwiftGenCLI/Logs.swift
+++ b/Sources/SwiftGenCLI/Logs.swift
@@ -8,6 +8,8 @@ import Foundation
 
 // MARK: Printing on stderr
 
+var commandLogLevel: CommandLogLevel = .default
+
 public enum LogLevel {
   case info, warning, error
 }
@@ -41,7 +43,9 @@ enum ANSIColor: UInt8, CustomStringConvertible {
 
 // Based on https://github.com/realm/SwiftLint/blob/0.39.2/Source/SwiftLintFramework/Extensions/QueuedPrint.swift
 
+
 public func logMessage(_ level: LogLevel, _ string: CustomStringConvertible) {
+  if commandLogLevel == .silent { return }
   logQueue.async {
     switch level {
     case .info:

--- a/Sources/SwiftGenCLI/Logs.swift
+++ b/Sources/SwiftGenCLI/Logs.swift
@@ -49,12 +49,13 @@ enum ANSIColor: UInt8, CustomStringConvertible {
 
 
 public func logMessage(_ level: LogLevel, _ string: CustomStringConvertible) {
-  if commandLogLevel == .quiet { return }
   logQueue.async {
     switch level {
     case .info:
+      if commandLogLevel == .quiet { return }
       fputs(ANSIColor.green.format("\(string)\n"), stdout)
     case .warning:
+      if commandLogLevel == .quiet { return }
       fputs(ANSIColor.yellow.format("swiftgen: warning: \(string)\n"), stderr)
     case .error:
       fputs(ANSIColor.red.format("swiftgen: error: \(string)\n"), stderr)

--- a/Tests/SwiftGenTests/ConfigRunTests.swift
+++ b/Tests/SwiftGenTests/ConfigRunTests.swift
@@ -27,7 +27,7 @@ final class ConfigRunTests: XCTestCase {
     do {
       let config = try Config(file: configFile, logger: logger.log)
       try configFile.parent().chdir {
-        try config.runCommands(logLevel: CommandLogLevel.verbose, logger: logger.log)
+        try config.runCommands(logLevel: .verbose, logger: logger.log)
       }
     } catch Config.Error.multipleErrors(let errors) {
       errors.forEach(logger.handleError)

--- a/Tests/SwiftGenTests/ConfigRunTests.swift
+++ b/Tests/SwiftGenTests/ConfigRunTests.swift
@@ -27,7 +27,7 @@ final class ConfigRunTests: XCTestCase {
     do {
       let config = try Config(file: configFile, logger: logger.log)
       try configFile.parent().chdir {
-        try config.runCommands(verbose: true, logger: logger.log)
+        try config.runCommands(logLevel: CommandLogLevel.verbose, logger: logger.log)
       }
     } catch Config.Error.multipleErrors(let errors) {
       errors.forEach(logger.handleError)


### PR DESCRIPTION
Fixes #823

Adding a new `CommandLogLevel` enum to add the option for silent log level. The only exception will be an error message if the config file fails to open, like this one:

> 
> swiftgen: error: File swiftgen.yml not found.
> swiftgen: error: It seems like there was an error running SwiftGen.
> 
> - Verify that your configuration file exists at the correct path, or create a new one using:
> > swiftgen config init
> 
> - Verify that your configuration file is valid by running:
> > swiftgen config lint
> 
> - If you have any other questions or issues, we have extensive documentation and an issue tracker on GitHub:
> > https://github.com/SwiftGen/SwiftGen

OId scripts passing the `verbose` parameter will still work.