### PR TITLE
Fonts: fix issue with access in sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ _None_
   [David Jennes](https://github.com/djbe)
   [#727](https://github.com/SwiftGen/SwiftGen/issues/727)
   [#965](https://github.com/SwiftGen/SwiftGen/pull/965)
+* Fonts: fix file-type check in sandboxed environments.  
+  [David Jennes](https://github.com/djbe)
+  [#952](https://github.com/SwiftGen/SwiftGen/issues/952)
+  [#967](https://github.com/SwiftGen/SwiftGen/pull/967)
 
 ### Internal Changes
 


### PR DESCRIPTION
Try to fix #952.

Getting resource keys of a file can fail in sandbox environments. Until this is fixed somehow, we're better of skipping this check (if the first step fails).