### PR TITLE
Make generated CoreData model class final when model isn't abstract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ _None_
   [Andre113](https://github.com/Andre113)
   [#823](https://github.com/SwiftGen/SwiftGen/issues/823)
   [#846](https://github.com/SwiftGen/SwiftGen/pull/846)
+* CoreData: ensure generated classes are `final` when model isn't abstract.  
+  [grsouza](https://github.com/grsouza)
+  [#940](https://github.com/SwiftGen/SwiftGen/pull/940)
 
 * Added `.artifactbundle` release uploads to support SE-0325 Swift Plugins.  
   [nicorichard](https://github.com/nicorichard)

--- a/Sources/SwiftGenCLI/templates/coredata/swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/coredata/swift4.stencil
@@ -20,6 +20,7 @@ import {{ import }}
 {% for name, entity in model.entities %}
 {% set superclass %}{{ model.entities[entity.superEntity].className|default:"NSManagedObject" }}{% endset %}
 {% set entityClassName %}{{ entity.className|default:"NSManagedObject" }}{% endset %}
+{% set hasChildren %}{% for aName,anEntity in model.entities where anEntity.superEntity == name %}1{% endfor %}{% endset %}
 // MARK: - {{ entity.name }}
 
 {% if not entity.shouldGenerateCode %}
@@ -32,7 +33,7 @@ import {{ import }}
 {% if param.generateObjcName %}
 @objc({{ entityClassName }})
 {% endif %}
-{{ accessModifier }} class {{ entityClassName }}: {{ superclass }} {
+{{ accessModifier }} {% if not entity.isAbstract and not hasChildren %}final {% endif %}class {{ entityClassName }}: {{ superclass }} {
   {% set override %}{% if superclass != "NSManagedObject" %}override {% endif %}{% endset %}
   {{ override }}{{ accessModifier }} class var entityName: String {
     return "{{ entity.name }}"

--- a/Sources/SwiftGenCLI/templates/coredata/swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/coredata/swift5.stencil
@@ -20,6 +20,7 @@ import {{ import }}
 {% for name, entity in model.entities %}
 {% set superclass %}{{ model.entities[entity.superEntity].className|default:"NSManagedObject" }}{% endset %}
 {% set entityClassName %}{{ entity.className|default:"NSManagedObject" }}{% endset %}
+{% set hasChildren %}{% for aName,anEntity in model.entities where anEntity.superEntity == name %}1{% endfor %}{% endset %}
 // MARK: - {{ entity.name }}
 
 {% if not entity.shouldGenerateCode %}
@@ -32,7 +33,7 @@ import {{ import }}
 {% if param.generateObjcName %}
 @objc({{ entityClassName }})
 {% endif %}
-{{ accessModifier }} class {{ entityClassName }}: {{ superclass }} {
+{{ accessModifier }} {% if not entity.isAbstract and not hasChildren %}final {% endif %}class {{ entityClassName }}: {{ superclass }} {
   {% set override %}{% if superclass != "NSManagedObject" %}override {% endif %}{% endset %}
   {{ override }}{{ accessModifier }} class var entityName: String {
     return "{{ entity.name }}"

--- a/Sources/TestUtils/Fixtures/Generated/CoreData/swift4/defaults-extraImports.swift
+++ b/Sources/TestUtils/Fixtures/Generated/CoreData/swift4/defaults-extraImports.swift
@@ -45,7 +45,7 @@ internal class AbstractEntity: NSManagedObject {
 
 // MARK: - ChildEntity
 
-internal class ChildEntity: MainEntity {
+internal final class ChildEntity: MainEntity {
   override internal class var entityName: String {
     return "ChildEntity"
   }
@@ -340,7 +340,7 @@ extension MainEntity {
 
 // MARK: - NewEntity
 
-internal class NewEntity: AbstractEntity {
+internal final class NewEntity: AbstractEntity {
   override internal class var entityName: String {
     return "NewEntity"
   }
@@ -365,7 +365,7 @@ internal class NewEntity: AbstractEntity {
 
 // MARK: - SecondaryEntity
 
-internal class SecondaryEntity: NSManagedObject {
+internal final class SecondaryEntity: NSManagedObject {
   internal class var entityName: String {
     return "SecondaryEntity"
   }

--- a/Sources/TestUtils/Fixtures/Generated/CoreData/swift4/defaults-generateObjcName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/CoreData/swift4/defaults-generateObjcName.swift
@@ -45,7 +45,7 @@ internal class AbstractEntity: NSManagedObject {
 // MARK: - ChildEntity
 
 @objc(ChildEntity)
-internal class ChildEntity: MainEntity {
+internal final class ChildEntity: MainEntity {
   override internal class var entityName: String {
     return "ChildEntity"
   }
@@ -342,7 +342,7 @@ extension MainEntity {
 // MARK: - NewEntity
 
 @objc(NewEntity)
-internal class NewEntity: AbstractEntity {
+internal final class NewEntity: AbstractEntity {
   override internal class var entityName: String {
     return "NewEntity"
   }
@@ -368,7 +368,7 @@ internal class NewEntity: AbstractEntity {
 // MARK: - SecondaryEntity
 
 @objc(SecondaryEntity)
-internal class SecondaryEntity: NSManagedObject {
+internal final class SecondaryEntity: NSManagedObject {
   internal class var entityName: String {
     return "SecondaryEntity"
   }

--- a/Sources/TestUtils/Fixtures/Generated/CoreData/swift4/defaults-importCoreLocation.swift
+++ b/Sources/TestUtils/Fixtures/Generated/CoreData/swift4/defaults-importCoreLocation.swift
@@ -44,7 +44,7 @@ internal class AbstractEntity: NSManagedObject {
 
 // MARK: - ChildEntity
 
-internal class ChildEntity: MainEntity {
+internal final class ChildEntity: MainEntity {
   override internal class var entityName: String {
     return "ChildEntity"
   }
@@ -339,7 +339,7 @@ extension MainEntity {
 
 // MARK: - NewEntity
 
-internal class NewEntity: AbstractEntity {
+internal final class NewEntity: AbstractEntity {
   override internal class var entityName: String {
     return "NewEntity"
   }
@@ -364,7 +364,7 @@ internal class NewEntity: AbstractEntity {
 
 // MARK: - SecondaryEntity
 
-internal class SecondaryEntity: NSManagedObject {
+internal final class SecondaryEntity: NSManagedObject {
   internal class var entityName: String {
     return "SecondaryEntity"
   }

--- a/Sources/TestUtils/Fixtures/Generated/CoreData/swift4/defaults-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/CoreData/swift4/defaults-publicAccess.swift
@@ -43,7 +43,7 @@ public class AbstractEntity: NSManagedObject {
 
 // MARK: - ChildEntity
 
-public class ChildEntity: MainEntity {
+public final class ChildEntity: MainEntity {
   override public class var entityName: String {
     return "ChildEntity"
   }
@@ -338,7 +338,7 @@ extension MainEntity {
 
 // MARK: - NewEntity
 
-public class NewEntity: AbstractEntity {
+public final class NewEntity: AbstractEntity {
   override public class var entityName: String {
     return "NewEntity"
   }
@@ -363,7 +363,7 @@ public class NewEntity: AbstractEntity {
 
 // MARK: - SecondaryEntity
 
-public class SecondaryEntity: NSManagedObject {
+public final class SecondaryEntity: NSManagedObject {
   public class var entityName: String {
     return "SecondaryEntity"
   }

--- a/Sources/TestUtils/Fixtures/Generated/CoreData/swift4/defaults.swift
+++ b/Sources/TestUtils/Fixtures/Generated/CoreData/swift4/defaults.swift
@@ -43,7 +43,7 @@ internal class AbstractEntity: NSManagedObject {
 
 // MARK: - ChildEntity
 
-internal class ChildEntity: MainEntity {
+internal final class ChildEntity: MainEntity {
   override internal class var entityName: String {
     return "ChildEntity"
   }
@@ -338,7 +338,7 @@ extension MainEntity {
 
 // MARK: - NewEntity
 
-internal class NewEntity: AbstractEntity {
+internal final class NewEntity: AbstractEntity {
   override internal class var entityName: String {
     return "NewEntity"
   }
@@ -363,7 +363,7 @@ internal class NewEntity: AbstractEntity {
 
 // MARK: - SecondaryEntity
 
-internal class SecondaryEntity: NSManagedObject {
+internal final class SecondaryEntity: NSManagedObject {
   internal class var entityName: String {
     return "SecondaryEntity"
   }

--- a/Sources/TestUtils/Fixtures/Generated/CoreData/swift5/defaults-extraImports.swift
+++ b/Sources/TestUtils/Fixtures/Generated/CoreData/swift5/defaults-extraImports.swift
@@ -45,7 +45,7 @@ internal class AbstractEntity: NSManagedObject {
 
 // MARK: - ChildEntity
 
-internal class ChildEntity: MainEntity {
+internal final class ChildEntity: MainEntity {
   override internal class var entityName: String {
     return "ChildEntity"
   }
@@ -340,7 +340,7 @@ extension MainEntity {
 
 // MARK: - NewEntity
 
-internal class NewEntity: AbstractEntity {
+internal final class NewEntity: AbstractEntity {
   override internal class var entityName: String {
     return "NewEntity"
   }
@@ -365,7 +365,7 @@ internal class NewEntity: AbstractEntity {
 
 // MARK: - SecondaryEntity
 
-internal class SecondaryEntity: NSManagedObject {
+internal final class SecondaryEntity: NSManagedObject {
   internal class var entityName: String {
     return "SecondaryEntity"
   }

--- a/Sources/TestUtils/Fixtures/Generated/CoreData/swift5/defaults-generateObjcName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/CoreData/swift5/defaults-generateObjcName.swift
@@ -45,7 +45,7 @@ internal class AbstractEntity: NSManagedObject {
 // MARK: - ChildEntity
 
 @objc(ChildEntity)
-internal class ChildEntity: MainEntity {
+internal final class ChildEntity: MainEntity {
   override internal class var entityName: String {
     return "ChildEntity"
   }
@@ -342,7 +342,7 @@ extension MainEntity {
 // MARK: - NewEntity
 
 @objc(NewEntity)
-internal class NewEntity: AbstractEntity {
+internal final class NewEntity: AbstractEntity {
   override internal class var entityName: String {
     return "NewEntity"
   }
@@ -368,7 +368,7 @@ internal class NewEntity: AbstractEntity {
 // MARK: - SecondaryEntity
 
 @objc(SecondaryEntity)
-internal class SecondaryEntity: NSManagedObject {
+internal final class SecondaryEntity: NSManagedObject {
   internal class var entityName: String {
     return "SecondaryEntity"
   }

--- a/Sources/TestUtils/Fixtures/Generated/CoreData/swift5/defaults-importCoreLocation.swift
+++ b/Sources/TestUtils/Fixtures/Generated/CoreData/swift5/defaults-importCoreLocation.swift
@@ -44,7 +44,7 @@ internal class AbstractEntity: NSManagedObject {
 
 // MARK: - ChildEntity
 
-internal class ChildEntity: MainEntity {
+internal final class ChildEntity: MainEntity {
   override internal class var entityName: String {
     return "ChildEntity"
   }
@@ -339,7 +339,7 @@ extension MainEntity {
 
 // MARK: - NewEntity
 
-internal class NewEntity: AbstractEntity {
+internal final class NewEntity: AbstractEntity {
   override internal class var entityName: String {
     return "NewEntity"
   }
@@ -364,7 +364,7 @@ internal class NewEntity: AbstractEntity {
 
 // MARK: - SecondaryEntity
 
-internal class SecondaryEntity: NSManagedObject {
+internal final class SecondaryEntity: NSManagedObject {
   internal class var entityName: String {
     return "SecondaryEntity"
   }

--- a/Sources/TestUtils/Fixtures/Generated/CoreData/swift5/defaults-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/CoreData/swift5/defaults-publicAccess.swift
@@ -43,7 +43,7 @@ public class AbstractEntity: NSManagedObject {
 
 // MARK: - ChildEntity
 
-public class ChildEntity: MainEntity {
+public final class ChildEntity: MainEntity {
   override public class var entityName: String {
     return "ChildEntity"
   }
@@ -338,7 +338,7 @@ extension MainEntity {
 
 // MARK: - NewEntity
 
-public class NewEntity: AbstractEntity {
+public final class NewEntity: AbstractEntity {
   override public class var entityName: String {
     return "NewEntity"
   }
@@ -363,7 +363,7 @@ public class NewEntity: AbstractEntity {
 
 // MARK: - SecondaryEntity
 
-public class SecondaryEntity: NSManagedObject {
+public final class SecondaryEntity: NSManagedObject {
   public class var entityName: String {
     return "SecondaryEntity"
   }

--- a/Sources/TestUtils/Fixtures/Generated/CoreData/swift5/defaults.swift
+++ b/Sources/TestUtils/Fixtures/Generated/CoreData/swift5/defaults.swift
@@ -43,7 +43,7 @@ internal class AbstractEntity: NSManagedObject {
 
 // MARK: - ChildEntity
 
-internal class ChildEntity: MainEntity {
+internal final class ChildEntity: MainEntity {
   override internal class var entityName: String {
     return "ChildEntity"
   }
@@ -338,7 +338,7 @@ extension MainEntity {
 
 // MARK: - NewEntity
 
-internal class NewEntity: AbstractEntity {
+internal final class NewEntity: AbstractEntity {
   override internal class var entityName: String {
     return "NewEntity"
   }
@@ -363,7 +363,7 @@ internal class NewEntity: AbstractEntity {
 
 // MARK: - SecondaryEntity
 
-internal class SecondaryEntity: NSManagedObject {
+internal final class SecondaryEntity: NSManagedObject {
   internal class var entityName: String {
     return "SecondaryEntity"
   }


### PR DESCRIPTION

Change Core Data Swift 5 template for adding support to set a class as `final` when the model isn't abstract.
