### PR TITLE
Workaround for Mint that does not yet support the SPM resource bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@ _None_
 
 ### Bug Fixes
 
-_None_
+* Workaround for Mint that does not yet support the SPM resource bundle.
+  [@tid-kijyun](https://github.com/tid-kijyun)
+  [#883](https://github.com/SwiftGen/SwiftGen/issues/883)
+  [#885](https://github.com/SwiftGen/SwiftGen/pull/885)
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _None_
 
 ### Bug Fixes
 
-* Workaround for Mint that does not yet support the SPM resource bundle.
+* Workaround for Mint that does not yet support the SPM resource bundle.  
   [@tid-kijyun](https://github.com/tid-kijyun)
   [#883](https://github.com/SwiftGen/SwiftGen/issues/883)
   [#885](https://github.com/SwiftGen/SwiftGen/pull/885)

--- a/Package.resources
+++ b/Package.resources
@@ -1,0 +1,2 @@
+.build/release/SwiftGen_SwiftGenCLI.bundle
+


### PR DESCRIPTION
Fixes #883.
It seems that Mint(v0.17.0) does not yet support the resource bundles supported by SPM (since 5.3).
To work around this problem, write the path to the bundle in `Package.resources` and tell Mint to copy it.

`Package.resources` should be removed after Mint adds support for SPM resource bundles.
However, it should work the same way as overwriting the same bundle, so I don't expect any additional problems for the time being.