### PR TITLE
Strings: reverted to case-sensitive sorting for keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,11 @@ _None_
   [David Jennes](https://github.com/djbe)
   [#950](https://github.com/SwiftGen/SwiftGen/issues/950)
   [#959](https://github.com/SwiftGen/SwiftGen/pull/959)
+* All parsers: fixed unstable output for keys that differed just by case.  
+  [grigorye](https://github.com/grigorye)
+  [David Jennes](https://github.com/djbe)
+  [#891](https://github.com/SwiftGen/SwiftGen/issues/891)
+  [#890](https://github.com/SwiftGen/SwiftGen/pull/890)
 
 ### Internal Changes
 

--- a/Sources/SwiftGenKit/Stencil/AssetsCatalogParser+Context.swift
+++ b/Sources/SwiftGenKit/Stencil/AssetsCatalogParser+Context.swift
@@ -14,7 +14,7 @@ import Foundation
 extension AssetsCatalog.Parser {
   public func stencilContext() -> [String: Any] {
     let catalogs = self.catalogs
-      .sorted { lhs, rhs in lhs.name < rhs.name }
+      .sorted { $0.name.compare($1.name, options: .caseInsensitive) == .orderedAscending }
       .map { catalog -> [String: Any] in
         [
           "name": catalog.name,

--- a/Sources/SwiftGenKit/Stencil/ColorsParser+Context.swift
+++ b/Sources/SwiftGenKit/Stencil/ColorsParser+Context.swift
@@ -14,10 +14,10 @@ import Foundation
 extension Colors.Parser {
   public func stencilContext() -> [String: Any] {
     let palettes: [[String: Any]] = self.palettes
-      .sorted { $0.name < $1.name }
+      .sorted { $0.name.compare($1.name, options: .caseInsensitive) == .orderedAscending }
       .map { palette in
         let colors = palette.colors
-          .sorted { $0.key < $1.key }
+          .sorted { $0.key.compare($1.key, options: .caseInsensitive) == .orderedAscending }
           .map(map(color:value:))
 
         return [

--- a/Sources/SwiftGenKit/Stencil/FilesParser+Context.swift
+++ b/Sources/SwiftGenKit/Stencil/FilesParser+Context.swift
@@ -10,7 +10,7 @@ import PathKit
 extension Files.Parser {
   public func stencilContext() -> [String: Any] {
     let groups: [[String: Any]] = files
-      .sorted { $0.key.lowercased() < $1.key.lowercased() }
+      .sorted { $0.key.compare($1.key, options: .caseInsensitive) == .orderedAscending }
       .map { name, files in
         var contents = structure(entries: files, usingMapper: map(file:))
         contents["name"] = name
@@ -43,7 +43,7 @@ extension Files.Parser {
     // Collect the files at this level
     let files = entries
       .filter { $0.path == keyPath }
-      .sorted { $0.name.lowercased() < $1.name.lowercased() }
+      .sorted { $0.name.compare($1.name, options: .caseInsensitive) == .orderedAscending }
       .map { mapper($0) }
 
     if !files.isEmpty {
@@ -54,7 +54,7 @@ extension Files.Parser {
     // sort and structure those files
     let childEntries = entries.filter { $0.path.count > keyPath.count }
     let children = Dictionary(grouping: childEntries) { $0.path[keyPath.count] }
-      .sorted { $0.key.lowercased() < $1.key.lowercased() }
+      .sorted { $0.key.compare($1.key, options: .caseInsensitive) == .orderedAscending }
       .map { name, entries in
         structure(entries: entries, atKeyPath: keyPath + [name], usingMapper: mapper)
       }

--- a/Sources/SwiftGenKit/Stencil/FontsParser+Context.swift
+++ b/Sources/SwiftGenKit/Stencil/FontsParser+Context.swift
@@ -15,9 +15,11 @@ extension Fonts.Parser {
   public func stencilContext() -> [String: Any] {
     // turn into array of dictionaries
     let families = entries
+      .sorted { $0.key.compare($1.key, options: .caseInsensitive) == .orderedAscending }
       .map { (name: String, family: Set<Fonts.Font>) -> [String: Any] in
         // Font
         let fonts = family
+          .sorted { $0.postScriptName.compare($1.postScriptName, options: .caseInsensitive) == .orderedAscending }
           .map { (font: Fonts.Font) -> [String: String] in
             [
               "name": font.postScriptName,
@@ -25,18 +27,12 @@ extension Fonts.Parser {
               "style": font.style
             ]
           }
-          .sorted { lhs, rhs in
-            lhs["name"] ?? "" < rhs["name"] ?? ""
-          }
 
         // Family
         return [
           "name": name,
           "fonts": fonts
         ]
-      }
-      .sorted { lhs, rhs in
-        lhs["name"] as? String ?? "" < rhs["name"] as? String ?? ""
       }
 
     return [

--- a/Sources/SwiftGenKit/Stencil/InterfaceBuilderParser+Context.swift
+++ b/Sources/SwiftGenKit/Stencil/InterfaceBuilderParser+Context.swift
@@ -14,7 +14,7 @@ import Foundation
 extension InterfaceBuilder.Parser {
   public func stencilContext() -> [String: Any] {
     let storyboards = self.storyboards
-      .sorted { lhs, rhs in lhs.name < rhs.name }
+      .sorted { $0.name.compare($1.name, options: .caseInsensitive) == .orderedAscending }
       .map(map(storyboard:))
     return [
       "modules": modules.sorted(),
@@ -27,10 +27,10 @@ extension InterfaceBuilder.Parser {
     var result: [String: Any] = [
       "name": storyboard.name,
       "scenes": storyboard.scenes
-        .sorted { $0.identifier < $1.identifier }
+        .sorted { $0.identifier.compare($1.identifier, options: .caseInsensitive) == .orderedAscending }
         .map(map(scene:)),
       "segues": storyboard.segues
-        .sorted { $0.identifier < $1.identifier }
+        .sorted { $0.identifier.compare($1.identifier, options: .caseInsensitive) == .orderedAscending }
         .map(map(segue:)),
       "platform": storyboard.platform.name
     ]

--- a/Sources/SwiftGenKit/Stencil/JSONParser+Context.swift
+++ b/Sources/SwiftGenKit/Stencil/JSONParser+Context.swift
@@ -14,7 +14,7 @@ import Foundation
 extension JSON.Parser {
   public func stencilContext() -> [String: Any] {
     let files = self.files
-      .sorted { lhs, rhs in lhs.name < rhs.name }
+      .sorted { $0.name.compare($1.name, options: .caseInsensitive) == .orderedAscending }
       .map(map(file:))
 
     return [

--- a/Sources/SwiftGenKit/Stencil/PlistParser+Context.swift
+++ b/Sources/SwiftGenKit/Stencil/PlistParser+Context.swift
@@ -14,7 +14,7 @@ import Foundation
 extension Plist.Parser {
   public func stencilContext() -> [String: Any] {
     let files = self.files
-      .sorted { lhs, rhs in lhs.name < rhs.name }
+      .sorted { $0.name.compare($1.name, options: .caseInsensitive) == .orderedAscending }
       .map(map(file:))
 
     return [

--- a/Sources/SwiftGenKit/Stencil/StringsParser+Context.swift
+++ b/Sources/SwiftGenKit/Stencil/StringsParser+Context.swift
@@ -40,7 +40,7 @@ extension Strings.Parser {
     }
 
     let tables = self.tables
-      .sorted { $0.key.lowercased() < $1.key.lowercased() }
+      .sorted { $0.key.compare($1.key, options: .caseInsensitive) == .orderedAscending }
       .map { name, entries in
         [
           "name": name,
@@ -70,7 +70,7 @@ extension Strings.Parser {
     // collect strings for this level
     let strings = entries
       .filter { $0.keyStructure.count == keyPath.count + 1 }
-      .sorted { $0.key.lowercased() < $1.key.lowercased() }
+      .sorted { $0.key.compare($1.key, options: .caseInsensitive) == .orderedAscending }
       .map { mapper($0, keyPath) }
 
     if !strings.isEmpty {
@@ -81,7 +81,7 @@ extension Strings.Parser {
     // and then structure those grouped entries
     let childEntries = entries.filter { $0.keyStructure.count > keyPath.count + 1 }
     let children = Dictionary(grouping: childEntries) { $0.keyStructure[keyPath.count] }
-      .sorted { $0.key < $1.key }
+      .sorted { $0.key.compare($1.key, options: .caseInsensitive) == .orderedAscending }
       .map { name, entries in
         structure(entries: entries, atKeyPath: keyPath + [name], usingMapper: mapper)
       }

--- a/Sources/SwiftGenKit/Stencil/YamlParser+Context.swift
+++ b/Sources/SwiftGenKit/Stencil/YamlParser+Context.swift
@@ -14,7 +14,7 @@ import Foundation
 extension Yaml.Parser {
   public func stencilContext() -> [String: Any] {
     let files = self.files
-      .sorted { lhs, rhs in lhs.name < rhs.name }
+      .sorted { $0.name.compare($1.name, options: .caseInsensitive) == .orderedAscending }
       .map(map(file:))
 
     return [

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift4/defaults-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift4/defaults-customBundle.swift
@@ -47,15 +47,15 @@ internal enum FontFamily {
     internal static let roman = FontConvertible(name: "Avenir-Roman", family: "Avenir", path: "Avenir.ttc")
     internal static let all: [FontConvertible] = [black, blackOblique, book, bookOblique, heavy, heavyOblique, light, lightOblique, medium, mediumOblique, oblique, roman]
   }
-  internal enum ZapfDingbats {
-    internal static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
-    internal static let all: [FontConvertible] = [regular]
-  }
   internal enum Public {
     internal static let `internal` = FontConvertible(name: "private", family: "public", path: "class.ttf")
     internal static let all: [FontConvertible] = [`internal`]
   }
-  internal static let allCustomFonts: [FontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, ZapfDingbats.all, Public.all].flatMap { $0 }
+  internal enum ZapfDingbats {
+    internal static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
+    internal static let all: [FontConvertible] = [regular]
+  }
+  internal static let allCustomFonts: [FontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, Public.all, ZapfDingbats.all].flatMap { $0 }
   internal static func registerAllCustomFonts() {
     allCustomFonts.forEach { $0.register() }
   }

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift4/defaults-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift4/defaults-customName.swift
@@ -47,15 +47,15 @@ internal enum CustomFamily {
     internal static let roman = MyFontConvertible(name: "Avenir-Roman", family: "Avenir", path: "Avenir.ttc")
     internal static let all: [MyFontConvertible] = [black, blackOblique, book, bookOblique, heavy, heavyOblique, light, lightOblique, medium, mediumOblique, oblique, roman]
   }
-  internal enum ZapfDingbats {
-    internal static let regular = MyFontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
-    internal static let all: [MyFontConvertible] = [regular]
-  }
   internal enum Public {
     internal static let `internal` = MyFontConvertible(name: "private", family: "public", path: "class.ttf")
     internal static let all: [MyFontConvertible] = [`internal`]
   }
-  internal static let allCustomFonts: [MyFontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, ZapfDingbats.all, Public.all].flatMap { $0 }
+  internal enum ZapfDingbats {
+    internal static let regular = MyFontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
+    internal static let all: [MyFontConvertible] = [regular]
+  }
+  internal static let allCustomFonts: [MyFontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, Public.all, ZapfDingbats.all].flatMap { $0 }
   internal static func registerAllCustomFonts() {
     allCustomFonts.forEach { $0.register() }
   }

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift4/defaults-lookupFunction.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift4/defaults-lookupFunction.swift
@@ -47,15 +47,15 @@ internal enum FontFamily {
     internal static let roman = FontConvertible(name: "Avenir-Roman", family: "Avenir", path: "Avenir.ttc")
     internal static let all: [FontConvertible] = [black, blackOblique, book, bookOblique, heavy, heavyOblique, light, lightOblique, medium, mediumOblique, oblique, roman]
   }
-  internal enum ZapfDingbats {
-    internal static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
-    internal static let all: [FontConvertible] = [regular]
-  }
   internal enum Public {
     internal static let `internal` = FontConvertible(name: "private", family: "public", path: "class.ttf")
     internal static let all: [FontConvertible] = [`internal`]
   }
-  internal static let allCustomFonts: [FontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, ZapfDingbats.all, Public.all].flatMap { $0 }
+  internal enum ZapfDingbats {
+    internal static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
+    internal static let all: [FontConvertible] = [regular]
+  }
+  internal static let allCustomFonts: [FontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, Public.all, ZapfDingbats.all].flatMap { $0 }
   internal static func registerAllCustomFonts() {
     allCustomFonts.forEach { $0.register() }
   }

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift4/defaults-preservePath.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift4/defaults-preservePath.swift
@@ -47,15 +47,15 @@ internal enum FontFamily {
     internal static let roman = FontConvertible(name: "Avenir-Roman", family: "Avenir", path: "Fonts/Avenir.ttc")
     internal static let all: [FontConvertible] = [black, blackOblique, book, bookOblique, heavy, heavyOblique, light, lightOblique, medium, mediumOblique, oblique, roman]
   }
-  internal enum ZapfDingbats {
-    internal static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "Fonts/ZapfDingbats.ttf")
-    internal static let all: [FontConvertible] = [regular]
-  }
   internal enum Public {
     internal static let `internal` = FontConvertible(name: "private", family: "public", path: "Fonts/class.ttf")
     internal static let all: [FontConvertible] = [`internal`]
   }
-  internal static let allCustomFonts: [FontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, ZapfDingbats.all, Public.all].flatMap { $0 }
+  internal enum ZapfDingbats {
+    internal static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "Fonts/ZapfDingbats.ttf")
+    internal static let all: [FontConvertible] = [regular]
+  }
+  internal static let allCustomFonts: [FontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, Public.all, ZapfDingbats.all].flatMap { $0 }
   internal static func registerAllCustomFonts() {
     allCustomFonts.forEach { $0.register() }
   }

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift4/defaults-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift4/defaults-publicAccess.swift
@@ -47,15 +47,15 @@ public enum FontFamily {
     public static let roman = FontConvertible(name: "Avenir-Roman", family: "Avenir", path: "Avenir.ttc")
     public static let all: [FontConvertible] = [black, blackOblique, book, bookOblique, heavy, heavyOblique, light, lightOblique, medium, mediumOblique, oblique, roman]
   }
-  public enum ZapfDingbats {
-    public static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
-    public static let all: [FontConvertible] = [regular]
-  }
   public enum Public {
     public static let `internal` = FontConvertible(name: "private", family: "public", path: "class.ttf")
     public static let all: [FontConvertible] = [`internal`]
   }
-  public static let allCustomFonts: [FontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, ZapfDingbats.all, Public.all].flatMap { $0 }
+  public enum ZapfDingbats {
+    public static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
+    public static let all: [FontConvertible] = [regular]
+  }
+  public static let allCustomFonts: [FontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, Public.all, ZapfDingbats.all].flatMap { $0 }
   public static func registerAllCustomFonts() {
     allCustomFonts.forEach { $0.register() }
   }

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift4/defaults.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift4/defaults.swift
@@ -47,15 +47,15 @@ internal enum FontFamily {
     internal static let roman = FontConvertible(name: "Avenir-Roman", family: "Avenir", path: "Avenir.ttc")
     internal static let all: [FontConvertible] = [black, blackOblique, book, bookOblique, heavy, heavyOblique, light, lightOblique, medium, mediumOblique, oblique, roman]
   }
-  internal enum ZapfDingbats {
-    internal static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
-    internal static let all: [FontConvertible] = [regular]
-  }
   internal enum Public {
     internal static let `internal` = FontConvertible(name: "private", family: "public", path: "class.ttf")
     internal static let all: [FontConvertible] = [`internal`]
   }
-  internal static let allCustomFonts: [FontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, ZapfDingbats.all, Public.all].flatMap { $0 }
+  internal enum ZapfDingbats {
+    internal static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
+    internal static let all: [FontConvertible] = [regular]
+  }
+  internal static let allCustomFonts: [FontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, Public.all, ZapfDingbats.all].flatMap { $0 }
   internal static func registerAllCustomFonts() {
     allCustomFonts.forEach { $0.register() }
   }

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults-customBundle.swift
@@ -46,15 +46,15 @@ internal enum FontFamily {
     internal static let roman = FontConvertible(name: "Avenir-Roman", family: "Avenir", path: "Avenir.ttc")
     internal static let all: [FontConvertible] = [black, blackOblique, book, bookOblique, heavy, heavyOblique, light, lightOblique, medium, mediumOblique, oblique, roman]
   }
-  internal enum ZapfDingbats {
-    internal static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
-    internal static let all: [FontConvertible] = [regular]
-  }
   internal enum Public {
     internal static let `internal` = FontConvertible(name: "private", family: "public", path: "class.ttf")
     internal static let all: [FontConvertible] = [`internal`]
   }
-  internal static let allCustomFonts: [FontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, ZapfDingbats.all, Public.all].flatMap { $0 }
+  internal enum ZapfDingbats {
+    internal static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
+    internal static let all: [FontConvertible] = [regular]
+  }
+  internal static let allCustomFonts: [FontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, Public.all, ZapfDingbats.all].flatMap { $0 }
   internal static func registerAllCustomFonts() {
     allCustomFonts.forEach { $0.register() }
   }

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults-customName.swift
@@ -46,15 +46,15 @@ internal enum CustomFamily {
     internal static let roman = MyFontConvertible(name: "Avenir-Roman", family: "Avenir", path: "Avenir.ttc")
     internal static let all: [MyFontConvertible] = [black, blackOblique, book, bookOblique, heavy, heavyOblique, light, lightOblique, medium, mediumOblique, oblique, roman]
   }
-  internal enum ZapfDingbats {
-    internal static let regular = MyFontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
-    internal static let all: [MyFontConvertible] = [regular]
-  }
   internal enum Public {
     internal static let `internal` = MyFontConvertible(name: "private", family: "public", path: "class.ttf")
     internal static let all: [MyFontConvertible] = [`internal`]
   }
-  internal static let allCustomFonts: [MyFontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, ZapfDingbats.all, Public.all].flatMap { $0 }
+  internal enum ZapfDingbats {
+    internal static let regular = MyFontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
+    internal static let all: [MyFontConvertible] = [regular]
+  }
+  internal static let allCustomFonts: [MyFontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, Public.all, ZapfDingbats.all].flatMap { $0 }
   internal static func registerAllCustomFonts() {
     allCustomFonts.forEach { $0.register() }
   }

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults-lookupFunction.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults-lookupFunction.swift
@@ -46,15 +46,15 @@ internal enum FontFamily {
     internal static let roman = FontConvertible(name: "Avenir-Roman", family: "Avenir", path: "Avenir.ttc")
     internal static let all: [FontConvertible] = [black, blackOblique, book, bookOblique, heavy, heavyOblique, light, lightOblique, medium, mediumOblique, oblique, roman]
   }
-  internal enum ZapfDingbats {
-    internal static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
-    internal static let all: [FontConvertible] = [regular]
-  }
   internal enum Public {
     internal static let `internal` = FontConvertible(name: "private", family: "public", path: "class.ttf")
     internal static let all: [FontConvertible] = [`internal`]
   }
-  internal static let allCustomFonts: [FontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, ZapfDingbats.all, Public.all].flatMap { $0 }
+  internal enum ZapfDingbats {
+    internal static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
+    internal static let all: [FontConvertible] = [regular]
+  }
+  internal static let allCustomFonts: [FontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, Public.all, ZapfDingbats.all].flatMap { $0 }
   internal static func registerAllCustomFonts() {
     allCustomFonts.forEach { $0.register() }
   }

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults-preservePath.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults-preservePath.swift
@@ -46,15 +46,15 @@ internal enum FontFamily {
     internal static let roman = FontConvertible(name: "Avenir-Roman", family: "Avenir", path: "Fonts/Avenir.ttc")
     internal static let all: [FontConvertible] = [black, blackOblique, book, bookOblique, heavy, heavyOblique, light, lightOblique, medium, mediumOblique, oblique, roman]
   }
-  internal enum ZapfDingbats {
-    internal static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "Fonts/ZapfDingbats.ttf")
-    internal static let all: [FontConvertible] = [regular]
-  }
   internal enum Public {
     internal static let `internal` = FontConvertible(name: "private", family: "public", path: "Fonts/class.ttf")
     internal static let all: [FontConvertible] = [`internal`]
   }
-  internal static let allCustomFonts: [FontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, ZapfDingbats.all, Public.all].flatMap { $0 }
+  internal enum ZapfDingbats {
+    internal static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "Fonts/ZapfDingbats.ttf")
+    internal static let all: [FontConvertible] = [regular]
+  }
+  internal static let allCustomFonts: [FontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, Public.all, ZapfDingbats.all].flatMap { $0 }
   internal static func registerAllCustomFonts() {
     allCustomFonts.forEach { $0.register() }
   }

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults-publicAccess.swift
@@ -46,15 +46,15 @@ public enum FontFamily {
     public static let roman = FontConvertible(name: "Avenir-Roman", family: "Avenir", path: "Avenir.ttc")
     public static let all: [FontConvertible] = [black, blackOblique, book, bookOblique, heavy, heavyOblique, light, lightOblique, medium, mediumOblique, oblique, roman]
   }
-  public enum ZapfDingbats {
-    public static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
-    public static let all: [FontConvertible] = [regular]
-  }
   public enum Public {
     public static let `internal` = FontConvertible(name: "private", family: "public", path: "class.ttf")
     public static let all: [FontConvertible] = [`internal`]
   }
-  public static let allCustomFonts: [FontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, ZapfDingbats.all, Public.all].flatMap { $0 }
+  public enum ZapfDingbats {
+    public static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
+    public static let all: [FontConvertible] = [regular]
+  }
+  public static let allCustomFonts: [FontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, Public.all, ZapfDingbats.all].flatMap { $0 }
   public static func registerAllCustomFonts() {
     allCustomFonts.forEach { $0.register() }
   }

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults.swift
@@ -46,15 +46,15 @@ internal enum FontFamily {
     internal static let roman = FontConvertible(name: "Avenir-Roman", family: "Avenir", path: "Avenir.ttc")
     internal static let all: [FontConvertible] = [black, blackOblique, book, bookOblique, heavy, heavyOblique, light, lightOblique, medium, mediumOblique, oblique, roman]
   }
-  internal enum ZapfDingbats {
-    internal static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
-    internal static let all: [FontConvertible] = [regular]
-  }
   internal enum Public {
     internal static let `internal` = FontConvertible(name: "private", family: "public", path: "class.ttf")
     internal static let all: [FontConvertible] = [`internal`]
   }
-  internal static let allCustomFonts: [FontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, ZapfDingbats.all, Public.all].flatMap { $0 }
+  internal enum ZapfDingbats {
+    internal static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
+    internal static let all: [FontConvertible] = [regular]
+  }
+  internal static let allCustomFonts: [FontConvertible] = [SFNSDisplay.all, SFNSText.all, Avenir.all, Public.all, ZapfDingbats.all].flatMap { $0 }
   internal static func registerAllCustomFonts() {
     allCustomFonts.forEach { $0.register() }
   }

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-customName.swift
@@ -20,10 +20,10 @@ internal enum XCTStoryboardCustom {
     case login = "Login"
     case modal = "Modal"
     case popover = "Popover"
-    case sheet = "Sheet"
-    case show = "Show"
     case `private`
     case `public`
+    case sheet = "Sheet"
+    case show = "Show"
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-ignoreTargetModule-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-ignoreTargetModule-withExtraModule.swift
@@ -19,10 +19,10 @@ internal enum StoryboardSegue {
     case login = "Login"
     case modal = "Modal"
     case popover = "Popover"
-    case sheet = "Sheet"
-    case show = "Show"
     case `private`
     case `public`
+    case sheet = "Sheet"
+    case show = "Show"
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-ignoreTargetModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-ignoreTargetModule.swift
@@ -20,10 +20,10 @@ internal enum StoryboardSegue {
     case login = "Login"
     case modal = "Modal"
     case popover = "Popover"
-    case sheet = "Sheet"
-    case show = "Show"
     case `private`
     case `public`
+    case sheet = "Sheet"
+    case show = "Show"
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-noDefinedModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-noDefinedModule.swift
@@ -21,10 +21,10 @@ internal enum StoryboardSegue {
     case login = "Login"
     case modal = "Modal"
     case popover = "Popover"
-    case sheet = "Sheet"
-    case show = "Show"
     case `private`
     case `public`
+    case sheet = "Sheet"
+    case show = "Show"
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-publicAccess.swift
@@ -20,10 +20,10 @@ public enum StoryboardSegue {
     case login = "Login"
     case modal = "Modal"
     case popover = "Popover"
-    case sheet = "Sheet"
-    case show = "Show"
     case `private`
     case `public`
+    case sheet = "Sheet"
+    case show = "Show"
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-withExtraModule.swift
@@ -19,10 +19,10 @@ internal enum StoryboardSegue {
     case login = "Login"
     case modal = "Modal"
     case popover = "Popover"
-    case sheet = "Sheet"
-    case show = "Show"
     case `private`
     case `public`
+    case sheet = "Sheet"
+    case show = "Show"
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all.swift
@@ -20,10 +20,10 @@ internal enum StoryboardSegue {
     case login = "Login"
     case modal = "Modal"
     case popover = "Popover"
-    case sheet = "Sheet"
-    case show = "Show"
     case `private`
     case `public`
+    case sheet = "Sheet"
+    case show = "Show"
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-customName.swift
@@ -20,10 +20,10 @@ internal enum XCTStoryboardCustom {
     case login = "Login"
     case modal = "Modal"
     case popover = "Popover"
-    case sheet = "Sheet"
-    case show = "Show"
     case `private`
     case `public`
+    case sheet = "Sheet"
+    case show = "Show"
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-ignoreTargetModule-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-ignoreTargetModule-withExtraModule.swift
@@ -19,10 +19,10 @@ internal enum StoryboardSegue {
     case login = "Login"
     case modal = "Modal"
     case popover = "Popover"
-    case sheet = "Sheet"
-    case show = "Show"
     case `private`
     case `public`
+    case sheet = "Sheet"
+    case show = "Show"
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-ignoreTargetModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-ignoreTargetModule.swift
@@ -20,10 +20,10 @@ internal enum StoryboardSegue {
     case login = "Login"
     case modal = "Modal"
     case popover = "Popover"
-    case sheet = "Sheet"
-    case show = "Show"
     case `private`
     case `public`
+    case sheet = "Sheet"
+    case show = "Show"
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-noDefinedModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-noDefinedModule.swift
@@ -21,10 +21,10 @@ internal enum StoryboardSegue {
     case login = "Login"
     case modal = "Modal"
     case popover = "Popover"
-    case sheet = "Sheet"
-    case show = "Show"
     case `private`
     case `public`
+    case sheet = "Sheet"
+    case show = "Show"
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-publicAccess.swift
@@ -20,10 +20,10 @@ public enum StoryboardSegue {
     case login = "Login"
     case modal = "Modal"
     case popover = "Popover"
-    case sheet = "Sheet"
-    case show = "Show"
     case `private`
     case `public`
+    case sheet = "Sheet"
+    case show = "Show"
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-withExtraModule.swift
@@ -19,10 +19,10 @@ internal enum StoryboardSegue {
     case login = "Login"
     case modal = "Modal"
     case popover = "Popover"
-    case sheet = "Sheet"
-    case show = "Show"
     case `private`
     case `public`
+    case sheet = "Sheet"
+    case show = "Show"
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all.swift
@@ -20,10 +20,10 @@ internal enum StoryboardSegue {
     case login = "Login"
     case modal = "Modal"
     case popover = "Popover"
-    case sheet = "Sheet"
-    case show = "Show"
     case `private`
     case `public`
+    case sheet = "Sheet"
+    case show = "Show"
   }
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name

--- a/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift4/all-customname.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift4/all-customname.swift
@@ -10,6 +10,17 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length number_separator type_body_length
 internal enum CustomPlist {
+  internal enum Configuration {
+    internal static let environment: String = "development"
+    internal static let flags: [Bool] = [true, false, true]
+    internal static let mixed: [Any] = ["One", 1, true]
+    internal static let mixed2: [Any] = [0.1, 1, true]
+    internal static let names: [String] = ["John", "Peter", "Nick"]
+    internal static let one: Int = 1
+    internal static let options: [String: Any] = ["Animation Style": "Party Mode"]
+    internal static let primes: [Int] = [2, 3, 5, 7]
+    internal static let zero: Int = 0
+  }
   internal enum Info {
     internal static let cfBundleDevelopmentRegion: String = "en"
     internal static let cfBundleDisplayName: String = "${PRODUCT_NAME}"
@@ -40,17 +51,6 @@ internal enum CustomPlist {
     internal static let userDate: Date = Date(timeIntervalSinceReferenceDate: 547184366)
     internal static let userFloat: Double = 3.14
     internal static let userInteger: Int = 5
-  }
-  internal enum Configuration {
-    internal static let environment: String = "development"
-    internal static let flags: [Bool] = [true, false, true]
-    internal static let mixed: [Any] = ["One", 1, true]
-    internal static let mixed2: [Any] = [0.1, 1, true]
-    internal static let names: [String] = ["John", "Peter", "Nick"]
-    internal static let one: Int = 1
-    internal static let options: [String: Any] = ["Animation Style": "Party Mode"]
-    internal static let primes: [Int] = [2, 3, 5, 7]
-    internal static let zero: Int = 0
   }
   internal enum ShoppingList {
     internal static let items: [String] = ["Eggs", "Bread", "Milk"]

--- a/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift4/all-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift4/all-forceFileNameEnum.swift
@@ -10,6 +10,17 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length number_separator type_body_length
 internal enum PlistFiles {
+  internal enum Configuration {
+    internal static let environment: String = "development"
+    internal static let flags: [Bool] = [true, false, true]
+    internal static let mixed: [Any] = ["One", 1, true]
+    internal static let mixed2: [Any] = [0.1, 1, true]
+    internal static let names: [String] = ["John", "Peter", "Nick"]
+    internal static let one: Int = 1
+    internal static let options: [String: Any] = ["Animation Style": "Party Mode"]
+    internal static let primes: [Int] = [2, 3, 5, 7]
+    internal static let zero: Int = 0
+  }
   internal enum Info {
     internal static let cfBundleDevelopmentRegion: String = "en"
     internal static let cfBundleDisplayName: String = "${PRODUCT_NAME}"
@@ -40,17 +51,6 @@ internal enum PlistFiles {
     internal static let userDate: Date = Date(timeIntervalSinceReferenceDate: 547184366)
     internal static let userFloat: Double = 3.14
     internal static let userInteger: Int = 5
-  }
-  internal enum Configuration {
-    internal static let environment: String = "development"
-    internal static let flags: [Bool] = [true, false, true]
-    internal static let mixed: [Any] = ["One", 1, true]
-    internal static let mixed2: [Any] = [0.1, 1, true]
-    internal static let names: [String] = ["John", "Peter", "Nick"]
-    internal static let one: Int = 1
-    internal static let options: [String: Any] = ["Animation Style": "Party Mode"]
-    internal static let primes: [Int] = [2, 3, 5, 7]
-    internal static let zero: Int = 0
   }
   internal enum ShoppingList {
     internal static let items: [String] = ["Eggs", "Bread", "Milk"]

--- a/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift4/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift4/all-publicAccess.swift
@@ -10,6 +10,17 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length number_separator type_body_length
 public enum PlistFiles {
+  public enum Configuration {
+    public static let environment: String = "development"
+    public static let flags: [Bool] = [true, false, true]
+    public static let mixed: [Any] = ["One", 1, true]
+    public static let mixed2: [Any] = [0.1, 1, true]
+    public static let names: [String] = ["John", "Peter", "Nick"]
+    public static let one: Int = 1
+    public static let options: [String: Any] = ["Animation Style": "Party Mode"]
+    public static let primes: [Int] = [2, 3, 5, 7]
+    public static let zero: Int = 0
+  }
   public enum Info {
     public static let cfBundleDevelopmentRegion: String = "en"
     public static let cfBundleDisplayName: String = "${PRODUCT_NAME}"
@@ -40,17 +51,6 @@ public enum PlistFiles {
     public static let userDate: Date = Date(timeIntervalSinceReferenceDate: 547184366)
     public static let userFloat: Double = 3.14
     public static let userInteger: Int = 5
-  }
-  public enum Configuration {
-    public static let environment: String = "development"
-    public static let flags: [Bool] = [true, false, true]
-    public static let mixed: [Any] = ["One", 1, true]
-    public static let mixed2: [Any] = [0.1, 1, true]
-    public static let names: [String] = ["John", "Peter", "Nick"]
-    public static let one: Int = 1
-    public static let options: [String: Any] = ["Animation Style": "Party Mode"]
-    public static let primes: [Int] = [2, 3, 5, 7]
-    public static let zero: Int = 0
   }
   public enum ShoppingList {
     public static let items: [String] = ["Eggs", "Bread", "Milk"]

--- a/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift4/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift4/all.swift
@@ -10,6 +10,17 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length number_separator type_body_length
 internal enum PlistFiles {
+  internal enum Configuration {
+    internal static let environment: String = "development"
+    internal static let flags: [Bool] = [true, false, true]
+    internal static let mixed: [Any] = ["One", 1, true]
+    internal static let mixed2: [Any] = [0.1, 1, true]
+    internal static let names: [String] = ["John", "Peter", "Nick"]
+    internal static let one: Int = 1
+    internal static let options: [String: Any] = ["Animation Style": "Party Mode"]
+    internal static let primes: [Int] = [2, 3, 5, 7]
+    internal static let zero: Int = 0
+  }
   internal enum Info {
     internal static let cfBundleDevelopmentRegion: String = "en"
     internal static let cfBundleDisplayName: String = "${PRODUCT_NAME}"
@@ -40,17 +51,6 @@ internal enum PlistFiles {
     internal static let userDate: Date = Date(timeIntervalSinceReferenceDate: 547184366)
     internal static let userFloat: Double = 3.14
     internal static let userInteger: Int = 5
-  }
-  internal enum Configuration {
-    internal static let environment: String = "development"
-    internal static let flags: [Bool] = [true, false, true]
-    internal static let mixed: [Any] = ["One", 1, true]
-    internal static let mixed2: [Any] = [0.1, 1, true]
-    internal static let names: [String] = ["John", "Peter", "Nick"]
-    internal static let one: Int = 1
-    internal static let options: [String: Any] = ["Animation Style": "Party Mode"]
-    internal static let primes: [Int] = [2, 3, 5, 7]
-    internal static let zero: Int = 0
   }
   internal enum ShoppingList {
     internal static let items: [String] = ["Eggs", "Bread", "Milk"]

--- a/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift5/all-customname.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift5/all-customname.swift
@@ -10,6 +10,17 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length number_separator type_body_length
 internal enum CustomPlist {
+  internal enum Configuration {
+    internal static let environment: String = "development"
+    internal static let flags: [Bool] = [true, false, true]
+    internal static let mixed: [Any] = ["One", 1, true]
+    internal static let mixed2: [Any] = [0.1, 1, true]
+    internal static let names: [String] = ["John", "Peter", "Nick"]
+    internal static let one: Int = 1
+    internal static let options: [String: Any] = ["Animation Style": "Party Mode"]
+    internal static let primes: [Int] = [2, 3, 5, 7]
+    internal static let zero: Int = 0
+  }
   internal enum Info {
     internal static let cfBundleDevelopmentRegion: String = "en"
     internal static let cfBundleDisplayName: String = "${PRODUCT_NAME}"
@@ -40,17 +51,6 @@ internal enum CustomPlist {
     internal static let userDate: Date = Date(timeIntervalSinceReferenceDate: 547184366)
     internal static let userFloat: Double = 3.14
     internal static let userInteger: Int = 5
-  }
-  internal enum Configuration {
-    internal static let environment: String = "development"
-    internal static let flags: [Bool] = [true, false, true]
-    internal static let mixed: [Any] = ["One", 1, true]
-    internal static let mixed2: [Any] = [0.1, 1, true]
-    internal static let names: [String] = ["John", "Peter", "Nick"]
-    internal static let one: Int = 1
-    internal static let options: [String: Any] = ["Animation Style": "Party Mode"]
-    internal static let primes: [Int] = [2, 3, 5, 7]
-    internal static let zero: Int = 0
   }
   internal enum ShoppingList {
     internal static let items: [String] = ["Eggs", "Bread", "Milk"]

--- a/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift5/all-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift5/all-forceFileNameEnum.swift
@@ -10,6 +10,17 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length number_separator type_body_length
 internal enum PlistFiles {
+  internal enum Configuration {
+    internal static let environment: String = "development"
+    internal static let flags: [Bool] = [true, false, true]
+    internal static let mixed: [Any] = ["One", 1, true]
+    internal static let mixed2: [Any] = [0.1, 1, true]
+    internal static let names: [String] = ["John", "Peter", "Nick"]
+    internal static let one: Int = 1
+    internal static let options: [String: Any] = ["Animation Style": "Party Mode"]
+    internal static let primes: [Int] = [2, 3, 5, 7]
+    internal static let zero: Int = 0
+  }
   internal enum Info {
     internal static let cfBundleDevelopmentRegion: String = "en"
     internal static let cfBundleDisplayName: String = "${PRODUCT_NAME}"
@@ -40,17 +51,6 @@ internal enum PlistFiles {
     internal static let userDate: Date = Date(timeIntervalSinceReferenceDate: 547184366)
     internal static let userFloat: Double = 3.14
     internal static let userInteger: Int = 5
-  }
-  internal enum Configuration {
-    internal static let environment: String = "development"
-    internal static let flags: [Bool] = [true, false, true]
-    internal static let mixed: [Any] = ["One", 1, true]
-    internal static let mixed2: [Any] = [0.1, 1, true]
-    internal static let names: [String] = ["John", "Peter", "Nick"]
-    internal static let one: Int = 1
-    internal static let options: [String: Any] = ["Animation Style": "Party Mode"]
-    internal static let primes: [Int] = [2, 3, 5, 7]
-    internal static let zero: Int = 0
   }
   internal enum ShoppingList {
     internal static let items: [String] = ["Eggs", "Bread", "Milk"]

--- a/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift5/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift5/all-publicAccess.swift
@@ -10,6 +10,17 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length number_separator type_body_length
 public enum PlistFiles {
+  public enum Configuration {
+    public static let environment: String = "development"
+    public static let flags: [Bool] = [true, false, true]
+    public static let mixed: [Any] = ["One", 1, true]
+    public static let mixed2: [Any] = [0.1, 1, true]
+    public static let names: [String] = ["John", "Peter", "Nick"]
+    public static let one: Int = 1
+    public static let options: [String: Any] = ["Animation Style": "Party Mode"]
+    public static let primes: [Int] = [2, 3, 5, 7]
+    public static let zero: Int = 0
+  }
   public enum Info {
     public static let cfBundleDevelopmentRegion: String = "en"
     public static let cfBundleDisplayName: String = "${PRODUCT_NAME}"
@@ -40,17 +51,6 @@ public enum PlistFiles {
     public static let userDate: Date = Date(timeIntervalSinceReferenceDate: 547184366)
     public static let userFloat: Double = 3.14
     public static let userInteger: Int = 5
-  }
-  public enum Configuration {
-    public static let environment: String = "development"
-    public static let flags: [Bool] = [true, false, true]
-    public static let mixed: [Any] = ["One", 1, true]
-    public static let mixed2: [Any] = [0.1, 1, true]
-    public static let names: [String] = ["John", "Peter", "Nick"]
-    public static let one: Int = 1
-    public static let options: [String: Any] = ["Animation Style": "Party Mode"]
-    public static let primes: [Int] = [2, 3, 5, 7]
-    public static let zero: Int = 0
   }
   public enum ShoppingList {
     public static let items: [String] = ["Eggs", "Bread", "Milk"]

--- a/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift5/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift5/all.swift
@@ -10,6 +10,17 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length number_separator type_body_length
 internal enum PlistFiles {
+  internal enum Configuration {
+    internal static let environment: String = "development"
+    internal static let flags: [Bool] = [true, false, true]
+    internal static let mixed: [Any] = ["One", 1, true]
+    internal static let mixed2: [Any] = [0.1, 1, true]
+    internal static let names: [String] = ["John", "Peter", "Nick"]
+    internal static let one: Int = 1
+    internal static let options: [String: Any] = ["Animation Style": "Party Mode"]
+    internal static let primes: [Int] = [2, 3, 5, 7]
+    internal static let zero: Int = 0
+  }
   internal enum Info {
     internal static let cfBundleDevelopmentRegion: String = "en"
     internal static let cfBundleDisplayName: String = "${PRODUCT_NAME}"
@@ -40,17 +51,6 @@ internal enum PlistFiles {
     internal static let userDate: Date = Date(timeIntervalSinceReferenceDate: 547184366)
     internal static let userFloat: Double = 3.14
     internal static let userInteger: Int = 5
-  }
-  internal enum Configuration {
-    internal static let environment: String = "development"
-    internal static let flags: [Bool] = [true, false, true]
-    internal static let mixed: [Any] = ["One", 1, true]
-    internal static let mixed2: [Any] = [0.1, 1, true]
-    internal static let names: [String] = ["John", "Peter", "Nick"]
-    internal static let one: Int = 1
-    internal static let options: [String: Any] = ["Animation Style": "Party Mode"]
-    internal static let primes: [Int] = [2, 3, 5, 7]
-    internal static let zero: Int = 0
   }
   internal enum ShoppingList {
     internal static let items: [String] = ["Eggs", "Bread", "Milk"]

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/all-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/all-customBundle.swift
@@ -10,6 +10,18 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal enum PlistFiles {
+  internal enum Configuration {
+    private static let _document = PlistDocument(path: "configuration.plist")
+    internal static let environment: String = _document["Environment"]
+    internal static let flags: [Bool] = _document["Flags"]
+    internal static let mixed: [Any] = _document["Mixed"]
+    internal static let mixed2: [Any] = _document["Mixed2"]
+    internal static let names: [String] = _document["Names"]
+    internal static let one: Int = _document["One"]
+    internal static let options: [String: Any] = _document["Options"]
+    internal static let primes: [Int] = _document["Primes"]
+    internal static let zero: Int = _document["Zero"]
+  }
   internal enum Info {
     private static let _document = PlistDocument(path: "Info.plist")
     internal static let cfBundleDevelopmentRegion: String = _document["CFBundleDevelopmentRegion"]
@@ -41,18 +53,6 @@ internal enum PlistFiles {
     internal static let userDate: Date = _document["User Date"]
     internal static let userFloat: Double = _document["User Float"]
     internal static let userInteger: Int = _document["User Integer"]
-  }
-  internal enum Configuration {
-    private static let _document = PlistDocument(path: "configuration.plist")
-    internal static let environment: String = _document["Environment"]
-    internal static let flags: [Bool] = _document["Flags"]
-    internal static let mixed: [Any] = _document["Mixed"]
-    internal static let mixed2: [Any] = _document["Mixed2"]
-    internal static let names: [String] = _document["Names"]
-    internal static let one: Int = _document["One"]
-    internal static let options: [String: Any] = _document["Options"]
-    internal static let primes: [Int] = _document["Primes"]
-    internal static let zero: Int = _document["Zero"]
   }
   internal enum ShoppingList {
     internal static let items: [String] = arrayFromPlist(at: "shopping-list.plist")

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/all-customName.swift
@@ -10,6 +10,18 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal enum CustomPlist {
+  internal enum Configuration {
+    private static let _document = PlistDocument(path: "configuration.plist")
+    internal static let environment: String = _document["Environment"]
+    internal static let flags: [Bool] = _document["Flags"]
+    internal static let mixed: [Any] = _document["Mixed"]
+    internal static let mixed2: [Any] = _document["Mixed2"]
+    internal static let names: [String] = _document["Names"]
+    internal static let one: Int = _document["One"]
+    internal static let options: [String: Any] = _document["Options"]
+    internal static let primes: [Int] = _document["Primes"]
+    internal static let zero: Int = _document["Zero"]
+  }
   internal enum Info {
     private static let _document = PlistDocument(path: "Info.plist")
     internal static let cfBundleDevelopmentRegion: String = _document["CFBundleDevelopmentRegion"]
@@ -41,18 +53,6 @@ internal enum CustomPlist {
     internal static let userDate: Date = _document["User Date"]
     internal static let userFloat: Double = _document["User Float"]
     internal static let userInteger: Int = _document["User Integer"]
-  }
-  internal enum Configuration {
-    private static let _document = PlistDocument(path: "configuration.plist")
-    internal static let environment: String = _document["Environment"]
-    internal static let flags: [Bool] = _document["Flags"]
-    internal static let mixed: [Any] = _document["Mixed"]
-    internal static let mixed2: [Any] = _document["Mixed2"]
-    internal static let names: [String] = _document["Names"]
-    internal static let one: Int = _document["One"]
-    internal static let options: [String: Any] = _document["Options"]
-    internal static let primes: [Int] = _document["Primes"]
-    internal static let zero: Int = _document["Zero"]
   }
   internal enum ShoppingList {
     internal static let items: [String] = arrayFromPlist(at: "shopping-list.plist")

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/all-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/all-forceFileNameEnum.swift
@@ -10,6 +10,18 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal enum PlistFiles {
+  internal enum Configuration {
+    private static let _document = PlistDocument(path: "configuration.plist")
+    internal static let environment: String = _document["Environment"]
+    internal static let flags: [Bool] = _document["Flags"]
+    internal static let mixed: [Any] = _document["Mixed"]
+    internal static let mixed2: [Any] = _document["Mixed2"]
+    internal static let names: [String] = _document["Names"]
+    internal static let one: Int = _document["One"]
+    internal static let options: [String: Any] = _document["Options"]
+    internal static let primes: [Int] = _document["Primes"]
+    internal static let zero: Int = _document["Zero"]
+  }
   internal enum Info {
     private static let _document = PlistDocument(path: "Info.plist")
     internal static let cfBundleDevelopmentRegion: String = _document["CFBundleDevelopmentRegion"]
@@ -41,18 +53,6 @@ internal enum PlistFiles {
     internal static let userDate: Date = _document["User Date"]
     internal static let userFloat: Double = _document["User Float"]
     internal static let userInteger: Int = _document["User Integer"]
-  }
-  internal enum Configuration {
-    private static let _document = PlistDocument(path: "configuration.plist")
-    internal static let environment: String = _document["Environment"]
-    internal static let flags: [Bool] = _document["Flags"]
-    internal static let mixed: [Any] = _document["Mixed"]
-    internal static let mixed2: [Any] = _document["Mixed2"]
-    internal static let names: [String] = _document["Names"]
-    internal static let one: Int = _document["One"]
-    internal static let options: [String: Any] = _document["Options"]
-    internal static let primes: [Int] = _document["Primes"]
-    internal static let zero: Int = _document["Zero"]
   }
   internal enum ShoppingList {
     internal static let items: [String] = arrayFromPlist(at: "shopping-list.plist")

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/all-lookupFunction.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/all-lookupFunction.swift
@@ -10,6 +10,18 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal enum PlistFiles {
+  internal enum Configuration {
+    private static let _document = PlistDocument(path: "configuration.plist")
+    internal static let environment: String = _document["Environment"]
+    internal static let flags: [Bool] = _document["Flags"]
+    internal static let mixed: [Any] = _document["Mixed"]
+    internal static let mixed2: [Any] = _document["Mixed2"]
+    internal static let names: [String] = _document["Names"]
+    internal static let one: Int = _document["One"]
+    internal static let options: [String: Any] = _document["Options"]
+    internal static let primes: [Int] = _document["Primes"]
+    internal static let zero: Int = _document["Zero"]
+  }
   internal enum Info {
     private static let _document = PlistDocument(path: "Info.plist")
     internal static let cfBundleDevelopmentRegion: String = _document["CFBundleDevelopmentRegion"]
@@ -41,18 +53,6 @@ internal enum PlistFiles {
     internal static let userDate: Date = _document["User Date"]
     internal static let userFloat: Double = _document["User Float"]
     internal static let userInteger: Int = _document["User Integer"]
-  }
-  internal enum Configuration {
-    private static let _document = PlistDocument(path: "configuration.plist")
-    internal static let environment: String = _document["Environment"]
-    internal static let flags: [Bool] = _document["Flags"]
-    internal static let mixed: [Any] = _document["Mixed"]
-    internal static let mixed2: [Any] = _document["Mixed2"]
-    internal static let names: [String] = _document["Names"]
-    internal static let one: Int = _document["One"]
-    internal static let options: [String: Any] = _document["Options"]
-    internal static let primes: [Int] = _document["Primes"]
-    internal static let zero: Int = _document["Zero"]
   }
   internal enum ShoppingList {
     internal static let items: [String] = arrayFromPlist(at: "shopping-list.plist")

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/all-preservePath.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/all-preservePath.swift
@@ -10,6 +10,18 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal enum PlistFiles {
+  internal enum Configuration {
+    private static let _document = PlistDocument(path: "configuration.plist")
+    internal static let environment: String = _document["Environment"]
+    internal static let flags: [Bool] = _document["Flags"]
+    internal static let mixed: [Any] = _document["Mixed"]
+    internal static let mixed2: [Any] = _document["Mixed2"]
+    internal static let names: [String] = _document["Names"]
+    internal static let one: Int = _document["One"]
+    internal static let options: [String: Any] = _document["Options"]
+    internal static let primes: [Int] = _document["Primes"]
+    internal static let zero: Int = _document["Zero"]
+  }
   internal enum Info {
     private static let _document = PlistDocument(path: "Info.plist")
     internal static let cfBundleDevelopmentRegion: String = _document["CFBundleDevelopmentRegion"]
@@ -41,18 +53,6 @@ internal enum PlistFiles {
     internal static let userDate: Date = _document["User Date"]
     internal static let userFloat: Double = _document["User Float"]
     internal static let userInteger: Int = _document["User Integer"]
-  }
-  internal enum Configuration {
-    private static let _document = PlistDocument(path: "configuration.plist")
-    internal static let environment: String = _document["Environment"]
-    internal static let flags: [Bool] = _document["Flags"]
-    internal static let mixed: [Any] = _document["Mixed"]
-    internal static let mixed2: [Any] = _document["Mixed2"]
-    internal static let names: [String] = _document["Names"]
-    internal static let one: Int = _document["One"]
-    internal static let options: [String: Any] = _document["Options"]
-    internal static let primes: [Int] = _document["Primes"]
-    internal static let zero: Int = _document["Zero"]
   }
   internal enum ShoppingList {
     internal static let items: [String] = arrayFromPlist(at: "shopping-list.plist")

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/all-publicAccess.swift
@@ -10,6 +10,18 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length type_body_length
 public enum PlistFiles {
+  public enum Configuration {
+    private static let _document = PlistDocument(path: "configuration.plist")
+    public static let environment: String = _document["Environment"]
+    public static let flags: [Bool] = _document["Flags"]
+    public static let mixed: [Any] = _document["Mixed"]
+    public static let mixed2: [Any] = _document["Mixed2"]
+    public static let names: [String] = _document["Names"]
+    public static let one: Int = _document["One"]
+    public static let options: [String: Any] = _document["Options"]
+    public static let primes: [Int] = _document["Primes"]
+    public static let zero: Int = _document["Zero"]
+  }
   public enum Info {
     private static let _document = PlistDocument(path: "Info.plist")
     public static let cfBundleDevelopmentRegion: String = _document["CFBundleDevelopmentRegion"]
@@ -41,18 +53,6 @@ public enum PlistFiles {
     public static let userDate: Date = _document["User Date"]
     public static let userFloat: Double = _document["User Float"]
     public static let userInteger: Int = _document["User Integer"]
-  }
-  public enum Configuration {
-    private static let _document = PlistDocument(path: "configuration.plist")
-    public static let environment: String = _document["Environment"]
-    public static let flags: [Bool] = _document["Flags"]
-    public static let mixed: [Any] = _document["Mixed"]
-    public static let mixed2: [Any] = _document["Mixed2"]
-    public static let names: [String] = _document["Names"]
-    public static let one: Int = _document["One"]
-    public static let options: [String: Any] = _document["Options"]
-    public static let primes: [Int] = _document["Primes"]
-    public static let zero: Int = _document["Zero"]
   }
   public enum ShoppingList {
     public static let items: [String] = arrayFromPlist(at: "shopping-list.plist")

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/all.swift
@@ -10,6 +10,18 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal enum PlistFiles {
+  internal enum Configuration {
+    private static let _document = PlistDocument(path: "configuration.plist")
+    internal static let environment: String = _document["Environment"]
+    internal static let flags: [Bool] = _document["Flags"]
+    internal static let mixed: [Any] = _document["Mixed"]
+    internal static let mixed2: [Any] = _document["Mixed2"]
+    internal static let names: [String] = _document["Names"]
+    internal static let one: Int = _document["One"]
+    internal static let options: [String: Any] = _document["Options"]
+    internal static let primes: [Int] = _document["Primes"]
+    internal static let zero: Int = _document["Zero"]
+  }
   internal enum Info {
     private static let _document = PlistDocument(path: "Info.plist")
     internal static let cfBundleDevelopmentRegion: String = _document["CFBundleDevelopmentRegion"]
@@ -41,18 +53,6 @@ internal enum PlistFiles {
     internal static let userDate: Date = _document["User Date"]
     internal static let userFloat: Double = _document["User Float"]
     internal static let userInteger: Int = _document["User Integer"]
-  }
-  internal enum Configuration {
-    private static let _document = PlistDocument(path: "configuration.plist")
-    internal static let environment: String = _document["Environment"]
-    internal static let flags: [Bool] = _document["Flags"]
-    internal static let mixed: [Any] = _document["Mixed"]
-    internal static let mixed2: [Any] = _document["Mixed2"]
-    internal static let names: [String] = _document["Names"]
-    internal static let one: Int = _document["One"]
-    internal static let options: [String: Any] = _document["Options"]
-    internal static let primes: [Int] = _document["Primes"]
-    internal static let zero: Int = _document["Zero"]
   }
   internal enum ShoppingList {
     internal static let items: [String] = arrayFromPlist(at: "shopping-list.plist")

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/all-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/all-customBundle.swift
@@ -10,6 +10,18 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal enum PlistFiles {
+  internal enum Configuration {
+    private static let _document = PlistDocument(path: "configuration.plist")
+    internal static let environment: String = _document["Environment"]
+    internal static let flags: [Bool] = _document["Flags"]
+    internal static let mixed: [Any] = _document["Mixed"]
+    internal static let mixed2: [Any] = _document["Mixed2"]
+    internal static let names: [String] = _document["Names"]
+    internal static let one: Int = _document["One"]
+    internal static let options: [String: Any] = _document["Options"]
+    internal static let primes: [Int] = _document["Primes"]
+    internal static let zero: Int = _document["Zero"]
+  }
   internal enum Info {
     private static let _document = PlistDocument(path: "Info.plist")
     internal static let cfBundleDevelopmentRegion: String = _document["CFBundleDevelopmentRegion"]
@@ -41,18 +53,6 @@ internal enum PlistFiles {
     internal static let userDate: Date = _document["User Date"]
     internal static let userFloat: Double = _document["User Float"]
     internal static let userInteger: Int = _document["User Integer"]
-  }
-  internal enum Configuration {
-    private static let _document = PlistDocument(path: "configuration.plist")
-    internal static let environment: String = _document["Environment"]
-    internal static let flags: [Bool] = _document["Flags"]
-    internal static let mixed: [Any] = _document["Mixed"]
-    internal static let mixed2: [Any] = _document["Mixed2"]
-    internal static let names: [String] = _document["Names"]
-    internal static let one: Int = _document["One"]
-    internal static let options: [String: Any] = _document["Options"]
-    internal static let primes: [Int] = _document["Primes"]
-    internal static let zero: Int = _document["Zero"]
   }
   internal enum ShoppingList {
     internal static let items: [String] = arrayFromPlist(at: "shopping-list.plist")

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/all-customName.swift
@@ -10,6 +10,18 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal enum CustomPlist {
+  internal enum Configuration {
+    private static let _document = PlistDocument(path: "configuration.plist")
+    internal static let environment: String = _document["Environment"]
+    internal static let flags: [Bool] = _document["Flags"]
+    internal static let mixed: [Any] = _document["Mixed"]
+    internal static let mixed2: [Any] = _document["Mixed2"]
+    internal static let names: [String] = _document["Names"]
+    internal static let one: Int = _document["One"]
+    internal static let options: [String: Any] = _document["Options"]
+    internal static let primes: [Int] = _document["Primes"]
+    internal static let zero: Int = _document["Zero"]
+  }
   internal enum Info {
     private static let _document = PlistDocument(path: "Info.plist")
     internal static let cfBundleDevelopmentRegion: String = _document["CFBundleDevelopmentRegion"]
@@ -41,18 +53,6 @@ internal enum CustomPlist {
     internal static let userDate: Date = _document["User Date"]
     internal static let userFloat: Double = _document["User Float"]
     internal static let userInteger: Int = _document["User Integer"]
-  }
-  internal enum Configuration {
-    private static let _document = PlistDocument(path: "configuration.plist")
-    internal static let environment: String = _document["Environment"]
-    internal static let flags: [Bool] = _document["Flags"]
-    internal static let mixed: [Any] = _document["Mixed"]
-    internal static let mixed2: [Any] = _document["Mixed2"]
-    internal static let names: [String] = _document["Names"]
-    internal static let one: Int = _document["One"]
-    internal static let options: [String: Any] = _document["Options"]
-    internal static let primes: [Int] = _document["Primes"]
-    internal static let zero: Int = _document["Zero"]
   }
   internal enum ShoppingList {
     internal static let items: [String] = arrayFromPlist(at: "shopping-list.plist")

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/all-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/all-forceFileNameEnum.swift
@@ -10,6 +10,18 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal enum PlistFiles {
+  internal enum Configuration {
+    private static let _document = PlistDocument(path: "configuration.plist")
+    internal static let environment: String = _document["Environment"]
+    internal static let flags: [Bool] = _document["Flags"]
+    internal static let mixed: [Any] = _document["Mixed"]
+    internal static let mixed2: [Any] = _document["Mixed2"]
+    internal static let names: [String] = _document["Names"]
+    internal static let one: Int = _document["One"]
+    internal static let options: [String: Any] = _document["Options"]
+    internal static let primes: [Int] = _document["Primes"]
+    internal static let zero: Int = _document["Zero"]
+  }
   internal enum Info {
     private static let _document = PlistDocument(path: "Info.plist")
     internal static let cfBundleDevelopmentRegion: String = _document["CFBundleDevelopmentRegion"]
@@ -41,18 +53,6 @@ internal enum PlistFiles {
     internal static let userDate: Date = _document["User Date"]
     internal static let userFloat: Double = _document["User Float"]
     internal static let userInteger: Int = _document["User Integer"]
-  }
-  internal enum Configuration {
-    private static let _document = PlistDocument(path: "configuration.plist")
-    internal static let environment: String = _document["Environment"]
-    internal static let flags: [Bool] = _document["Flags"]
-    internal static let mixed: [Any] = _document["Mixed"]
-    internal static let mixed2: [Any] = _document["Mixed2"]
-    internal static let names: [String] = _document["Names"]
-    internal static let one: Int = _document["One"]
-    internal static let options: [String: Any] = _document["Options"]
-    internal static let primes: [Int] = _document["Primes"]
-    internal static let zero: Int = _document["Zero"]
   }
   internal enum ShoppingList {
     internal static let items: [String] = arrayFromPlist(at: "shopping-list.plist")

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/all-lookupFunction.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/all-lookupFunction.swift
@@ -10,6 +10,18 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal enum PlistFiles {
+  internal enum Configuration {
+    private static let _document = PlistDocument(path: "configuration.plist")
+    internal static let environment: String = _document["Environment"]
+    internal static let flags: [Bool] = _document["Flags"]
+    internal static let mixed: [Any] = _document["Mixed"]
+    internal static let mixed2: [Any] = _document["Mixed2"]
+    internal static let names: [String] = _document["Names"]
+    internal static let one: Int = _document["One"]
+    internal static let options: [String: Any] = _document["Options"]
+    internal static let primes: [Int] = _document["Primes"]
+    internal static let zero: Int = _document["Zero"]
+  }
   internal enum Info {
     private static let _document = PlistDocument(path: "Info.plist")
     internal static let cfBundleDevelopmentRegion: String = _document["CFBundleDevelopmentRegion"]
@@ -41,18 +53,6 @@ internal enum PlistFiles {
     internal static let userDate: Date = _document["User Date"]
     internal static let userFloat: Double = _document["User Float"]
     internal static let userInteger: Int = _document["User Integer"]
-  }
-  internal enum Configuration {
-    private static let _document = PlistDocument(path: "configuration.plist")
-    internal static let environment: String = _document["Environment"]
-    internal static let flags: [Bool] = _document["Flags"]
-    internal static let mixed: [Any] = _document["Mixed"]
-    internal static let mixed2: [Any] = _document["Mixed2"]
-    internal static let names: [String] = _document["Names"]
-    internal static let one: Int = _document["One"]
-    internal static let options: [String: Any] = _document["Options"]
-    internal static let primes: [Int] = _document["Primes"]
-    internal static let zero: Int = _document["Zero"]
   }
   internal enum ShoppingList {
     internal static let items: [String] = arrayFromPlist(at: "shopping-list.plist")

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/all-preservePath.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/all-preservePath.swift
@@ -10,6 +10,18 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal enum PlistFiles {
+  internal enum Configuration {
+    private static let _document = PlistDocument(path: "configuration.plist")
+    internal static let environment: String = _document["Environment"]
+    internal static let flags: [Bool] = _document["Flags"]
+    internal static let mixed: [Any] = _document["Mixed"]
+    internal static let mixed2: [Any] = _document["Mixed2"]
+    internal static let names: [String] = _document["Names"]
+    internal static let one: Int = _document["One"]
+    internal static let options: [String: Any] = _document["Options"]
+    internal static let primes: [Int] = _document["Primes"]
+    internal static let zero: Int = _document["Zero"]
+  }
   internal enum Info {
     private static let _document = PlistDocument(path: "Info.plist")
     internal static let cfBundleDevelopmentRegion: String = _document["CFBundleDevelopmentRegion"]
@@ -41,18 +53,6 @@ internal enum PlistFiles {
     internal static let userDate: Date = _document["User Date"]
     internal static let userFloat: Double = _document["User Float"]
     internal static let userInteger: Int = _document["User Integer"]
-  }
-  internal enum Configuration {
-    private static let _document = PlistDocument(path: "configuration.plist")
-    internal static let environment: String = _document["Environment"]
-    internal static let flags: [Bool] = _document["Flags"]
-    internal static let mixed: [Any] = _document["Mixed"]
-    internal static let mixed2: [Any] = _document["Mixed2"]
-    internal static let names: [String] = _document["Names"]
-    internal static let one: Int = _document["One"]
-    internal static let options: [String: Any] = _document["Options"]
-    internal static let primes: [Int] = _document["Primes"]
-    internal static let zero: Int = _document["Zero"]
   }
   internal enum ShoppingList {
     internal static let items: [String] = arrayFromPlist(at: "shopping-list.plist")

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/all-publicAccess.swift
@@ -10,6 +10,18 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length type_body_length
 public enum PlistFiles {
+  public enum Configuration {
+    private static let _document = PlistDocument(path: "configuration.plist")
+    public static let environment: String = _document["Environment"]
+    public static let flags: [Bool] = _document["Flags"]
+    public static let mixed: [Any] = _document["Mixed"]
+    public static let mixed2: [Any] = _document["Mixed2"]
+    public static let names: [String] = _document["Names"]
+    public static let one: Int = _document["One"]
+    public static let options: [String: Any] = _document["Options"]
+    public static let primes: [Int] = _document["Primes"]
+    public static let zero: Int = _document["Zero"]
+  }
   public enum Info {
     private static let _document = PlistDocument(path: "Info.plist")
     public static let cfBundleDevelopmentRegion: String = _document["CFBundleDevelopmentRegion"]
@@ -41,18 +53,6 @@ public enum PlistFiles {
     public static let userDate: Date = _document["User Date"]
     public static let userFloat: Double = _document["User Float"]
     public static let userInteger: Int = _document["User Integer"]
-  }
-  public enum Configuration {
-    private static let _document = PlistDocument(path: "configuration.plist")
-    public static let environment: String = _document["Environment"]
-    public static let flags: [Bool] = _document["Flags"]
-    public static let mixed: [Any] = _document["Mixed"]
-    public static let mixed2: [Any] = _document["Mixed2"]
-    public static let names: [String] = _document["Names"]
-    public static let one: Int = _document["One"]
-    public static let options: [String: Any] = _document["Options"]
-    public static let primes: [Int] = _document["Primes"]
-    public static let zero: Int = _document["Zero"]
   }
   public enum ShoppingList {
     public static let items: [String] = arrayFromPlist(at: "shopping-list.plist")

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/all.swift
@@ -10,6 +10,18 @@ import Foundation
 
 // swiftlint:disable identifier_name line_length type_body_length
 internal enum PlistFiles {
+  internal enum Configuration {
+    private static let _document = PlistDocument(path: "configuration.plist")
+    internal static let environment: String = _document["Environment"]
+    internal static let flags: [Bool] = _document["Flags"]
+    internal static let mixed: [Any] = _document["Mixed"]
+    internal static let mixed2: [Any] = _document["Mixed2"]
+    internal static let names: [String] = _document["Names"]
+    internal static let one: Int = _document["One"]
+    internal static let options: [String: Any] = _document["Options"]
+    internal static let primes: [Int] = _document["Primes"]
+    internal static let zero: Int = _document["Zero"]
+  }
   internal enum Info {
     private static let _document = PlistDocument(path: "Info.plist")
     internal static let cfBundleDevelopmentRegion: String = _document["CFBundleDevelopmentRegion"]
@@ -41,18 +53,6 @@ internal enum PlistFiles {
     internal static let userDate: Date = _document["User Date"]
     internal static let userFloat: Double = _document["User Float"]
     internal static let userInteger: Int = _document["User Integer"]
-  }
-  internal enum Configuration {
-    private static let _document = PlistDocument(path: "configuration.plist")
-    internal static let environment: String = _document["Environment"]
-    internal static let flags: [Bool] = _document["Flags"]
-    internal static let mixed: [Any] = _document["Mixed"]
-    internal static let mixed2: [Any] = _document["Mixed2"]
-    internal static let names: [String] = _document["Names"]
-    internal static let one: Int = _document["One"]
-    internal static let options: [String: Any] = _document["Options"]
-    internal static let primes: [Int] = _document["Primes"]
-    internal static let zero: Int = _document["Zero"]
   }
   internal enum ShoppingList {
     internal static let items: [String] = arrayFromPlist(at: "shopping-list.plist")

--- a/Sources/TestUtils/Fixtures/StencilContexts/Fonts/defaults.yaml
+++ b/Sources/TestUtils/Fixtures/StencilContexts/Fonts/defaults.yaml
@@ -63,12 +63,12 @@ families:
     style: "Roman"
   name: "Avenir"
 - fonts:
-  - name: "ZapfDingbatsITC"
-    path: "Fonts/ZapfDingbats.ttf"
-    style: "Regular"
-  name: "Zapf Dingbats"
-- fonts:
   - name: "private"
     path: "Fonts/class.ttf"
     style: "internal"
   name: "public"
+- fonts:
+  - name: "ZapfDingbatsITC"
+    path: "Fonts/ZapfDingbats.ttf"
+    style: "Regular"
+  name: "Zapf Dingbats"

--- a/Sources/TestUtils/Fixtures/StencilContexts/IB-macOS/all.yaml
+++ b/Sources/TestUtils/Fixtures/StencilContexts/IB-macOS/all.yaml
@@ -124,18 +124,6 @@ storyboards:
     module: "AppKit"
     moduleIsPlaceholder: false
     type: "NSStoryboardSegue"
-  - customClass: ""
-    customModule: ""
-    identifier: "Sheet"
-    module: "AppKit"
-    moduleIsPlaceholder: false
-    type: "NSStoryboardSegue"
-  - customClass: ""
-    customModule: ""
-    identifier: "Show"
-    module: "AppKit"
-    moduleIsPlaceholder: false
-    type: "NSStoryboardSegue"
   - customClass: "RotateSegue"
     customModule: "NotCurrentModule"
     identifier: "private"
@@ -148,6 +136,18 @@ storyboards:
     module: "SwiftGen"
     moduleIsPlaceholder: false
     type: "ZoomSegue"
+  - customClass: ""
+    customModule: ""
+    identifier: "Sheet"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    identifier: "Show"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
 - name: "Placeholder"
   platform: "macOS"
   scenes:

--- a/Sources/TestUtils/Fixtures/StencilContexts/IB-macOS/messages.yaml
+++ b/Sources/TestUtils/Fixtures/StencilContexts/IB-macOS/messages.yaml
@@ -71,18 +71,6 @@ storyboards:
     module: "AppKit"
     moduleIsPlaceholder: false
     type: "NSStoryboardSegue"
-  - customClass: ""
-    customModule: ""
-    identifier: "Sheet"
-    module: "AppKit"
-    moduleIsPlaceholder: false
-    type: "NSStoryboardSegue"
-  - customClass: ""
-    customModule: ""
-    identifier: "Show"
-    module: "AppKit"
-    moduleIsPlaceholder: false
-    type: "NSStoryboardSegue"
   - customClass: "RotateSegue"
     customModule: "NotCurrentModule"
     identifier: "private"
@@ -95,3 +83,15 @@ storyboards:
     module: "SwiftGen"
     moduleIsPlaceholder: false
     type: "ZoomSegue"
+  - customClass: ""
+    customModule: ""
+    identifier: "Sheet"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"
+  - customClass: ""
+    customModule: ""
+    identifier: "Show"
+    module: "AppKit"
+    moduleIsPlaceholder: false
+    type: "NSStoryboardSegue"

--- a/Sources/TestUtils/Fixtures/StencilContexts/Plist/all.yaml
+++ b/Sources/TestUtils/Fixtures/StencilContexts/Plist/all.yaml
@@ -1,6 +1,148 @@
 files:
 - document:
     data:
+      Environment: "development"
+      Flags:
+      - true
+      - false
+      - true
+      Mixed:
+      - "One"
+      - 1
+      - true
+      Mixed2:
+      - 1e-1
+      - 1
+      - true
+      Names:
+      - "John"
+      - "Peter"
+      - "Nick"
+      One: 1
+      Options:
+        Animation Style: "Party Mode"
+      Primes:
+      - 2
+      - 3
+      - 5
+      - 7
+      Zero: 0
+    metadata:
+      properties:
+        Environment:
+          type: "String"
+        Flags:
+          element:
+            type: "Bool"
+          type: "Array"
+        Mixed:
+          element:
+            items:
+            - type: "String"
+            - type: "Int"
+            - type: "Bool"
+            type: "Any"
+          type: "Array"
+        Mixed2:
+          element:
+            items:
+            - type: "Double"
+            - type: "Int"
+            - type: "Bool"
+            type: "Any"
+          type: "Array"
+        Names:
+          element:
+            type: "String"
+          type: "Array"
+        One:
+          type: "Int"
+        Options:
+          properties:
+            Animation Style:
+              type: "String"
+          type: "Dictionary"
+        Primes:
+          element:
+            type: "Int"
+          type: "Array"
+        Zero:
+          type: "Int"
+      type: "Dictionary"
+  documents:
+  - data:
+      Environment: "development"
+      Flags:
+      - true
+      - false
+      - true
+      Mixed:
+      - "One"
+      - 1
+      - true
+      Mixed2:
+      - 1e-1
+      - 1
+      - true
+      Names:
+      - "John"
+      - "Peter"
+      - "Nick"
+      One: 1
+      Options:
+        Animation Style: "Party Mode"
+      Primes:
+      - 2
+      - 3
+      - 5
+      - 7
+      Zero: 0
+    metadata:
+      properties:
+        Environment:
+          type: "String"
+        Flags:
+          element:
+            type: "Bool"
+          type: "Array"
+        Mixed:
+          element:
+            items:
+            - type: "String"
+            - type: "Int"
+            - type: "Bool"
+            type: "Any"
+          type: "Array"
+        Mixed2:
+          element:
+            items:
+            - type: "Double"
+            - type: "Int"
+            - type: "Bool"
+            type: "Any"
+          type: "Array"
+        Names:
+          element:
+            type: "String"
+          type: "Array"
+        One:
+          type: "Int"
+        Options:
+          properties:
+            Animation Style:
+              type: "String"
+          type: "Dictionary"
+        Primes:
+          element:
+            type: "Int"
+          type: "Array"
+        Zero:
+          type: "Int"
+      type: "Dictionary"
+  name: "configuration"
+  path: "configuration.plist"
+- document:
+    data:
       CFBundleDevelopmentRegion: "en"
       CFBundleDisplayName: "${PRODUCT_NAME}"
       CFBundleExecutable: "${EXECUTABLE_NAME}"
@@ -265,148 +407,6 @@ files:
       type: "Dictionary"
   name: "Info"
   path: "Info.plist"
-- document:
-    data:
-      Environment: "development"
-      Flags:
-      - true
-      - false
-      - true
-      Mixed:
-      - "One"
-      - 1
-      - true
-      Mixed2:
-      - 1e-1
-      - 1
-      - true
-      Names:
-      - "John"
-      - "Peter"
-      - "Nick"
-      One: 1
-      Options:
-        Animation Style: "Party Mode"
-      Primes:
-      - 2
-      - 3
-      - 5
-      - 7
-      Zero: 0
-    metadata:
-      properties:
-        Environment:
-          type: "String"
-        Flags:
-          element:
-            type: "Bool"
-          type: "Array"
-        Mixed:
-          element:
-            items:
-            - type: "String"
-            - type: "Int"
-            - type: "Bool"
-            type: "Any"
-          type: "Array"
-        Mixed2:
-          element:
-            items:
-            - type: "Double"
-            - type: "Int"
-            - type: "Bool"
-            type: "Any"
-          type: "Array"
-        Names:
-          element:
-            type: "String"
-          type: "Array"
-        One:
-          type: "Int"
-        Options:
-          properties:
-            Animation Style:
-              type: "String"
-          type: "Dictionary"
-        Primes:
-          element:
-            type: "Int"
-          type: "Array"
-        Zero:
-          type: "Int"
-      type: "Dictionary"
-  documents:
-  - data:
-      Environment: "development"
-      Flags:
-      - true
-      - false
-      - true
-      Mixed:
-      - "One"
-      - 1
-      - true
-      Mixed2:
-      - 1e-1
-      - 1
-      - true
-      Names:
-      - "John"
-      - "Peter"
-      - "Nick"
-      One: 1
-      Options:
-        Animation Style: "Party Mode"
-      Primes:
-      - 2
-      - 3
-      - 5
-      - 7
-      Zero: 0
-    metadata:
-      properties:
-        Environment:
-          type: "String"
-        Flags:
-          element:
-            type: "Bool"
-          type: "Array"
-        Mixed:
-          element:
-            items:
-            - type: "String"
-            - type: "Int"
-            - type: "Bool"
-            type: "Any"
-          type: "Array"
-        Mixed2:
-          element:
-            items:
-            - type: "Double"
-            - type: "Int"
-            - type: "Bool"
-            type: "Any"
-          type: "Array"
-        Names:
-          element:
-            type: "String"
-          type: "Array"
-        One:
-          type: "Int"
-        Options:
-          properties:
-            Animation Style:
-              type: "String"
-          type: "Dictionary"
-        Primes:
-          element:
-            type: "Int"
-          type: "Array"
-        Zero:
-          type: "Int"
-      type: "Dictionary"
-  name: "configuration"
-  path: "configuration.plist"
 - document:
     data:
     - "Eggs"


### PR DESCRIPTION
This should fix https://github.com/SwiftGen/SwiftGen/issues/891, as well as slightly affect the performance due to no need to lowercase keys on every comparison during the sorting.
