### PR TITLE
Allow dropping `$` from positional variants in StringsDict

### DIFF
--- a/Sources/SwiftGenKit/Parsers/Strings/StringsDictEntry.swift
+++ b/Sources/SwiftGenKit/Parsers/Strings/StringsDictEntry.swift
@@ -141,7 +141,7 @@ extension StringsDict {
   /// - Parameter formatKey: The formatKey from which the variable names should be parsed.
   /// - Returns: An array of discovered variable names, their range within the `formatKey` and the positional argument.
   private static func variableNames(fromFormatKey formatKey: String) -> [VariableNameResult] {
-    let pattern = #"%(?>(\d+)\$)?#@([\w\.\p{Pd}]+)@"#
+    let pattern = #"%(?>(\d+)\$?)?#@([\w\.\p{Pd}]+)@"#
     guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else {
       fatalError("Unable to compile regular expression when parsing StringsDict entries")
     }


### PR DESCRIPTION
Xcode accepts with `$` dropped, which I tested myself with a Demo project, so we should consider accepting that style as well.
This fixes #915.

* [ ] I've started my branch from the `develop` branch (gitflow)
  * [ ] And I've selected `develop` as the "base" branch for this Pull Request I'm about to create
* [ ] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself  
      _(or added `#trivial` to the PR title if I think it doesn't warrant a mention in the CHANGELOG)_
  * [ ] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
  * [ ] Add a period and 2 spaces at the end of your short entry description
  * [ ] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

