### PR TITLE
Point Stencil to use correct repo URL.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -66,7 +66,7 @@
       },
       {
         "package": "Stencil",
-        "repositoryURL": "https://github.com/kylef/Stencil.git",
+        "repositoryURL": "https://github.com/stencilproject/Stencil.git",
         "state": {
           "branch": null,
           "revision": "973e190edf5d09274e4a6bc2e636c86899ed84c3",

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.6"),
     .package(url: "https://github.com/kylef/Commander.git", from: "0.9.1"),
     .package(url: "https://github.com/kylef/PathKit.git", from: "1.0.1"),
-    .package(url: "https://github.com/kylef/Stencil.git", from: "0.14.1"),
+    .package(url: "https://github.com/stencilproject/Stencil.git", from: "0.14.1"),
     .package(url: "https://github.com/shibapm/Komondor.git", from: "1.1.1"),
     .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", from: "2.8.0"),
     .package(url: "https://github.com/tid-kijyun/Kanna.git", from: "5.2.7")


### PR DESCRIPTION
This repo has moved from `https://github.com/kylef/Stencil.git` to `https://github.com/stencilproject/Stencil.git`, and from XCode 13.3 (or even earlier) this started to emit warnings, because `StencilSwiftKit` and `SwiftGen` pointed to different URL:s.

This changes `SwiftGen` to use the new URL, fixing the warning.