### PR TITLE
Support Swift Package plugins: Add artifactbundle to release assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ _None_
   [#823](https://github.com/SwiftGen/SwiftGen/issues/823)
   [#846](https://github.com/SwiftGen/SwiftGen/pull/846)
 
+* Added `.artifactbundle` release uploads to support SE-0325 Swift Plugins.  
+  [nicorichard](https://github.com/nicorichard)
+  [#913](https://github.com/SwiftGen/SwiftGen/issues/913)
+
 ### Bug Fixes
 
 _None_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ _None_
 * Added `.artifactbundle` release uploads to support SE-0325 Swift Plugins.  
   [nicorichard](https://github.com/nicorichard)
   [#913](https://github.com/SwiftGen/SwiftGen/issues/913)
+  [#926](https://github.com/SwiftGen/SwiftGen/pull/926)
 
 ### Bug Fixes
 

--- a/Documentation/Articles/SwiftGen-Build-Tool-Package-Plugins.md
+++ b/Documentation/Articles/SwiftGen-Build-Tool-Package-Plugins.md
@@ -6,7 +6,7 @@ Using this new functionality it is possible to create a SwiftGen plugin for our 
 
 ## Making the SwiftGen binary available to your plugin
 
-Simply add the following binary target to your `Package.swift`, each SwiftGen release includes a `.artifactbundle` compatible with Swift Plugin development.
+Simply add the following binary target to your `Package.swift`. Each recent SwiftGen release includes a `.artifactbundle` compatible with Swift Plugin development.
 
 ```swift
 targets: [

--- a/Documentation/Articles/SwiftGen-Build-Tool-Package-Plugins.md
+++ b/Documentation/Articles/SwiftGen-Build-Tool-Package-Plugins.md
@@ -1,0 +1,70 @@
+# Creating a SwiftGen Build Tool Package Plugin
+
+[SE-0325](https://github.com/apple/swift-evolution/blob/main/proposals/0325-swiftpm-additional-plugin-apis.md) introduced the ability to create Swift Package Plugins for our Swift Packages, and it was officially released in [Swift 5.6](https://github.com/apple/swift/blob/main/CHANGELOG.md#swift-56).
+
+Using this new functionality it is possible to create a SwiftGen plugin for our Swift Packages which automatically keeps our generated files up to date.
+
+## Making the SwiftGen binary available to your plugin
+
+Simply add the following binary target to your `Package.swift`, each SwiftGen release includes a `.artifactbundle` compatible with Swift Plugin development.
+
+```swift
+targets: [
+    .plugin(
+        name: "YourSwiftGenPlugin",
+        capability: .buildTool(),
+        dependencies: [
+            "swiftgen"
+        ]
+    ),    
+    .binaryTarget(
+        name: "swiftgen",
+        url: "https://github.com/SwiftGen/SwiftGen/releases/download/6.5.1/swiftgen.artifactbundle.zip",
+        checksum: "a8e445b41ac0fd81459e07657ee19445ff6cbeef64eb0b3df51637b85f925da8"
+    )
+]
+```
+
+> 👋 Remember to replace the version and checksum with appropriate values, you can find the most recent SwiftGen releases [HERE](https://github.com/SwiftGen/SwiftGen/releases)
+
+## Using the tool in your plugin
+
+After the SwiftGen binary has been introduced to your package, your plugin will be able to execute SwiftGen by searching the context for a tool named `swiftgen`.
+
+A barebones example:
+
+```swift
+import PackagePlugin
+import Foundation
+
+@main
+struct SwiftGenPlugin: BuildToolPlugin {
+    func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
+        [
+            Command.prebuildCommand(
+                displayName: "Running SwiftGen",
+                executable: try context.tool(named: "swiftgen").path,
+                arguments: [
+                    "config",
+                    "run",
+                    "--config", "\(target.directory.appending("swiftgen.yml"))"
+                ],
+                environment: [
+                    "PROJECT_DIR": "\(context.package.directory)",
+                    "TARGET_NAME": "\(target.name)",
+                    "DERIVED_SOURCES_DIR": "\(context.pluginWorkDirectory)",
+                ],
+                outputFilesDirectory: context.pluginWorkDirectory
+            )
+        ]
+    }
+}
+```
+
+## Examples
+
+Other examples of Swift package build tool plugins development
+
+- <https://github.com/nicorichard/SwiftGenPlugin>
+- <https://github.com/abertelrud/swiftpm-buildtool-plugin-examples>
+- <https://github.com/apple/swift-package-manager/tree/main/Fixtures/Miscellaneous/Plugins/MyBinaryToolPlugin>

--- a/Documentation/Articles/SwiftGen-Build-Tool-Package-Plugins.md
+++ b/Documentation/Articles/SwiftGen-Build-Tool-Package-Plugins.md
@@ -27,7 +27,7 @@ targets: [
 
 > 👋 Remember to replace the version and checksum with appropriate values, you can find the most recent SwiftGen releases [HERE](https://github.com/SwiftGen/SwiftGen/releases)
 
-> 🧮 To generate the checksum yourself you can use `shasum -a 256 swiftgen.artifactbundle.zip`
+> 🧮 To generate the [checksum](https://developer.apple.com/documentation/swift_packages/target/3583312-checksum) yourself you can use `swift package compute-checksum swiftgen.artifactbundle.zip`.
 
 ## Using the tool in your plugin
 

--- a/Documentation/Articles/SwiftGen-Build-Tool-Package-Plugins.md
+++ b/Documentation/Articles/SwiftGen-Build-Tool-Package-Plugins.md
@@ -27,6 +27,8 @@ targets: [
 
 > 👋 Remember to replace the version and checksum with appropriate values, you can find the most recent SwiftGen releases [HERE](https://github.com/SwiftGen/SwiftGen/releases)
 
+> 🧮 To generate the checksum yourself you can use `shasum -a 256 swiftgen.artifactbundle.zip`
+
 ## Using the tool in your plugin
 
 After the SwiftGen binary has been introduced to your package, your plugin will be able to execute SwiftGen by searching the context for a tool named `swiftgen`.

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -24,6 +24,10 @@ This directory contains documentation for various topics related to SwiftGen, su
 
 Most of the SwiftGen provided templates generate code that allows you to load resources at runtime, but in some cases you may want to modify how these resources are loaded. The built-in templates [can be configured to handle these cases](Articles/Customize-loading-of-resources.md) without resorting to custom templates.
 
+### Creating a SwiftGen plugin
+
+Learn how to use SwiftGen [in your Swift Build-Tool/Command Plugin](Articles/SwiftGen-Build-Tool-Package-Plugins.md).
+
 ## [Parsers Documentation](Parsers/)
 
 SwiftGen uses parsers to parse different type of input files, like asset catalogs, strings files, font files, etc.

--- a/rakelib/artifactbundle.info.json.template
+++ b/rakelib/artifactbundle.info.json.template
@@ -1,0 +1,15 @@
+{
+    "schemaVersion": "1.0",
+    "artifacts": {
+        "swiftgen": {
+            "type": "executable",
+            "version": "VERSION",
+            "variants": [
+                {
+                    "path": "swiftgen/bin/swiftgen",
+                    "supportedTriples": ["x86_64-apple-macosx", "arm64-apple-macosx"]
+                },
+            ]
+        }
+    }
+}

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -170,7 +170,7 @@ namespace :release do
   task :github => :artifactbundle do
     v = Utils.podspec_version('SwiftGen')
 
-    artifact_paths = [
+    artifact_names = [
       "swiftgen-#{v}.zip",
       "swiftgen.artifactbundle.zip"
     ]    
@@ -179,9 +179,9 @@ namespace :release do
     changelog = `sed -n /'^## #{v}$'/,/'^## '/p CHANGELOG.md`.gsub(/^## .*$/, '').strip
 
     # Append checksums for our generated artifacts
-    changelog << "\n### Checksums\n"
-    for artifact_path in artifact_paths
-      changelog << "- #{artifact_path} #{Digest::SHA256.file(artifact_path)}"
+    changelog << "\n\n### Checksums\n"
+    for artifact_name in artifact_names
+      changelog << "\n- #{artifact_name} `#{Digest::SHA256.file("#{BUILD_DIR}/#{artifact_name}")}`"
     end
 
     Utils.print_header "Releasing version #{v} on GitHub"
@@ -193,8 +193,8 @@ namespace :release do
     end
    
     # Upload our artifacts
-    for artifact_path in artifact_paths
-      github_upload(json, artifact_path)
+    for artifact_name in artifact_names
+      github_upload(json, artifact_name)
     end
   end
 

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -132,7 +132,7 @@ namespace :release do
     end
 
     # Zip the bundle
-    `cd #{BUILD_DIR}/swiftgen.artifactbundle; zip -r ../swiftgen-#{Utils.podspec_version('SwiftGen')}.artifactbundle.zip .`
+    `cd #{BUILD_DIR}; zip -r swiftgen.artifactbundle.zip swiftgen.artifactbundle/`
   end
 
   def post(url, content_type)
@@ -153,7 +153,7 @@ namespace :release do
     JSON.parse(response.body)
   end
 
-  def github_upload(filename)
+  def github_upload(json, filename)
     upload_url = json['upload_url'].gsub(/\{.*\}/, "?name=#{filename}")
     zipfile = "#{BUILD_DIR}/#{filename}"
     zipsize = File.size(zipfile)
@@ -178,8 +178,8 @@ namespace :release do
       req.body = { tag_name: v, name: v, body: changelog, draft: false, prerelease: false }.to_json
     end
    
-    github_upload("swiftgen-#{v}.zip")
-    github_upload("swiftgen-#{v}.artifactbundle.zip")
+    github_upload(json, "swiftgen-#{v}.zip")
+    github_upload(json, "swiftgen.artifactbundle.zip")
   end
 
   desc 'pod trunk push SwiftGen to CocoaPods'


### PR DESCRIPTION
> **Warning** Do not merge: this Draft PR was only created to run CI checks from a PR that came from a fork.

This PR was created by pulling the content of [#926](https://github.com/SwiftGen/SwiftGen/pull/926) in the main repo — instead of being from @nicorichard 's fork — by running `git pull git@github.com:nicorichard/SwiftGen.git develop_artifact_bundle` into this newly created branch. This was done so that CI can run without any security issue (because Danger can't run on forks for security reasons, and only works on PRs that are from this repo) and so that the Danger CI step could analyse and validate the PR.

Once all the warnings found by Danger have been addressed in #926, we should land #926 and close this Draft PR (because 926 is where all the GitHub discussions are).