### PR TITLE
Universal builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ _None_
   [David Jennes](https://github.com/djbe)
   [#562](https://github.com/SwiftGen/SwiftGen/issues/562)
   [#797](https://github.com/SwiftGen/SwiftGen/pull/797)
+* Support M1 and Intel devices (universal binary).  
+  [David Jennes](https://github.com/djbe)
+  [#805](https://github.com/SwiftGen/SwiftGen/issues/805)
+  [#880](https://github.com/SwiftGen/SwiftGen/pull/880)
 
 ### Bug Fixes
 

--- a/Rakefile
+++ b/Rakefile
@@ -37,7 +37,7 @@ namespace :cli do
   task :build do |task, args|
     Utils.print_header 'Building Binary'
     Utils.run(
-      %(swift build --disable-sandbox -c release),
+      %(swift build --disable-sandbox -c release --arch arm64 --arch x86_64),
       task, xcrun: true, formatter: :raw
     )
   end

--- a/Rakefile
+++ b/Rakefile
@@ -46,8 +46,8 @@ namespace :cli do
        "(defaults $bindir=#{BUILD_DIR}/swiftgen/bin/)"
   task :install, %i[bindir] => :build do |task, args|
     bindir = defaults(args)
-    generated_binary_path = "#{BUILD_DIR}/release/swiftgen"
-    generated_bundle_path = "#{BUILD_DIR}/release/SwiftGen_SwiftGenCLI.bundle"
+    generated_binary_path = "#{BUILD_DIR}/apple/Products/Release/swiftgen"
+    generated_bundle_path = "#{BUILD_DIR}/apple/Products/Release/SwiftGen_SwiftGenCLI.bundle"
 
     Utils.print_header "Installing binary in #{bindir}"
     Utils.run([


### PR DESCRIPTION
Ensure that our releases can run on M1 devices without using Rosetta.