### PR TITLE
Rake build: handle universal & slim builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ _None_
 
 ### Internal Changes
 
-_None_
+* Tweak release script to handle both universal & slim builds.  
+  [David Jennes](https://github.com/djbe)
+  [#884](https://github.com/SwiftGen/SwiftGen/pull/884)
 
 ## 6.5.0
 

--- a/Sources/SwiftGenCLI/Path+CommonLocations.swift
+++ b/Sources/SwiftGenCLI/Path+CommonLocations.swift
@@ -36,18 +36,6 @@ extension Path {
   // Deprecated: Remove this in SwiftGen 7.0
   public static let deprecatedAppSupportTemplates = Path.deprecatedApplicationSupport + "SwiftGen/templates"
   public static let bundledTemplates = Path(Bundle.module.path(forResource: "templates", ofType: nil) ?? "")
-
-  // MARK: Private
-
-  private static let templatesRelativePath: String = {
-    if let path = Bundle.main.object(forInfoDictionaryKey: "TemplatePath") as? String, !path.isEmpty {
-      return path
-    } else if let path = BundleToken.bundle.path(forResource: "templates", ofType: nil) {
-      return path
-    } else {
-      return "../templates"
-    }
-  }()
 }
 
 /// URL to the Documentation on GitHub
@@ -57,11 +45,3 @@ public func gitHubDocURL(version: String, path: String = "") -> URL {
     string: "https://github.com/SwiftGen/SwiftGen/\(type)/\(version)/Documentation/\(path)"
   )! // swiftlint:disable:this force_unwrapping
 }
-
-// swiftlint:disable convenience_type
-private final class BundleToken {
-  static let bundle: Bundle = {
-    Bundle(for: BundleToken.self)
-  }()
-}
-// swiftlint:enable convenience_type

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -107,7 +107,9 @@ namespace :release do
   end
 
   desc 'Create a zip containing all the prebuilt binaries'
-  task :zip => ['cli:clean', 'cli:install'] do
+  task :zip => ['cli:clean'] do
+    # Force a universal build
+    task('cli:install').invoke(nil, true)
     `cp LICENCE README.md CHANGELOG.md #{BUILD_DIR}/swiftgen`
     `cd #{BUILD_DIR}/swiftgen; zip -r ../swiftgen-#{Utils.podspec_version('SwiftGen')}.zip .`
   end


### PR DESCRIPTION
Needed because Homebrew wants slim builds, but for our zip releases (zip, cocoapods, ...) we want universal builds.
Refs: https://github.com/Homebrew/homebrew-core/pull/86408#issuecomment-933094677

By default we'll create a "slim" build (only active arch.). To create a universal build you need to run:
```bash
bundle exec rake "cli:install[,true]"
```

Note: the first parameter is the path where to install, empty in this example (--> default).