### PR TITLE
Implement Stencil (file) loader

### DIFF
--- a/.github/workflows/test-spm.yml
+++ b/.github/workflows/test-spm.yml
@@ -26,7 +26,6 @@ jobs:
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-spm-
-      # TODO: This should run the tests once SPM supports testing an executable
       -
-        name: Build
+        name: Run tests
         run: bundle exec rake spm:test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ _None_
   [David Jennes](https://github.com/djbe)
   [#952](https://github.com/SwiftGen/SwiftGen/issues/952)
   [#967](https://github.com/SwiftGen/SwiftGen/pull/967)
+* Fixed Stencil tags that can refer to other templates, such as the `include` tag.  
+  [David Jennes](https://github.com/djbe)
+  [#950](https://github.com/SwiftGen/SwiftGen/issues/950)
+  [#959](https://github.com/SwiftGen/SwiftGen/pull/959)
 
 ### Internal Changes
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/shibapm/Komondor.git",
         "state": {
           "branch": null,
-          "revision": "7c3c6040c01c99b83afc7eaa8f2a8a69337f659a",
-          "version": "1.1.1"
+          "revision": "90b087b1e39069684b1ff4bf915c2aae594f2d60",
+          "version": "1.1.3"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/shibapm/PackageConfig.git",
         "state": {
           "branch": null,
-          "revision": "8a390979f64d0447ecd78abba4786db0d96ff568",
-          "version": "1.0.1"
+          "revision": "58523193c26fb821ed1720dcd8a21009055c7cdb",
+          "version": "1.1.3"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/stencilproject/Stencil.git",
         "state": {
           "branch": null,
-          "revision": "973e190edf5d09274e4a6bc2e636c86899ed84c3",
-          "version": "0.14.1"
+          "revision": "ccd9402682f4c07dac9561befd207c8156e80e20",
+          "version": "0.14.2"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/SwiftGen/StencilSwiftKit.git",
         "state": {
           "branch": null,
-          "revision": "54cbedcdbb4334e03930adcff7343ffaf317bf0f",
-          "version": "2.8.0"
+          "revision": "a329217a79ce9b20557f870b926f7ae9769af05e",
+          "version": "2.9.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,8 @@ let package = Package(
     .package(url: "https://github.com/kylef/Commander.git", from: "0.9.1"),
     .package(url: "https://github.com/kylef/PathKit.git", from: "1.0.1"),
     .package(url: "https://github.com/stencilproject/Stencil.git", from: "0.14.1"),
-    .package(url: "https://github.com/shibapm/Komondor.git", from: "1.1.1"),
-    .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", from: "2.8.0"),
+    .package(url: "https://github.com/shibapm/Komondor.git", .exact("1.1.3")),
+    .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", from: "2.9.0"),
     .package(url: "https://github.com/tid-kijyun/Kanna.git", from: "5.2.7")
   ],
   targets: [

--- a/Sources/SwiftGen/Commander/ParserCLICommands.swift
+++ b/Sources/SwiftGen/Commander/ParserCLICommands.swift
@@ -91,10 +91,11 @@ extension ParserCLI {
           templateFullPath: templatePath
         )
         let templateRealPath = try templateRef.resolvePath(forParser: self)
+        let environment = stencilSwiftEnvironment(templatePaths: [templateRealPath.parent()])
 
         let template = try StencilSwiftTemplate(
           templateString: templateRealPath.read(),
-          environment: stencilSwiftEnvironment()
+          environment: environment
         )
 
         let context = parser.stencilContext()

--- a/Sources/SwiftGenCLI/Config/Config+Run.swift
+++ b/Sources/SwiftGenCLI/Config/Config+Run.swift
@@ -64,9 +64,10 @@ extension ConfigEntry {
 
     for entryOutput in outputs {
       let templateRealPath = try entryOutput.template.resolvePath(forParser: parserCommand, logger: logger)
+      let environment = stencilSwiftEnvironment(templatePaths: [templateRealPath.parent()])
       let template = try StencilSwiftTemplate(
         templateString: templateRealPath.read(),
-        environment: stencilSwiftEnvironment()
+        environment: environment
       )
 
       let enriched = try StencilContext.enrich(context: context, parameters: entryOutput.parameters)

--- a/Sources/TestUtils/TestsHelper.swift
+++ b/Sources/TestUtils/TestsHelper.swift
@@ -91,14 +91,9 @@ public class Fixtures {
     return result
   }
 
-  static func template(for name: String, sub: Directory) -> String {
-    do {
-      // Directly load from SwiftGenFramework bundle
-      let path = Path.bundledTemplates + sub.rawValue.lowercased() + name
-      return try path.read()
-    } catch let error {
-      fatalError("Unable to load fixture \(name)'s content: \(error)")
-    }
+  static func template(for name: String, sub: Directory) -> Path {
+    // Directly load from SwiftGenFramework bundle
+    return Path.bundledTemplates + sub.rawValue.lowercased() + name
   }
 
   static func output(template: String, variation: String, sub: Directory) -> String {

--- a/Sources/TestUtils/VariationGenerator.swift
+++ b/Sources/TestUtils/VariationGenerator.swift
@@ -39,11 +39,16 @@ public extension XCTestCase {
     contextVariations: VariationGenerator? = nil,
     outputExtension: String = "swift"
   ) {
-    let templateString = Fixtures.template(for: "\(templateName).stencil", sub: directory)
-    let template = StencilSwiftTemplate(
-      templateString: templateString,
-      environment: stencilSwiftEnvironment()
-    )
+    let template: StencilSwiftTemplate
+    do {
+      let templateRealPath = Fixtures.template(for: "\(templateName).stencil", sub: directory)
+      template = StencilSwiftTemplate(
+        templateString: try templateRealPath.read(),
+        environment: stencilSwiftEnvironment(templatePaths: [templateRealPath.parent()])
+      )
+    } catch {
+      fatalError("Unable to load fixture \(templateName)'s content: \(error)")
+    }
 
     // default values
     let contextVariations = contextVariations ?? { [(context: $1, suffix: "")] }

--- a/rakelib/dependencies.rake
+++ b/rakelib/dependencies.rake
@@ -11,7 +11,7 @@ namespace :dependencies do
   desc 'Check if the DEPENDENCIES.md file and Package.swift + SwiftGenKit.podspec are in sync'
   # options: Use 'check[plain]' to avoid coloring and dashes. Useful for using in Dangerfile.
   task :check, [:plain] do |_, args|
-    spm_deps = File.open('Package.swift').grep(/\.package\(url: ".+\/(.+?)\.git", from: .+\)/) { Regexp.last_match(1) }
+    spm_deps = File.open('Package.swift').grep(/\.package\(url: ".+\/(.+?)\.git", .+\)/) { Regexp.last_match(1) }
     swiftgenkit_deps = Utils.podspec_as_json('SwiftGenKit')['dependencies'].keys
     all_core_deps = (TOOLS + spm_deps + swiftgenkit_deps).uniq
     documented_deps = File.open('DEPENDENCIES.md').grep(/### (.*)/) { Regexp.last_match(1) }


### PR DESCRIPTION
Fixes #950.

Based myself on [what Sourcery does](https://github.com/krzysztofzablocki/Sourcery/blob/1.8.1/SourceryStencil/Sources/StencilTemplate.swift#L127), namely take the parent folder of the template being used.