### PR TITLE
Support Swift Package Plugins: Adds a task to include a `.artifactbundle` with the release assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ _None_
   [#823](https://github.com/SwiftGen/SwiftGen/issues/823)
   [#846](https://github.com/SwiftGen/SwiftGen/pull/846)
 
+* Added `.artifactbundle` release uploads to support SE-0325 Swift Plugins.  
+  [nicorichard](https://github.com/nicorichard)
+  [#913](https://github.com/SwiftGen/SwiftGen/issues/913)
+
 ### Bug Fixes
 
 _None_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ _None_
 * Added `.artifactbundle` release uploads to support SE-0325 Swift Plugins.  
   [nicorichard](https://github.com/nicorichard)
   [#913](https://github.com/SwiftGen/SwiftGen/issues/913)
+  [#926](https://github.com/SwiftGen/SwiftGen/pull/926)
 
 ### Bug Fixes
 

--- a/Documentation/Articles/SwiftGen-Build-Tool-Package-Plugins.md
+++ b/Documentation/Articles/SwiftGen-Build-Tool-Package-Plugins.md
@@ -6,7 +6,7 @@ Using this new functionality it is possible to create a SwiftGen plugin for our 
 
 ## Making the SwiftGen binary available to your plugin
 
-Simply add the following binary target to your `Package.swift`, each SwiftGen release includes a `.artifactbundle` compatible with Swift Plugin development.
+Simply add the following binary target to your `Package.swift`. Each recent SwiftGen release includes a `.artifactbundle` compatible with Swift Plugin development.
 
 ```swift
 targets: [

--- a/Documentation/Articles/SwiftGen-Build-Tool-Package-Plugins.md
+++ b/Documentation/Articles/SwiftGen-Build-Tool-Package-Plugins.md
@@ -1,0 +1,70 @@
+# Creating a SwiftGen Build Tool Package Plugin
+
+[SE-0325](https://github.com/apple/swift-evolution/blob/main/proposals/0325-swiftpm-additional-plugin-apis.md) introduced the ability to create Swift Package Plugins for our Swift Packages, and it was officially released in [Swift 5.6](https://github.com/apple/swift/blob/main/CHANGELOG.md#swift-56).
+
+Using this new functionality it is possible to create a SwiftGen plugin for our Swift Packages which automatically keeps our generated files up to date.
+
+## Making the SwiftGen binary available to your plugin
+
+Simply add the following binary target to your `Package.swift`, each SwiftGen release includes a `.artifactbundle` compatible with Swift Plugin development.
+
+```swift
+targets: [
+    .plugin(
+        name: "YourSwiftGenPlugin",
+        capability: .buildTool(),
+        dependencies: [
+            "swiftgen"
+        ]
+    ),    
+    .binaryTarget(
+        name: "swiftgen",
+        url: "https://github.com/SwiftGen/SwiftGen/releases/download/6.5.1/swiftgen.artifactbundle.zip",
+        checksum: "a8e445b41ac0fd81459e07657ee19445ff6cbeef64eb0b3df51637b85f925da8"
+    )
+]
+```
+
+> 👋 Remember to replace the version and checksum with appropriate values, you can find the most recent SwiftGen releases [HERE](https://github.com/SwiftGen/SwiftGen/releases)
+
+## Using the tool in your plugin
+
+After the SwiftGen binary has been introduced to your package, your plugin will be able to execute SwiftGen by searching the context for a tool named `swiftgen`.
+
+A barebones example:
+
+```swift
+import PackagePlugin
+import Foundation
+
+@main
+struct SwiftGenPlugin: BuildToolPlugin {
+    func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
+        [
+            Command.prebuildCommand(
+                displayName: "Running SwiftGen",
+                executable: try context.tool(named: "swiftgen").path,
+                arguments: [
+                    "config",
+                    "run",
+                    "--config", "\(target.directory.appending("swiftgen.yml"))"
+                ],
+                environment: [
+                    "PROJECT_DIR": "\(context.package.directory)",
+                    "TARGET_NAME": "\(target.name)",
+                    "DERIVED_SOURCES_DIR": "\(context.pluginWorkDirectory)",
+                ],
+                outputFilesDirectory: context.pluginWorkDirectory
+            )
+        ]
+    }
+}
+```
+
+## Examples
+
+Other examples of Swift package build tool plugins development
+
+- <https://github.com/nicorichard/SwiftGenPlugin>
+- <https://github.com/abertelrud/swiftpm-buildtool-plugin-examples>
+- <https://github.com/apple/swift-package-manager/tree/main/Fixtures/Miscellaneous/Plugins/MyBinaryToolPlugin>

--- a/Documentation/Articles/SwiftGen-Build-Tool-Package-Plugins.md
+++ b/Documentation/Articles/SwiftGen-Build-Tool-Package-Plugins.md
@@ -27,7 +27,7 @@ targets: [
 
 > 👋 Remember to replace the version and checksum with appropriate values, you can find the most recent SwiftGen releases [HERE](https://github.com/SwiftGen/SwiftGen/releases)
 
-> 🧮 To generate the checksum yourself you can use `shasum -a 256 swiftgen.artifactbundle.zip`
+> 🧮 To generate the [checksum](https://developer.apple.com/documentation/swift_packages/target/3583312-checksum) yourself you can use `swift package compute-checksum swiftgen.artifactbundle.zip`.
 
 ## Using the tool in your plugin
 

--- a/Documentation/Articles/SwiftGen-Build-Tool-Package-Plugins.md
+++ b/Documentation/Articles/SwiftGen-Build-Tool-Package-Plugins.md
@@ -27,6 +27,8 @@ targets: [
 
 > 👋 Remember to replace the version and checksum with appropriate values, you can find the most recent SwiftGen releases [HERE](https://github.com/SwiftGen/SwiftGen/releases)
 
+> 🧮 To generate the checksum yourself you can use `shasum -a 256 swiftgen.artifactbundle.zip`
+
 ## Using the tool in your plugin
 
 After the SwiftGen binary has been introduced to your package, your plugin will be able to execute SwiftGen by searching the context for a tool named `swiftgen`.

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -24,6 +24,10 @@ This directory contains documentation for various topics related to SwiftGen, su
 
 Most of the SwiftGen provided templates generate code that allows you to load resources at runtime, but in some cases you may want to modify how these resources are loaded. The built-in templates [can be configured to handle these cases](Articles/Customize-loading-of-resources.md) without resorting to custom templates.
 
+### Creating a SwiftGen plugin
+
+Learn how to use SwiftGen [in your Swift Build-Tool/Command Plugin](Articles/SwiftGen-Build-Tool-Package-Plugins.md).
+
 ## [Parsers Documentation](Parsers/)
 
 SwiftGen uses parsers to parse different type of input files, like asset catalogs, strings files, font files, etc.

--- a/rakelib/artifactbundle.info.json.template
+++ b/rakelib/artifactbundle.info.json.template
@@ -1,0 +1,15 @@
+{
+    "schemaVersion": "1.0",
+    "artifacts": {
+        "swiftgen": {
+            "type": "executable",
+            "version": "VERSION",
+            "variants": [
+                {
+                    "path": "swiftgen/bin/swiftgen",
+                    "supportedTriples": ["x86_64-apple-macosx", "arm64-apple-macosx"]
+                },
+            ]
+        }
+    }
+}

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -170,7 +170,7 @@ namespace :release do
   task :github => :artifactbundle do
     v = Utils.podspec_version('SwiftGen')
 
-    artifact_paths = [
+    artifact_names = [
       "swiftgen-#{v}.zip",
       "swiftgen.artifactbundle.zip"
     ]    
@@ -179,9 +179,9 @@ namespace :release do
     changelog = `sed -n /'^## #{v}$'/,/'^## '/p CHANGELOG.md`.gsub(/^## .*$/, '').strip
 
     # Append checksums for our generated artifacts
-    changelog << "\n### Checksums\n"
-    for artifact_path in artifact_paths
-      changelog << "- #{artifact_path} #{Digest::SHA256.file(artifact_path)}"
+    changelog << "\n\n### Checksums\n"
+    for artifact_name in artifact_names
+      changelog << "\n- #{artifact_name} `#{Digest::SHA256.file("#{BUILD_DIR}/#{artifact_name}")}`"
     end
 
     Utils.print_header "Releasing version #{v} on GitHub"
@@ -193,8 +193,8 @@ namespace :release do
     end
    
     # Upload our artifacts
-    for artifact_path in artifact_paths
-      github_upload(json, artifact_path)
+    for artifact_name in artifact_names
+      github_upload(json, artifact_name)
     end
   end
 

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -132,7 +132,7 @@ namespace :release do
     end
 
     # Zip the bundle
-    `cd #{BUILD_DIR}/swiftgen.artifactbundle; zip -r ../swiftgen-#{Utils.podspec_version('SwiftGen')}.artifactbundle.zip .`
+    `cd #{BUILD_DIR}; zip -r swiftgen.artifactbundle.zip swiftgen.artifactbundle/`
   end
 
   def post(url, content_type)
@@ -153,7 +153,7 @@ namespace :release do
     JSON.parse(response.body)
   end
 
-  def github_upload(filename)
+  def github_upload(json, filename)
     upload_url = json['upload_url'].gsub(/\{.*\}/, "?name=#{filename}")
     zipfile = "#{BUILD_DIR}/#{filename}"
     zipsize = File.size(zipfile)
@@ -178,8 +178,8 @@ namespace :release do
       req.body = { tag_name: v, name: v, body: changelog, draft: false, prerelease: false }.to_json
     end
    
-    github_upload("swiftgen-#{v}.zip")
-    github_upload("swiftgen-#{v}.artifactbundle.zip")
+    github_upload(json, "swiftgen-#{v}.zip")
+    github_upload(json, "swiftgen.artifactbundle.zip")
   end
 
   desc 'pod trunk push SwiftGen to CocoaPods'


### PR DESCRIPTION
* [X] I've started my branch from the `develop` branch (gitflow)
  * [X] And I've selected `develop` as the "base" branch for this Pull Request I'm about to create
* [X] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself  
      _(or added `#trivial` to the PR title if I think it doesn't warrant a mention in the CHANGELOG)_
  * [X] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
  * [X] Add a period and 2 spaces at the end of your short entry description
  * [X] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

👋 Hello! This is my first PR on this project, I welcome your suggestions!

### Motivation

In order to create Swift Package plugins, a prebuilt `.artifactbundle` containing the tool must be used. 

At the moment we do not have a one-size-fits-all Package Plugin tooling for SwiftGen, and I'm not sure if given the current Package Plugin limitations we will be able to provide this. 

In the meantime, we should provide a well-known source for the prebuilt binary so that users can easily and safely create their own plugin tooling and have quick access to the latest SwiftGen updates.

### Changes

Added a task to bundle a `.artifactbundle` matching the specifications from [SE-0305](https://github.com/apple/swift-evolution/blob/main/proposals/0305-swiftpm-binary-target-improvements.md)

The bundle has been zipped for significant size savings.

This new format allows users to write Swift Plugins as outlined by [SE-0325](https://github.com/apple/swift-evolution/blob/main/proposals/0325-swiftpm-additional-plugin-apis.md) and made available in Swift 5.6

### How to test

The content of the generated release can be [verified on my fork **HERE**](https://github.com/nicorichard/SwiftGen/releases/tag/6.5.1)

![image](https://user-images.githubusercontent.com/3505591/160426848-6a46cd98-f4fe-4015-8662-af6f46eece7b.png)

I created a SwiftGen SPM plugin (https://github.com/nicorichard/SwiftGenPlugin) which uses the `.artifactbundle` from this release, this can already be linked to any project and used to experiment and test the solution. You can see the plugin working from my repository's Example target, I have also tested the plugin as a remote dependency and everything works as expected.

```swift
print(L10n.localizeMe)
```

🎉

```
I have been localized!
Program ended with exit code: 0
```

### Impact

In order to not impact any existing expectations for the SwiftGen pre-built binary I did not elect to change the format of the provided zip file which is already included in releases. Instead, I have included both formats making this change completely opt-in.

### Solved Issues

This task alone is only a partial solution for #913  

However, I believe that the rest of the solution should be provided through a separate repository ([like my own](https://github.com/nicorichard/SwiftGenPlugin)) or through educating users how they can write their own plugin directly in their project directories.

If the SwiftGen community/maintainers would like, I would be happy to port my example to the SwiftGen organization namespace and continue work on it.

### Notes

- The artifact bundle folder title must match the intended binary target name
- The artifact bundle folder must be embedded into the zip, this was easy to miss but difficult to diagnose