### PR TITLE
Hotfix: Use PathKit 1.0.1 to fix Xcode 13 compilation issue #trivial

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/kylef/Commander.git", from: "0.9.0"),
-        .package(url: "https://github.com/kylef/PathKit.git", from: "0.9.0"),
+        .package(url: "https://github.com/kylef/PathKit.git", from: "1.0.1"),
         .package(url: "https://github.com/kylef/Stencil.git", from: "0.13.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.0"),
         .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", from: "2.7.0"),


### PR DESCRIPTION
* [ ] I've started my branch from the `develop` branch (gitflow)
  * [ ] And I've selected `develop` as the "base" branch for this Pull Request I'm about to create
* [x] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself  
      _(or added `#trivial` to the PR title if I think it doesn't warrant a mention in the CHANGELOG)_
  * [ ] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
  * [ ] Add a period and 2 spaces at the end of your short entry description
  * [ ] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

Although the PR instructions say to point to the `develop` branch, I'm opening up this PR anyway to the `stable` branch in case the changes on `develop` aren't stable enough to quickly ship a `6.4.1` Xcode 13 hotfix release. 

PathKit 1.0.1 resolves this Xcode 13 compilation issue: https://github.com/kylef/PathKit/pull/80

Cheers!