### PR TITLE
Modern spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 * The Swift 4 templates are now deprecated. This means we will no longer test if the generated output is valid Swift code. We will still try to keep these up-to-date with context changes.  
   [David Jennes](https://github.com/djbe)
   [#955](https://github.com/SwiftGen/SwiftGen/pull/955)
+* Our spacing & trimming "hack" is now considered deprecated, and in the next major version we'll switch to Stencil's new "smart" trimming behaviour (see [Stencil documentation](https://stencil.fuller.li/en/latest/templates.html#whitespace-control) for more information). Our built-in templates have already switched to this modern behaviour, you can try it with your own templates by using the `--experimental-modern-spacing` flag.  
+  [David Jennes](https://github.com/djbe)
+  [#976](https://github.com/SwiftGen/SwiftGen/pull/976)
 
 ### New Features
 
@@ -37,6 +40,9 @@
   [David Jennes](https://github.com/djbe)
   [#928](https://github.com/SwiftGen/SwiftGen/issues/928)
   [#961](https://github.com/SwiftGen/SwiftGen/pull/961)
+* Added an experimental flag `--experimental-modern-spacing` to enable modern spacing control, see [Stencil documentation](https://stencil.fuller.li/en/latest/templates.html#whitespace-control) for more information. It will disable our own trimming "hack", and enable Stencil's "smart" trimming.  
+  [David Jennes](https://github.com/djbe)
+  [#976](https://github.com/SwiftGen/SwiftGen/pull/976)
 
 ### Bug Fixes
 
@@ -77,6 +83,9 @@
 * Switched from [Commander](https://github.com/kylef/Commander) to Swift's own [ArgumentParser](https://github.com/apple/swift-argument-parser) library.  
   [David Jennes](https://github.com/djbe)
   [#966](https://github.com/SwiftGen/SwiftGen/pull/966)
+* Updated to Stencil 0.15 and StencilSwiftKit 2.10.  
+  [David Jennes](https://github.com/djbe)
+  [#976](https://github.com/SwiftGen/SwiftGen/pull/976)
 
 ## 6.5.1
 

--- a/Documentation/MigrationGuide.md
+++ b/Documentation/MigrationGuide.md
@@ -11,6 +11,14 @@ All the migration guides for SwiftGen are spread out over a few files, depending
 
 ----
 
+# Migrating to SwiftGen 6.6
+
+## Deprecation of whitespace behaviour
+
+We're deprecating our old workarounds for issues with Stencil whitespace control, now that Stencil supports granular control on how whitespace is generated and trimmed in template output.
+
+Our built-in templates have been adapted for the new behaviour, and you can preview it in your own custom templates using the `--experimental-modern-spacing` CLI flag. Do note that this behaviour is subject to changes until the release of SwiftGen 7.0.
+
 # Migrating to SwiftGen 6.2
 
 ## Deprecation of Application Support lookup for named templates

--- a/Documentation/templates/MigrationGuide.md
+++ b/Documentation/templates/MigrationGuide.md
@@ -4,6 +4,14 @@ There are no major changes in the templates, only a small edge case:
 
 In the `strings` templates, if you were providing a custom `lookupFunction`, the signature of that function has changed. Previously, the function had to accept 2 parameters (table and key), now the function must accept 3 parameters: table, key and value.
 
+### Deprecation notices for template writers
+
+There are a few deprecation notices:
+
+- Our workaround for spacing/trimming is deprecated, and will soon switch to Stencil's "smart" trimming behaviour.
+- StencilSwiftKit's `removeNewlines` filter is deprecated (replaced by Stencil's new syntax).
+- You can see a preview of all these changes by taking a look at our built-in templates, which have been updated to the new syntax. If you'd like to try it for your own templates, use the `--experimental-modern-spacing` CLI flag.
+
 # SwiftGen 6.3 Templates Migration Guide
 
 There are no major changes in the templates, only a small deprecation notice:

--- a/Package.resolved
+++ b/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stencilproject/Stencil.git",
       "state" : {
-        "revision" : "ccd9402682f4c07dac9561befd207c8156e80e20",
-        "version" : "0.14.2"
+        "revision" : "8989f8a18998bd67b1727c2c0798b7c0436aa481",
+        "version" : "0.15.0"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SwiftGen/StencilSwiftKit.git",
       "state" : {
-        "revision" : "a329217a79ce9b20557f870b926f7ae9769af05e",
-        "version" : "2.9.0"
+        "revision" : "631c85b83b89e9b229b2a7d5affe3b24f4a9701e",
+        "version" : "2.10.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,9 +15,9 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.0.0"),
     .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.6"),
     .package(url: "https://github.com/kylef/PathKit.git", from: "1.0.1"),
-    .package(url: "https://github.com/stencilproject/Stencil.git", from: "0.14.1"),
+    .package(url: "https://github.com/stencilproject/Stencil.git", from: "0.15.0"),
     .package(url: "https://github.com/shibapm/Komondor.git", exact: "1.1.3"),
-    .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", from: "2.9.0"),
+    .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", from: "2.10.0"),
     .package(url: "https://github.com/tid-kijyun/Kanna.git", from: "5.2.7")
   ],
   targets: [

--- a/Sources/SwiftGen/Commands/Config/Config Run.swift
+++ b/Sources/SwiftGen/Commands/Config/Config Run.swift
@@ -17,6 +17,9 @@ extension Commands.Config {
     @Flag
     var logLevel: CommandLogLevel = .default
 
+    @OptionGroup(visibility: .hidden)
+    var spacing: Commands.ExperimentalSpacing
+
     func validate() throws {
       try config.validateExists()
     }
@@ -29,7 +32,7 @@ extension Commands.Config {
 
         logMessage(.info, "Executing configuration file \(config.file)")
         try config.file.parent().chdir {
-          try configuration.runCommands(logLevel: commandLogLevel)
+          try configuration.runCommands(modernSpacing: spacing.modernSpacing, logLevel: commandLogLevel)
         }
       } catch let error as Config.Error {
         logMessage(.error, error)

--- a/Sources/SwiftGen/Commands/Run.swift
+++ b/Sources/SwiftGen/Commands/Run.swift
@@ -74,7 +74,12 @@ extension Commands.Run {
       try parser.searchAndParse(paths: paths, filter: filter)
 
       let templateRealPath = try template.reference.resolvePath(forParser: Parser.info)
-      let template = try Template.load(from: templateRealPath, modernSpacing: spacing.modernSpacing)
+      let isBundledTemplate = try template.reference.isBundled(forParser: Parser.info)
+      let template = try Template.load(
+        from: templateRealPath,
+        modernSpacing: isBundledTemplate || spacing.modernSpacing
+      )
+
       let context = parser.stencilContext()
       let enriched = try StencilContext.enrich(context: context, parameters: templateParameters)
       let rendered = try template.render(enriched)

--- a/Sources/SwiftGen/Commands/Run.swift
+++ b/Sources/SwiftGen/Commands/Run.swift
@@ -6,6 +6,7 @@
 
 import ArgumentParser
 import PathKit
+import Stencil
 import StencilSwiftKit
 import SwiftGenCLI
 import SwiftGenKit
@@ -57,6 +58,9 @@ extension Commands.Run {
     @OptionGroup
     var output: Commands.OutputDestination
 
+    @OptionGroup(visibility: .hidden)
+    var spacing: Commands.ExperimentalSpacing
+
     @Argument(help: .init(Parser.info.pathDescription, valueName: "path"))
     var paths: [Path]
 
@@ -70,11 +74,7 @@ extension Commands.Run {
       try parser.searchAndParse(paths: paths, filter: filter)
 
       let templateRealPath = try template.reference.resolvePath(forParser: Parser.info)
-      let template = try StencilSwiftTemplate(
-        templateString: templateRealPath.read(),
-        environment: stencilSwiftEnvironment()
-      )
-
+      let template = try Template.load(from: templateRealPath, modernSpacing: spacing.modernSpacing)
       let context = parser.stencilContext()
       let enriched = try StencilContext.enrich(context: context, parameters: templateParameters)
       let rendered = try template.render(enriched)

--- a/Sources/SwiftGen/Common/ExperimentalFlags.swift
+++ b/Sources/SwiftGen/Common/ExperimentalFlags.swift
@@ -1,0 +1,19 @@
+//
+// SwiftGen
+// Copyright © 2020 SwiftGen
+// MIT Licence
+//
+
+import ArgumentParser
+import PathKit
+import SwiftGenCLI
+
+extension Commands {
+  struct ExperimentalSpacing: ParsableArguments {
+    @Option(
+      name: [.customLong("experimental-modern-spacing")],
+      help: "Enable modern spacing control, i.e. enables Stencil's `smart` trimming."
+    )
+    var modernSpacing: Bool = false
+  }
+}

--- a/Sources/SwiftGen/Version.swift
+++ b/Sources/SwiftGen/Version.swift
@@ -7,6 +7,6 @@
 enum Version {
   static let swiftgen = "6.5.1"
   static let swiftGenKit = "6.5.1"
-  static let stencil = "0.14.1"
-  static let stencilSwiftKit = "2.8.0"
+  static let stencil = "0.15.0"
+  static let stencilSwiftKit = "2.10.0"
 }

--- a/Sources/SwiftGenCLI/Config/Config+Run.swift
+++ b/Sources/SwiftGenCLI/Config/Config+Run.swift
@@ -6,14 +6,19 @@
 
 import AppKit
 import PathKit
+import Stencil
 import StencilSwiftKit
 import SwiftGenKit
 
 extension Config {
-  public func runCommands(logLevel: CommandLogLevel, logger: (LogLevel, String) -> Void = logMessage) throws {
+  public func runCommands(
+    modernSpacing: Bool,
+    logLevel: CommandLogLevel,
+    logger: (LogLevel, String) -> Void = logMessage
+  ) throws {
     let errors = commands.parallelCompactMap { cmd, entry -> Swift.Error? in
       do {
-        try run(parserCommand: cmd, entry: entry, logLevel: logLevel, logger: logger)
+        try run(parserCommand: cmd, entry: entry, modernSpacing: modernSpacing, logLevel: logLevel, logger: logger)
         return nil
       } catch {
         return error
@@ -30,6 +35,7 @@ extension Config {
   private func run(
     parserCommand: ParserCLI,
     entry: ConfigEntry,
+    modernSpacing: Bool,
     logLevel: CommandLogLevel,
     logger: (LogLevel, String) -> Void
   ) throws {
@@ -43,12 +49,12 @@ extension Config {
     }
 
     try entry.checkPaths()
-    try entry.run(parserCommand: parserCommand, logger: logger)
+    try entry.run(parserCommand: parserCommand, modernSpacing: modernSpacing, logger: logger)
   }
 }
 
 extension ConfigEntry {
-  func run(parserCommand: ParserCLI, logger: (LogLevel, String) -> Void) throws {
+  func run(parserCommand: ParserCLI, modernSpacing: Bool, logger: (LogLevel, String) -> Void) throws {
     let context: [String: Any] = try withoutActuallyEscaping(logger) { logger in
       let parser = try parserCommand.parserType.init(options: options) { msg, _, _ in
         logger(.warning, msg)
@@ -64,12 +70,7 @@ extension ConfigEntry {
 
     for entryOutput in outputs {
       let templateRealPath = try entryOutput.template.resolvePath(forParser: parserCommand, logger: logger)
-      let environment = stencilSwiftEnvironment(templatePaths: [templateRealPath.parent()])
-      let template = try StencilSwiftTemplate(
-        templateString: templateRealPath.read(),
-        environment: environment
-      )
-
+      let template = try Template.load(from: templateRealPath, modernSpacing: modernSpacing)
       let enriched = try StencilContext.enrich(context: context, parameters: entryOutput.parameters)
       let rendered = try template.render(enriched)
       let output = OutputDestination.file(entryOutput.output)

--- a/Sources/SwiftGenCLI/Config/Config+Run.swift
+++ b/Sources/SwiftGenCLI/Config/Config+Run.swift
@@ -70,7 +70,9 @@ extension ConfigEntry {
 
     for entryOutput in outputs {
       let templateRealPath = try entryOutput.template.resolvePath(forParser: parserCommand, logger: logger)
-      let template = try Template.load(from: templateRealPath, modernSpacing: modernSpacing)
+      let isBundledTemplate = entryOutput.template.isBundled(forParser: parserCommand)
+      let template = try Template.load(from: templateRealPath, modernSpacing: isBundledTemplate || modernSpacing)
+
       let enriched = try StencilContext.enrich(context: context, parameters: entryOutput.parameters)
       let rendered = try template.render(enriched)
       let output = OutputDestination.file(entryOutput.output)

--- a/Sources/SwiftGenCLI/Template Loader.swift
+++ b/Sources/SwiftGenCLI/Template Loader.swift
@@ -1,0 +1,29 @@
+//
+// SwiftGen
+// Copyright © 2020 SwiftGen
+// MIT Licence
+//
+
+import PathKit
+import Stencil
+import StencilSwiftKit
+
+public extension Template {
+  static func load(from path: Path, modernSpacing: Bool) throws -> Template {
+    if modernSpacing {
+      return try Template(
+        templateString: path.read(),
+        environment: stencilSwiftEnvironment(templatePaths: [path.parent()])
+      )
+    } else {
+      return try StencilSwiftTemplate(
+        templateString: path.read(),
+        environment: stencilSwiftEnvironment(
+          templatePaths: [path.parent()],
+          templateClass: StencilSwiftTemplate.self,
+          trimBehaviour: .nothing
+        )
+      )
+    }
+  }
+}

--- a/Sources/SwiftGenCLI/templates/colors/literals-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/colors/literals-swift4.stencil
@@ -6,10 +6,14 @@
 {% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
 #if os(macOS)
   import AppKit
-  {% if enumName != 'NSColor' %}{{accessModifier}} enum {{enumName}} { }{% endif %}
+  {% if enumName != 'NSColor' %}
+  {{accessModifier}} enum {{enumName}} { }
+  {% endif %}
 #elseif os(iOS) || os(tvOS) || os(watchOS)
   import UIKit
-  {% if enumName != 'UIColor' %}{{accessModifier}} enum {{enumName}} { }{% endif %}
+  {% if enumName != 'UIColor' %}
+  {{accessModifier}} enum {{enumName}} { }
+  {% endif %}
 #endif
 
 // swiftlint:disable superfluous_disable_command
@@ -23,14 +27,14 @@
 {% macro enumBlock colors accessPrefix %}
   {% for color in colors %}
   /// 0x{{color.red}}{{color.green}}{{color.blue}}{{color.alpha}} (r: {{color.red|hexToInt}}, g: {{color.green|hexToInt}}, b: {{color.blue|hexToInt}}, a: {{color.alpha|hexToInt}})
-  {{accessPrefix}}static let {{color.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = #colorLiteral(red: {% call h2f color.red %}, green: {% call h2f color.green %}, blue: {% call h2f color.blue %}, alpha: {% call h2f color.alpha %})
+  {{accessPrefix}}static let {{color.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = #colorLiteral(red: {%+ call h2f color.red %}, green: {%+ call h2f color.green %}, blue: {%+ call h2f color.blue %}, alpha: {%+ call h2f color.alpha %})
   {% endfor %}
 {% endmacro %}
   {% if palettes.count > 1 or param.forceFileNameEnum %}
-  {% set accessPrefix %}{{accessModifier}} {% endset %}
+  {% set accessPrefix %}{{accessModifier}} {%+ endset %}
   {% for palette in palettes %}
   enum {{palette.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call enumBlock palette.colors accessPrefix %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call enumBlock palette.colors accessPrefix %}{% endfilter %}
   }
   {% endfor %}
   {% else %}

--- a/Sources/SwiftGenCLI/templates/colors/literals-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/colors/literals-swift5.stencil
@@ -6,10 +6,14 @@
 {% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
 #if os(macOS)
   import AppKit
-  {% if enumName != 'NSColor' %}{{accessModifier}} enum {{enumName}} { }{% endif %}
+  {% if enumName != 'NSColor' %}
+  {{accessModifier}} enum {{enumName}} { }
+  {% endif %}
 #elseif os(iOS) || os(tvOS) || os(watchOS)
   import UIKit
-  {% if enumName != 'UIColor' %}{{accessModifier}} enum {{enumName}} { }{% endif %}
+  {% if enumName != 'UIColor' %}
+  {{accessModifier}} enum {{enumName}} { }
+  {% endif %}
 #endif
 
 // swiftlint:disable superfluous_disable_command
@@ -23,14 +27,14 @@
 {% macro enumBlock colors accessPrefix %}
   {% for color in colors %}
   /// 0x{{color.red}}{{color.green}}{{color.blue}}{{color.alpha}} (r: {{color.red|hexToInt}}, g: {{color.green|hexToInt}}, b: {{color.blue|hexToInt}}, a: {{color.alpha|hexToInt}})
-  {{accessPrefix}}static let {{color.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = #colorLiteral(red: {% call h2f color.red %}, green: {% call h2f color.green %}, blue: {% call h2f color.blue %}, alpha: {% call h2f color.alpha %})
+  {{accessPrefix}}static let {{color.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = #colorLiteral(red: {%+ call h2f color.red %}, green: {%+ call h2f color.green %}, blue: {%+ call h2f color.blue %}, alpha: {%+ call h2f color.alpha %})
   {% endfor %}
 {% endmacro %}
   {% if palettes.count > 1 or param.forceFileNameEnum %}
-  {% set accessPrefix %}{{accessModifier}} {% endset %}
+  {% set accessPrefix %}{{accessModifier}} {%+ endset %}
   {% for palette in palettes %}
   enum {{palette.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call enumBlock palette.colors accessPrefix %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call enumBlock palette.colors accessPrefix %}{% endfilter %}
   }
   {% endfor %}
   {% else %}

--- a/Sources/SwiftGenCLI/templates/colors/swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/colors/swift4.stencil
@@ -27,13 +27,13 @@
   {% for color in colors %}
   /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#{{color.red}}{{color.green}}{{color.blue}}"></span>
   /// Alpha: {{color.alpha|hexToInt|int255toFloat|percent}} <br/> (0x{{color.red}}{{color.green}}{{color.blue}}{{color.alpha}})
-  {{accessModifier}} static let {{color.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}(rgbaValue: {% call rgbaValue color %})
+  {{accessModifier}} static let {{color.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}(rgbaValue: {%+ call rgbaValue color %})
   {% endfor %}
 {% endmacro %}
   {% if palettes.count > 1 or param.forceFileNameEnum %}
   {% for palette in palettes %}
   {{accessModifier}} enum {{palette.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call enumBlock palette.colors %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call enumBlock palette.colors %}{% endfilter %}
   }
   {% endfor %}
   {% else %}

--- a/Sources/SwiftGenCLI/templates/colors/swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/colors/swift5.stencil
@@ -27,13 +27,13 @@
   {% for color in colors %}
   /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#{{color.red}}{{color.green}}{{color.blue}}"></span>
   /// Alpha: {{color.alpha|hexToInt|int255toFloat|percent}} <br/> (0x{{color.red}}{{color.green}}{{color.blue}}{{color.alpha}})
-  {{accessModifier}} static let {{color.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}(rgbaValue: {% call rgbaValue color %})
+  {{accessModifier}} static let {{color.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}(rgbaValue: {%+ call rgbaValue color %})
   {% endfor %}
 {% endmacro %}
   {% if palettes.count > 1 or param.forceFileNameEnum %}
   {% for palette in palettes %}
   {{accessModifier}} enum {{palette.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call enumBlock palette.colors %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call enumBlock palette.colors %}{% endfilter %}
   }
   {% endfor %}
   {% else %}

--- a/Sources/SwiftGenCLI/templates/coredata/swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/coredata/swift4.stencil
@@ -9,7 +9,9 @@ import Foundation
 import {{ import }}
 {% empty %}
 {# If extraImports is a single String instead of an array, `for` considers it empty but we still have to check if there's a single String value #}
-{% if param.extraImports %}import {{ param.extraImports }}{% endif %}
+{%- if param.extraImports %}
+import {{ param.extraImports }}
+{% endif %}
 {% endfor %}
 
 // swiftlint:disable attributes file_length vertical_whitespace_closing_braces
@@ -33,8 +35,8 @@ import {{ import }}
 {% if param.generateObjcName %}
 @objc({{ entityClassName }})
 {% endif %}
-{{ accessModifier }} {% if not entity.isAbstract and not hasChildren %}final {% endif %}class {{ entityClassName }}: {{ superclass }} {
-  {% set override %}{% if superclass != "NSManagedObject" %}override {% endif %}{% endset %}
+{{ accessModifier }} {%+ if not entity.isAbstract and not hasChildren %}final {%+ endif %}class {{ entityClassName }}: {{ superclass }} {
+  {% set override %}{% if superclass != "NSManagedObject" %}override {%+ endif %}{% endset %}
   {{ override }}{{ accessModifier }} class var entityName: String {
     return "{{ entity.name }}"
   }
@@ -64,7 +66,7 @@ import {{ import }}
       defer { didAccessValue(forKey: key) }
 
       guard let value = primitiveValue(forKey: key) as? {{ rawType }}.RawValue else {
-        {% if unwrapOptional %}fatalError("Could not convert value for key '\(key)' to type '{{ rawType }}.RawValue'"){% else %}return nil{% endif %}
+        {%+ if unwrapOptional %}fatalError("Could not convert value for key '\(key)' to type '{{ rawType }}.RawValue'"){% else %}return nil{% endif +%}
       }
       {% if attribute.userInfo.nonOptionalInit or not unwrapOptional %}
       return {{ rawType }}(rawValue: value)
@@ -74,14 +76,16 @@ import {{ import }}
       }
       return result
       {% endif %}
-    }{% if not attribute.isDerived %}
+    }
+    {% if not attribute.isDerived %}
     set {
       let key = "{{ attribute.name }}"
       willChangeValue(forKey: key)
       defer { didChangeValue(forKey: key) }
 
       setPrimitiveValue(newValue{% if not unwrapOptional %}?{% endif %}.rawValue, forKey: key)
-    }{% endif %}
+    }
+    {% endif %}
   }
   {% elif attribute.usesScalarValueType and attribute.isOptional %}
   {{ accessModifier }} var {{ attribute.name }}: {{ attribute.typeName }}? {
@@ -91,14 +95,16 @@ import {{ import }}
       defer { didAccessValue(forKey: key) }
 
       return primitiveValue(forKey: key) as? {{ attribute.typeName }}
-    }{% if not attribute.isDerived %}
+    }
+    {% if not attribute.isDerived %}
     set {
       let key = "{{ attribute.name }}"
       willChangeValue(forKey: key)
       defer { didChangeValue(forKey: key) }
 
       setPrimitiveValue(newValue, forKey: key)
-    }{% endif %}
+    }
+    {% endif %}
   }
   {% elif attribute.isDerived %}
   {{ accessModifier }} var {{ attribute.name }}: {{ attribute.typeName }}{% if attribute.isOptional %}?{% endif %} {
@@ -116,14 +122,14 @@ import {{ import }}
     {% endif %}
   }
   {% else %}
-  @NSManaged {{ accessModifier }} var {{ attribute.name }}: {{ attribute.typeName }}{% if attribute.isOptional %}?{% endif %}
+  @NSManaged {{ accessModifier }} var {{ attribute.name }}: {{ attribute.typeName }}{% if attribute.isOptional %}?{% endif +%}
   {% endif %}
   {% endfor %}
   {% for relationship in entity.relationships %}
   {% if relationship.isToMany %}
-  @NSManaged {{ accessModifier }} var {{ relationship.name }}: {% if relationship.isOrdered %}NSOrderedSet{% else %}Set<{{ model.entities[relationship.destinationEntity].className|default:"NSManagedObject" }}>{% endif %}{% if relationship.isOptional %}?{% endif %}
+  @NSManaged {{ accessModifier }} var {{ relationship.name }}: {%+ if relationship.isOrdered %}NSOrderedSet{% else %}Set<{{ model.entities[relationship.destinationEntity].className|default:"NSManagedObject" }}>{% endif %}{% if relationship.isOptional %}?{% endif +%}
   {% else %}
-  @NSManaged {{ accessModifier }} var {{ relationship.name }}: {{ model.entities[relationship.destinationEntity].className|default:"NSManagedObject" }}{% if relationship.isOptional %}?{% endif %}
+  @NSManaged {{ accessModifier }} var {{ relationship.name }}: {{ model.entities[relationship.destinationEntity].className|default:"NSManagedObject" }}{% if relationship.isOptional %}?{% endif +%}
   {% endif %}
   {% endfor %}
   {% for fetchedProperty in entity.fetchedProperties %}
@@ -178,21 +184,20 @@ extension {{ entityClassName }} {
 
 extension {{ entityClassName }} {
   {% for fetchRequest in model.fetchRequests[entity.name] %}
-  {% set resultTypeName %}{% filter removeNewlines:"leading" %}
-    {% if fetchRequest.resultType == "Object" %}
+  {% set resultTypeName -%}
+    {%- if fetchRequest.resultType == "Object" -%}
     {{ entityClassName }}
-    {% elif fetchRequest.resultType == "Object ID" %}
+    {%- elif fetchRequest.resultType == "Object ID" -%}
     NSManagedObjectID
-    {% elif fetchRequest.resultType == "Dictionary" %}
+    {%- elif fetchRequest.resultType == "Dictionary" -%}
     [String: Any]
-    {% endif %}
-  {% endfilter %}{% endset %}
-  class func fetch{{ fetchRequest.name | upperFirstLetter }}({% filter removeNewlines:"leading" %}
-    managedObjectContext: NSManagedObjectContext
-    {% for variableName, variableType in fetchRequest.substitutionVariables %}
+    {%- endif -%}
+  {%- endset %}
+  class func fetch{{ fetchRequest.name | upperFirstLetter }}(managedObjectContext: NSManagedObjectContext
+    {%- for variableName, variableType in fetchRequest.substitutionVariables -%}
     , {{ variableName | lowerFirstWord }}: {{ variableType }}
-    {% endfor %}
-  {% endfilter %}) throws -> [{{ resultTypeName }}] {
+    {%- endfor -%}
+  ) throws -> [{{ resultTypeName }}] {
     guard let persistentStoreCoordinator = managedObjectContext.persistentStoreCoordinator else {
       fatalError("Managed object context has no persistent store coordinator for getting fetch request templates")
     }

--- a/Sources/SwiftGenCLI/templates/coredata/swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/coredata/swift5.stencil
@@ -9,7 +9,9 @@ import Foundation
 import {{ import }}
 {% empty %}
 {# If extraImports is a single String instead of an array, `for` considers it empty but we still have to check if there's a single String value #}
-{% if param.extraImports %}import {{ param.extraImports }}{% endif %}
+{%- if param.extraImports %}
+import {{ param.extraImports }}
+{% endif %}
 {% endfor %}
 
 // swiftlint:disable attributes file_length vertical_whitespace_closing_braces
@@ -33,8 +35,8 @@ import {{ import }}
 {% if param.generateObjcName %}
 @objc({{ entityClassName }})
 {% endif %}
-{{ accessModifier }} {% if not entity.isAbstract and not hasChildren %}final {% endif %}class {{ entityClassName }}: {{ superclass }} {
-  {% set override %}{% if superclass != "NSManagedObject" %}override {% endif %}{% endset %}
+{{ accessModifier }} {%+ if not entity.isAbstract and not hasChildren %}final {%+ endif %}class {{ entityClassName }}: {{ superclass }} {
+  {% set override %}{% if superclass != "NSManagedObject" %}override {%+ endif %}{% endset %}
   {{ override }}{{ accessModifier }} class var entityName: String {
     return "{{ entity.name }}"
   }
@@ -64,7 +66,7 @@ import {{ import }}
       defer { didAccessValue(forKey: key) }
 
       guard let value = primitiveValue(forKey: key) as? {{ rawType }}.RawValue else {
-        {% if unwrapOptional %}fatalError("Could not convert value for key '\(key)' to type '{{ rawType }}.RawValue'"){% else %}return nil{% endif %}
+        {%+ if unwrapOptional %}fatalError("Could not convert value for key '\(key)' to type '{{ rawType }}.RawValue'"){% else %}return nil{% endif +%}
       }
       {% if attribute.userInfo.nonOptionalInit or not unwrapOptional %}
       return {{ rawType }}(rawValue: value)
@@ -74,14 +76,16 @@ import {{ import }}
       }
       return result
       {% endif %}
-    }{% if not attribute.isDerived %}
+    }
+    {% if not attribute.isDerived %}
     set {
       let key = "{{ attribute.name }}"
       willChangeValue(forKey: key)
       defer { didChangeValue(forKey: key) }
 
       setPrimitiveValue(newValue{% if not unwrapOptional %}?{% endif %}.rawValue, forKey: key)
-    }{% endif %}
+    }
+    {% endif %}
   }
   {% elif attribute.usesScalarValueType and attribute.isOptional %}
   {{ accessModifier }} var {{ attribute.name }}: {{ attribute.typeName }}? {
@@ -91,14 +95,16 @@ import {{ import }}
       defer { didAccessValue(forKey: key) }
 
       return primitiveValue(forKey: key) as? {{ attribute.typeName }}
-    }{% if not attribute.isDerived %}
+    }
+    {% if not attribute.isDerived %}
     set {
       let key = "{{ attribute.name }}"
       willChangeValue(forKey: key)
       defer { didChangeValue(forKey: key) }
 
       setPrimitiveValue(newValue, forKey: key)
-    }{% endif %}
+    }
+    {% endif %}
   }
   {% elif attribute.isDerived %}
   {{ accessModifier }} var {{ attribute.name }}: {{ attribute.typeName }}{% if attribute.isOptional %}?{% endif %} {
@@ -116,14 +122,14 @@ import {{ import }}
     {% endif %}
   }
   {% else %}
-  @NSManaged {{ accessModifier }} var {{ attribute.name }}: {{ attribute.typeName }}{% if attribute.isOptional %}?{% endif %}
+  @NSManaged {{ accessModifier }} var {{ attribute.name }}: {{ attribute.typeName }}{% if attribute.isOptional %}?{% endif +%}
   {% endif %}
   {% endfor %}
   {% for relationship in entity.relationships %}
   {% if relationship.isToMany %}
-  @NSManaged {{ accessModifier }} var {{ relationship.name }}: {% if relationship.isOrdered %}NSOrderedSet{% else %}Set<{{ model.entities[relationship.destinationEntity].className|default:"NSManagedObject" }}>{% endif %}{% if relationship.isOptional %}?{% endif %}
+  @NSManaged {{ accessModifier }} var {{ relationship.name }}: {%+ if relationship.isOrdered %}NSOrderedSet{% else %}Set<{{ model.entities[relationship.destinationEntity].className|default:"NSManagedObject" }}>{% endif %}{% if relationship.isOptional %}?{% endif +%}
   {% else %}
-  @NSManaged {{ accessModifier }} var {{ relationship.name }}: {{ model.entities[relationship.destinationEntity].className|default:"NSManagedObject" }}{% if relationship.isOptional %}?{% endif %}
+  @NSManaged {{ accessModifier }} var {{ relationship.name }}: {{ model.entities[relationship.destinationEntity].className|default:"NSManagedObject" }}{% if relationship.isOptional %}?{% endif +%}
   {% endif %}
   {% endfor %}
   {% for fetchedProperty in entity.fetchedProperties %}
@@ -178,21 +184,20 @@ extension {{ entityClassName }} {
 
 extension {{ entityClassName }} {
   {% for fetchRequest in model.fetchRequests[entity.name] %}
-  {% set resultTypeName %}{% filter removeNewlines:"leading" %}
-    {% if fetchRequest.resultType == "Object" %}
+  {% set resultTypeName -%}
+    {%- if fetchRequest.resultType == "Object" -%}
     {{ entityClassName }}
-    {% elif fetchRequest.resultType == "Object ID" %}
+    {%- elif fetchRequest.resultType == "Object ID" -%}
     NSManagedObjectID
-    {% elif fetchRequest.resultType == "Dictionary" %}
+    {%- elif fetchRequest.resultType == "Dictionary" -%}
     [String: Any]
-    {% endif %}
-  {% endfilter %}{% endset %}
-  class func fetch{{ fetchRequest.name | upperFirstLetter }}({% filter removeNewlines:"leading" %}
-    managedObjectContext: NSManagedObjectContext
-    {% for variableName, variableType in fetchRequest.substitutionVariables %}
+    {%- endif -%}
+  {%- endset %}
+  class func fetch{{ fetchRequest.name | upperFirstLetter }}(managedObjectContext: NSManagedObjectContext
+    {%- for variableName, variableType in fetchRequest.substitutionVariables -%}
     , {{ variableName | lowerFirstWord }}: {{ variableType }}
-    {% endfor %}
-  {% endfilter %}) throws -> [{{ resultTypeName }}] {
+    {%- endfor -%}
+  ) throws -> [{{ resultTypeName }}] {
     guard let persistentStoreCoordinator = managedObjectContext.persistentStoreCoordinator else {
       fatalError("Managed object context has no persistent store coordinator for getting fetch request templates")
     }

--- a/Sources/SwiftGenCLI/templates/files/flat-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/files/flat-swift4.stencil
@@ -21,9 +21,9 @@ import Foundation
   {% endfor %}
 {% endmacro %}
 {% macro fileBlock file %}
-  /// {% if file.path and param.preservePath %}{{file.path}}/{% endif %}{{file.name}}{% if file.ext %}.{{file.ext}}{% endif %}
+  /// {%+ if file.path and param.preservePath %}{{file.path}}/{% endif %}{{file.name}}{% if file.ext %}.{{file.ext}}{% endif +%}
   {% set identifier %}{{ file.name }}{% if useExt %}.{{ file.ext }}{% endif %}{% endset %}
-  {{accessModifier}} static let {{identifier|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{resourceType}}(name: "{{file.name}}", ext: {% if file.ext %}"{{file.ext}}"{% else %}nil{% endif %}, relativePath: "{{file.path if param.preservePath}}", mimeType: "{{file.mimeType}}")
+  {{accessModifier}} static let {{identifier|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{resourceType}}(name: "{{file.name}}", ext: {%+ if file.ext %}"{{file.ext}}"{% else %}nil{% endif %}, relativePath: "{{file.path if param.preservePath}}", mimeType: "{{file.mimeType}}")
 {% endmacro %}
 {% macro dirBlock directory %}
   {% for file in directory.files %}

--- a/Sources/SwiftGenCLI/templates/files/flat-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/files/flat-swift5.stencil
@@ -21,9 +21,9 @@ import Foundation
   {% endfor %}
 {% endmacro %}
 {% macro fileBlock file %}
-  /// {% if file.path and param.preservePath %}{{file.path}}/{% endif %}{{file.name}}{% if file.ext %}.{{file.ext}}{% endif %}
+  /// {%+ if file.path and param.preservePath %}{{file.path}}/{% endif %}{{file.name}}{% if file.ext %}.{{file.ext}}{% endif +%}
   {% set identifier %}{{ file.name }}{% if useExt %}.{{ file.ext }}{% endif %}{% endset %}
-  {{accessModifier}} static let {{identifier|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{resourceType}}(name: "{{file.name}}", ext: {% if file.ext %}"{{file.ext}}"{% else %}nil{% endif %}, relativePath: "{{file.path if param.preservePath}}", mimeType: "{{file.mimeType}}")
+  {{accessModifier}} static let {{identifier|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{resourceType}}(name: "{{file.name}}", ext: {%+ if file.ext %}"{{file.ext}}"{% else %}nil{% endif %}, relativePath: "{{file.path if param.preservePath}}", mimeType: "{{file.mimeType}}")
 {% endmacro %}
 {% macro dirBlock directory %}
   {% for file in directory.files %}

--- a/Sources/SwiftGenCLI/templates/files/structured-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/files/structured-swift4.stencil
@@ -21,19 +21,19 @@ import Foundation
   {% endfor %}
 {% endmacro %}
 {% macro fileBlock file %}
-  /// {% if file.path and param.preservePath %}{{file.path}}/{% endif %}{{file.name}}{% if file.ext %}.{{file.ext}}{% endif %}
+  /// {%+ if file.path and param.preservePath %}{{file.path}}/{% endif %}{{file.name}}{% if file.ext %}.{{file.ext}}{% endif +%}
   {% set identifier %}{{ file.name }}{% if useExt %}.{{ file.ext }}{% endif %}{% endset %}
-  {{accessModifier}} static let {{identifier|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{resourceType}}(name: "{{file.name}}", ext: {% if file.ext %}"{{file.ext}}"{% else %}nil{% endif %}, relativePath: "{{file.path if param.preservePath}}", mimeType: "{{file.mimeType}}")
+  {{accessModifier}} static let {{identifier|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{resourceType}}(name: "{{file.name}}", ext: {%+ if file.ext %}"{{file.ext}}"{% else %}nil{% endif %}, relativePath: "{{file.path if param.preservePath}}", mimeType: "{{file.mimeType}}")
 {% endmacro %}
 {% macro dirBlock directory parent %}
   {% set fullDir %}{{parent}}{{directory.name}}/{% endset %}
   /// {{ fullDir }}
   {{accessModifier}} enum {{directory.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
     {% for file in directory.files %}
-    {% filter indent:2 %}{% call fileBlock file %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call fileBlock file %}{% endfilter %}
     {% endfor %}
     {% for dir in directory.directories %}
-    {% filter indent:2 %}{% call dirBlock dir fullDir %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call dirBlock dir fullDir %}{% endfilter %}
     {% endfor %}
   }
 {% endmacro %}
@@ -43,7 +43,7 @@ import Foundation
   {% if groups.count > 1 or param.forceFileNameEnum %}
   {% for group in groups %}
   {{accessModifier}} enum {{group.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call groupBlock group %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call groupBlock group %}{% endfilter %}
   }
   {% endfor %}
   {% else %}

--- a/Sources/SwiftGenCLI/templates/files/structured-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/files/structured-swift5.stencil
@@ -21,19 +21,19 @@ import Foundation
   {% endfor %}
 {% endmacro %}
 {% macro fileBlock file %}
-  /// {% if file.path and param.preservePath %}{{file.path}}/{% endif %}{{file.name}}{% if file.ext %}.{{file.ext}}{% endif %}
+  /// {%+ if file.path and param.preservePath %}{{file.path}}/{% endif %}{{file.name}}{% if file.ext %}.{{file.ext}}{% endif +%}
   {% set identifier %}{{ file.name }}{% if useExt %}.{{ file.ext }}{% endif %}{% endset %}
-  {{accessModifier}} static let {{identifier|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{resourceType}}(name: "{{file.name}}", ext: {% if file.ext %}"{{file.ext}}"{% else %}nil{% endif %}, relativePath: "{{file.path if param.preservePath}}", mimeType: "{{file.mimeType}}")
+  {{accessModifier}} static let {{identifier|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{resourceType}}(name: "{{file.name}}", ext: {%+ if file.ext %}"{{file.ext}}"{% else %}nil{% endif %}, relativePath: "{{file.path if param.preservePath}}", mimeType: "{{file.mimeType}}")
 {% endmacro %}
 {% macro dirBlock directory parent %}
   {% set fullDir %}{{parent}}{{directory.name}}/{% endset %}
   /// {{ fullDir }}
   {{accessModifier}} enum {{directory.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
     {% for file in directory.files %}
-    {% filter indent:2 %}{% call fileBlock file %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call fileBlock file %}{% endfilter %}
     {% endfor %}
     {% for dir in directory.directories %}
-    {% filter indent:2 %}{% call dirBlock dir fullDir %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call dirBlock dir fullDir %}{% endfilter %}
     {% endfor %}
   }
 {% endmacro %}
@@ -43,7 +43,7 @@ import Foundation
   {% if groups.count > 1 or param.forceFileNameEnum %}
   {% for group in groups %}
   {{accessModifier}} enum {{group.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call groupBlock group %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call groupBlock group %}{% endfilter %}
   }
   {% endfor %}
   {% else %}

--- a/Sources/SwiftGenCLI/templates/fonts/swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/fonts/swift4.stencil
@@ -21,13 +21,13 @@
 // MARK: - Fonts
 
 // swiftlint:disable identifier_name line_length type_body_length
-{% macro transformPath path %}{% filter removeNewlines %}
-  {% if param.preservePath %}
+{% macro transformPath path %}
+  {%- if param.preservePath -%}
     {{path}}
-  {% else %}
+  {%- else -%}
     {{path|basename}}
-  {% endif %}
-{% endfilter %}{% endmacro %}
+  {%- endif -%}
+{% endmacro %}
 {{accessModifier}} enum {{param.enumName|default:"FontFamily"}} {
   {% for family in families %}
   {{accessModifier}} enum {{family.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {

--- a/Sources/SwiftGenCLI/templates/fonts/swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/fonts/swift5.stencil
@@ -20,13 +20,13 @@
 // MARK: - Fonts
 
 // swiftlint:disable identifier_name line_length type_body_length
-{% macro transformPath path %}{% filter removeNewlines %}
-  {% if param.preservePath %}
+{% macro transformPath path %}
+  {%- if param.preservePath -%}
     {{path}}
-  {% else %}
+  {%- else -%}
     {{path|basename}}
-  {% endif %}
-{% endfilter %}{% endmacro %}
+  {%- endif -%}
+{% endmacro %}
 {{accessModifier}} enum {{param.enumName|default:"FontFamily"}} {
   {% for family in families %}
   {{accessModifier}} enum {{family.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {

--- a/Sources/SwiftGenCLI/templates/ib/scenes-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/ib/scenes-swift4.stencil
@@ -19,20 +19,20 @@ import {{module}}
 
 // swiftlint:disable explicit_type_interface identifier_name line_length prefer_self_in_static_references
 // swiftlint:disable type_body_length type_name
-{% macro moduleName item %}{% filter removeNewlines %}
-  {% if item.moduleIsPlaceholder %}
+{% macro moduleName item %}
+  {%- if item.moduleIsPlaceholder -%}
     {{ env.PRODUCT_MODULE_NAME|default:param.module }}
-  {% else %}
+  {%- else -%}
     {{ item.module }}
-  {% endif %}
-{% endfilter %}{% endmacro %}
-{% macro className item %}{% filter removeNewlines %}
-  {% set module %}{% call moduleName item %}{% endset %}
-  {% if module and ( not param.ignoreTargetModule or module != env.PRODUCT_MODULE_NAME and module != param.module ) %}
+  {%- endif -%}
+{% endmacro %}
+{% macro className item %}
+  {%- set module %}{% call moduleName item %}{% endset -%}
+  {%- if module and ( not param.ignoreTargetModule or module != env.PRODUCT_MODULE_NAME and module != param.module ) -%}
     {{module}}.
-  {% endif %}
+  {%- endif -%}
   {{item.type}}
-{% endfilter %}{% endmacro %}
+{%- endmacro %}
 {{accessModifier}} enum {{param.enumName|default:"StoryboardScene"}} {
   {% for storyboard in storyboards %}
   {% set storyboardName %}{{storyboard.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}{% endset %}
@@ -63,7 +63,7 @@ import {{module}}
 
 {{accessModifier}} extension StoryboardType {
   static var storyboard: {{prefix}}Storyboard {
-    let name = {% if isAppKit %}NSStoryboard.Name({% endif %}self.storyboardName{% if isAppKit %}){% endif %}
+    let name = {%+ if isAppKit %}NSStoryboard.Name({% endif %}self.storyboardName{% if isAppKit %}){% endif +%}
     {% if param.lookupFunction %}
     return {{param.lookupFunction}}(name)
     {% else %}
@@ -77,7 +77,7 @@ import {{module}}
   {{accessModifier}} let identifier: String
 
   {{accessModifier}} func instantiate() -> T {
-    let identifier = {% if isAppKit %}NSStoryboard.SceneIdentifier({% endif %}self.identifier{% if isAppKit %}){% endif %}
+    let identifier = {%+ if isAppKit %}NSStoryboard.SceneIdentifier({% endif %}self.identifier{% if isAppKit %}){% endif +%}
     guard let controller = storyboard.storyboard.instantiate{{controller}}(withIdentifier: identifier) as? T else {
       fatalError("{{controller}} '\(identifier)' is not of the expected class \(T.self).")
     }

--- a/Sources/SwiftGenCLI/templates/ib/scenes-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/ib/scenes-swift5.stencil
@@ -18,20 +18,20 @@ import {{module}}
 // MARK: - Storyboard Scenes
 
 // swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
-{% macro moduleName item %}{% filter removeNewlines %}
-  {% if item.moduleIsPlaceholder %}
+{% macro moduleName item %}
+  {%- if item.moduleIsPlaceholder -%}
     {{ env.PRODUCT_MODULE_NAME|default:param.module }}
-  {% else %}
+  {%- else -%}
     {{ item.module }}
-  {% endif %}
-{% endfilter %}{% endmacro %}
-{% macro className item %}{% filter removeNewlines %}
-  {% set module %}{% call moduleName item %}{% endset %}
-  {% if module and ( not param.ignoreTargetModule or module != env.PRODUCT_MODULE_NAME and module != param.module ) %}
+  {%- endif -%}
+{% endmacro %}
+{% macro className item %}
+  {%- set module %}{% call moduleName item %}{% endset -%}
+  {%- if module and ( not param.ignoreTargetModule or module != env.PRODUCT_MODULE_NAME and module != param.module ) -%}
     {{module}}.
-  {% endif %}
+  {%- endif -%}
   {{item.type}}
-{% endfilter %}{% endmacro %}
+{%- endmacro %}
 {{accessModifier}} enum {{param.enumName|default:"StoryboardScene"}} {
   {% for storyboard in storyboards %}
   {% set storyboardName %}{{storyboard.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}{% endset %}
@@ -61,7 +61,7 @@ import {{module}}
 
 {{accessModifier}} extension StoryboardType {
   static var storyboard: {{prefix}}Storyboard {
-    let name = {% if isAppKit %}NSStoryboard.Name({% endif %}self.storyboardName{% if isAppKit %}){% endif %}
+    let name = {%+ if isAppKit %}NSStoryboard.Name({% endif %}self.storyboardName{% if isAppKit %}){% endif +%}
     {% if param.lookupFunction %}
     return {{param.lookupFunction}}(name)
     {% else %}
@@ -75,7 +75,7 @@ import {{module}}
   {{accessModifier}} let identifier: String
 
   {{accessModifier}} func instantiate() -> T {
-    let identifier = {% if isAppKit %}NSStoryboard.SceneIdentifier({% endif %}self.identifier{% if isAppKit %}){% endif %}
+    let identifier = {%+ if isAppKit %}NSStoryboard.SceneIdentifier({% endif %}self.identifier{% if isAppKit %}){% endif +%}
     guard let controller = storyboard.storyboard.instantiate{{controller}}(withIdentifier: identifier) as? T else {
       fatalError("{{controller}} '\(identifier)' is not of the expected class \(T.self).")
     }

--- a/Sources/SwiftGenCLI/templates/ib/segues-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/ib/segues-swift4.stencil
@@ -21,7 +21,7 @@ import {{module}}
   {{accessModifier}} enum {{storyboard.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}: String, SegueType {
     {% for segue in storyboard.segues %}
     {% set segueID %}{{segue.identifier|swiftIdentifier:"pretty"|lowerFirstWord}}{% endset %}
-    case {{segueID|escapeReservedKeywords}}{% if segueID != segue.identifier %} = "{{segue.identifier}}"{% endif %}
+    case {{segueID|escapeReservedKeywords}}{% if segueID != segue.identifier %} = "{{segue.identifier}}"{% endif +%}
     {% endfor %}
   }
   {% endfor %}
@@ -32,15 +32,15 @@ import {{module}}
 
 {{accessModifier}} protocol SegueType: RawRepresentable {}
 
-{{accessModifier}} extension {% if isAppKit %}NSSeguePerforming{% else %}UIViewController{% endif %} {
+{{accessModifier}} extension {%+ if isAppKit %}NSSeguePerforming{% else %}UIViewController{% endif %} {
   func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
-    let identifier = {% if isAppKit %}NSStoryboardSegue.Identifier({% endif %}segue.rawValue{% if isAppKit %}){% endif %}
+    let identifier = {%+ if isAppKit %}NSStoryboardSegue.Identifier({% endif %}segue.rawValue{% if isAppKit %}){% endif +%}
     performSegue{% if isAppKit %}?{% endif %}(withIdentifier: identifier, sender: sender)
   }
 }
 
 {{accessModifier}} extension SegueType where RawValue == String {
-  init?(_ segue: {% if isAppKit %}NS{% else %}UI{% endif %}StoryboardSegue) {
+  init?(_ segue: {%+ if isAppKit %}NS{% else %}UI{% endif %}StoryboardSegue) {
     {% if isAppKit %}
     #if swift(>=4.2)
     guard let identifier = segue.identifier else { return nil }

--- a/Sources/SwiftGenCLI/templates/ib/segues-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/ib/segues-swift5.stencil
@@ -21,7 +21,7 @@ import {{module}}
   {{accessModifier}} enum {{storyboard.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}: String, SegueType {
     {% for segue in storyboard.segues %}
     {% set segueID %}{{segue.identifier|swiftIdentifier:"pretty"|lowerFirstWord}}{% endset %}
-    case {{segueID|escapeReservedKeywords}}{% if segueID != segue.identifier %} = "{{segue.identifier}}"{% endif %}
+    case {{segueID|escapeReservedKeywords}}{% if segueID != segue.identifier %} = "{{segue.identifier}}"{% endif +%}
     {% endfor %}
   }
   {% endfor %}
@@ -32,15 +32,15 @@ import {{module}}
 
 {{accessModifier}} protocol SegueType: RawRepresentable {}
 
-{{accessModifier}} extension {% if isAppKit %}NSSeguePerforming{% else %}UIViewController{% endif %} {
+{{accessModifier}} extension {%+ if isAppKit %}NSSeguePerforming{% else %}UIViewController{% endif %} {
   func perform<S: SegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
-    let identifier = {% if isAppKit %}NSStoryboardSegue.Identifier({% endif %}segue.rawValue{% if isAppKit %}){% endif %}
+    let identifier = {%+ if isAppKit %}NSStoryboardSegue.Identifier({% endif %}segue.rawValue{% if isAppKit %}){% endif +%}
     performSegue{% if isAppKit %}?{% endif %}(withIdentifier: identifier, sender: sender)
   }
 }
 
 {{accessModifier}} extension SegueType where RawValue == String {
-  init?(_ segue: {% if isAppKit %}NS{% else %}UI{% endif %}StoryboardSegue) {
+  init?(_ segue: {%+ if isAppKit %}NS{% else %}UI{% endif %}StoryboardSegue) {
     {% if isAppKit %}
     #if swift(>=4.2)
     guard let identifier = segue.identifier else { return nil }

--- a/Sources/SwiftGenCLI/templates/json/inline-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/json/inline-swift4.stencil
@@ -15,61 +15,59 @@ import Foundation
 {% macro documentBlock file document %}
   {% set rootType %}{% call typeBlock document.metadata %}{% endset %}
   {% if document.metadata.type == "Array" %}
-  {{accessModifier}} static let items: {{rootType}} = {% call valueBlock document.data document.metadata %}
+  {{accessModifier}} static let items: {{rootType}} = {%+ call valueBlock document.data document.metadata +%}
   {% elif document.metadata.type == "Dictionary" %}
   {% for key,value in document.metadata.properties %}
-  {{accessModifier}} {% call propertyBlock key value document.data %}
+  {{accessModifier}} {%+ call propertyBlock key value document.data %}
   {% endfor %}
   {% else %}
-  {{accessModifier}} static let value: {{rootType}} = {% call valueBlock document.data document.metadata %}
+  {{accessModifier}} static let value: {{rootType}} = {%+ call valueBlock document.data document.metadata +%}
   {% endif %}
 {% endmacro %}
-{% macro typeBlock metadata %}{% filter removeNewlines:"leading" %}
-  {% if metadata.type == "Array" %}
+{% macro typeBlock metadata %}
+  {%- if metadata.type == "Array" -%}
     [{% call typeBlock metadata.element %}]
-  {% elif metadata.type == "Dictionary" %}
+  {%- elif metadata.type == "Dictionary" -%}
     [String: Any]
-  {% elif metadata.type == "Optional" %}
+  {%- elif metadata.type == "Optional" -%}
     Any?
-  {% else %}
+  {%- else -%}
     {{metadata.type}}
-  {% endif %}
-{% endfilter %}{% endmacro %}
-{% macro propertyBlock key metadata data %}{% filter removeNewlines:"leading" %}
-  {% set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset %}
-  {% set propertyType %}{% call typeBlock metadata %}{% endset %}
-  static let {{propertyName}}: {{propertyType}} = {% call valueBlock data[key] metadata %}
-{% endfilter %}{% endmacro %}
-{% macro valueBlock value metadata %}{% filter removeNewlines:"leading" %}
-  {% if metadata.type == "String" %}
+  {%- endif -%}
+{% endmacro %}
+{% macro propertyBlock key metadata data %}
+  {%- set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset -%}
+  {%- set propertyType %}{% call typeBlock metadata %}{% endset -%}
+  static let {{propertyName}}: {{propertyType}} = {%+ call valueBlock data[key] metadata +%}
+{% endmacro %}
+{% macro valueBlock value metadata %}
+  {%- if metadata.type == "String" -%}
     "{{ value }}"
-  {% elif metadata.type == "Optional" %}
+  {%- elif metadata.type == "Optional" -%}
     nil
-  {% elif metadata.type == "Array" and value %}
-    [{% for value in value %}
-      {% call valueBlock value metadata.element.items[forloop.counter0]|default:metadata.element %}
+  {%- elif metadata.type == "Array" and value -%}
+    [{% for value in value -%}
+      {%- call valueBlock value metadata.element.items[forloop.counter0]|default:metadata.element -%}
       {{ ", " if not forloop.last }}
-    {% endfor %}]
-  {% elif metadata.type == "Dictionary" %}
-    [{% for key,value in value %}
-      "{{key}}": {% call valueBlock value metadata.properties[key] %}
+    {%- endfor %}]
+  {%- elif metadata.type == "Dictionary" -%}
+    [{% for key,value in value -%}
+      "{{key}}": {%+ call valueBlock value metadata.properties[key] -%}
       {{ ", " if not forloop.last }}
-    {% empty %}
+    {%- empty -%}
       :
-    {% endfor %}]
-  {% elif metadata.type == "Bool" %}
-    {% if value %}true{% else %}false{% endif %}
-  {% else %}
+    {%- endfor %}]
+  {%- else -%}
     {{ value }}
-  {% endif %}
-{% endfilter %}{% endmacro %}
+  {%- endif -%}
+{% endmacro %}
 
 // swiftlint:disable identifier_name line_length number_separator type_body_length
 {{accessModifier}} enum {{param.enumName|default:"JSONFiles"}} {
   {% if files.count > 1 or param.forceFileNameEnum %}
   {% for file in files %}
   {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call fileBlock file %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call fileBlock file %}{% endfilter %}
   }
   {% endfor %}
   {% else %}

--- a/Sources/SwiftGenCLI/templates/json/inline-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/json/inline-swift5.stencil
@@ -15,61 +15,59 @@ import Foundation
 {% macro documentBlock file document %}
   {% set rootType %}{% call typeBlock document.metadata %}{% endset %}
   {% if document.metadata.type == "Array" %}
-  {{accessModifier}} static let items: {{rootType}} = {% call valueBlock document.data document.metadata %}
+  {{accessModifier}} static let items: {{rootType}} = {%+ call valueBlock document.data document.metadata +%}
   {% elif document.metadata.type == "Dictionary" %}
   {% for key,value in document.metadata.properties %}
-  {{accessModifier}} {% call propertyBlock key value document.data %}
+  {{accessModifier}} {%+ call propertyBlock key value document.data %}
   {% endfor %}
   {% else %}
-  {{accessModifier}} static let value: {{rootType}} = {% call valueBlock document.data document.metadata %}
+  {{accessModifier}} static let value: {{rootType}} = {%+ call valueBlock document.data document.metadata +%}
   {% endif %}
 {% endmacro %}
-{% macro typeBlock metadata %}{% filter removeNewlines:"leading" %}
-  {% if metadata.type == "Array" %}
+{% macro typeBlock metadata %}
+  {%- if metadata.type == "Array" -%}
     [{% call typeBlock metadata.element %}]
-  {% elif metadata.type == "Dictionary" %}
+  {%- elif metadata.type == "Dictionary" -%}
     [String: Any]
-  {% elif metadata.type == "Optional" %}
+  {%- elif metadata.type == "Optional" -%}
     Any?
-  {% else %}
+  {%- else -%}
     {{metadata.type}}
-  {% endif %}
-{% endfilter %}{% endmacro %}
-{% macro propertyBlock key metadata data %}{% filter removeNewlines:"leading" %}
-  {% set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset %}
-  {% set propertyType %}{% call typeBlock metadata %}{% endset %}
-  static let {{propertyName}}: {{propertyType}} = {% call valueBlock data[key] metadata %}
-{% endfilter %}{% endmacro %}
-{% macro valueBlock value metadata %}{% filter removeNewlines:"leading" %}
-  {% if metadata.type == "String" %}
+  {%- endif -%}
+{% endmacro %}
+{% macro propertyBlock key metadata data %}
+  {%- set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset -%}
+  {%- set propertyType %}{% call typeBlock metadata %}{% endset -%}
+  static let {{propertyName}}: {{propertyType}} = {%+ call valueBlock data[key] metadata +%}
+{% endmacro %}
+{% macro valueBlock value metadata %}
+  {%- if metadata.type == "String" -%}
     "{{ value }}"
-  {% elif metadata.type == "Optional" %}
+  {%- elif metadata.type == "Optional" -%}
     nil
-  {% elif metadata.type == "Array" and value %}
-    [{% for value in value %}
-      {% call valueBlock value metadata.element.items[forloop.counter0]|default:metadata.element %}
+  {%- elif metadata.type == "Array" and value -%}
+    [{% for value in value -%}
+      {%- call valueBlock value metadata.element.items[forloop.counter0]|default:metadata.element -%}
       {{ ", " if not forloop.last }}
-    {% endfor %}]
-  {% elif metadata.type == "Dictionary" %}
-    [{% for key,value in value %}
-      "{{key}}": {% call valueBlock value metadata.properties[key] %}
+    {%- endfor %}]
+  {%- elif metadata.type == "Dictionary" -%}
+    [{% for key,value in value -%}
+      "{{key}}": {%+ call valueBlock value metadata.properties[key] -%}
       {{ ", " if not forloop.last }}
-    {% empty %}
+    {%- empty -%}
       :
-    {% endfor %}]
-  {% elif metadata.type == "Bool" %}
-    {% if value %}true{% else %}false{% endif %}
-  {% else %}
+    {%- endfor %}]
+  {%- else -%}
     {{ value }}
-  {% endif %}
-{% endfilter %}{% endmacro %}
+  {%- endif -%}
+{% endmacro %}
 
 // swiftlint:disable identifier_name line_length number_separator type_body_length
 {{accessModifier}} enum {{param.enumName|default:"JSONFiles"}} {
   {% if files.count > 1 or param.forceFileNameEnum %}
   {% for file in files %}
   {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call fileBlock file %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call fileBlock file %}{% endfilter %}
   }
   {% endfor %}
   {% else %}

--- a/Sources/SwiftGenCLI/templates/json/runtime-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/json/runtime-swift4.stencil
@@ -18,44 +18,43 @@ import Foundation
   {{accessModifier}} static let items: {{rootType}} = objectFromJSON(at: "{% call transformPath file.path %}")
   {% elif document.metadata.type == "Dictionary" %}
   private static let _document = JSONDocument(path: "{% call transformPath file.path %}")
-
   {% for key,value in document.metadata.properties %}
-  {{accessModifier}} {% call propertyBlock key value %}
+  {{accessModifier}} {%+ call propertyBlock key value %}
   {% endfor %}
   {% else %}
   {{accessModifier}} static let value: {{rootType}} = objectFromJSON(at: "{% call transformPath file.path %}")
   {% endif %}
 {% endmacro %}
-{% macro typeBlock metadata %}{% filter removeNewlines:"leading" %}
-  {% if metadata.type == "Array" %}
+{% macro typeBlock metadata %}
+  {%- if metadata.type == "Array" -%}
     [{% call typeBlock metadata.element %}]
-  {% elif metadata.type == "Dictionary" %}
+  {%- elif metadata.type == "Dictionary" -%}
     [String: Any]
-  {% elif metadata.type == "Optional" %}
+  {%- elif metadata.type == "Optional" -%}
     Any?
-  {% else %}
+  {%- else -%}
     {{metadata.type}}
-  {% endif %}
-{% endfilter %}{% endmacro %}
-{% macro propertyBlock key metadata %}{% filter removeNewlines:"leading" %}
-  {% set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset %}
-  {% set propertyType %}{% call typeBlock metadata %}{% endset %}
+  {%- endif -%}
+{% endmacro %}
+{% macro propertyBlock key metadata %}
+  {%- set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset -%}
+  {%- set propertyType %}{% call typeBlock metadata %}{% endset -%}
   static let {{propertyName}}: {{propertyType}} = _document["{{key}}"]
-{% endfilter %}{% endmacro %}
-{% macro transformPath path %}{% filter removeNewlines %}
-  {% if param.preservePath %}
+{% endmacro %}
+{% macro transformPath path %}
+  {%- if param.preservePath -%}
     {{path}}
-  {% else %}
+  {%- else -%}
     {{path|basename}}
-  {% endif %}
-{% endfilter %}{% endmacro %}
+  {%- endif -%}
+{% endmacro %}
 
 // swiftlint:disable identifier_name line_length type_body_length
 {{accessModifier}} enum {{param.enumName|default:"JSONFiles"}} {
   {% if files.count > 1 or param.forceFileNameEnum %}
   {% for file in files %}
   {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call fileBlock file %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call fileBlock file %}{% endfilter %}
   }
   {% endfor %}
   {% else %}

--- a/Sources/SwiftGenCLI/templates/json/runtime-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/json/runtime-swift5.stencil
@@ -18,44 +18,43 @@ import Foundation
   {{accessModifier}} static let items: {{rootType}} = objectFromJSON(at: "{% call transformPath file.path %}")
   {% elif document.metadata.type == "Dictionary" %}
   private static let _document = JSONDocument(path: "{% call transformPath file.path %}")
-
   {% for key,value in document.metadata.properties %}
-  {{accessModifier}} {% call propertyBlock key value %}
+  {{accessModifier}} {%+ call propertyBlock key value %}
   {% endfor %}
   {% else %}
   {{accessModifier}} static let value: {{rootType}} = objectFromJSON(at: "{% call transformPath file.path %}")
   {% endif %}
 {% endmacro %}
-{% macro typeBlock metadata %}{% filter removeNewlines:"leading" %}
-  {% if metadata.type == "Array" %}
+{% macro typeBlock metadata %}
+  {%- if metadata.type == "Array" -%}
     [{% call typeBlock metadata.element %}]
-  {% elif metadata.type == "Dictionary" %}
+  {%- elif metadata.type == "Dictionary" -%}
     [String: Any]
-  {% elif metadata.type == "Optional" %}
+  {%- elif metadata.type == "Optional" -%}
     Any?
-  {% else %}
+  {%- else -%}
     {{metadata.type}}
-  {% endif %}
-{% endfilter %}{% endmacro %}
-{% macro propertyBlock key metadata %}{% filter removeNewlines:"leading" %}
-  {% set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset %}
-  {% set propertyType %}{% call typeBlock metadata %}{% endset %}
+  {%- endif -%}
+{% endmacro %}
+{% macro propertyBlock key metadata %}
+  {%- set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset -%}
+  {%- set propertyType %}{% call typeBlock metadata %}{% endset -%}
   static let {{propertyName}}: {{propertyType}} = _document["{{key}}"]
-{% endfilter %}{% endmacro %}
-{% macro transformPath path %}{% filter removeNewlines %}
-  {% if param.preservePath %}
+{% endmacro %}
+{% macro transformPath path %}
+  {%- if param.preservePath -%}
     {{path}}
-  {% else %}
+  {%- else -%}
     {{path|basename}}
-  {% endif %}
-{% endfilter %}{% endmacro %}
+  {%- endif -%}
+{% endmacro %}
 
 // swiftlint:disable identifier_name line_length type_body_length
 {{accessModifier}} enum {{param.enumName|default:"JSONFiles"}} {
   {% if files.count > 1 or param.forceFileNameEnum %}
   {% for file in files %}
   {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call fileBlock file %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call fileBlock file %}{% endfilter %}
   }
   {% endfor %}
   {% else %}

--- a/Sources/SwiftGenCLI/templates/plist/inline-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/plist/inline-swift4.stencil
@@ -15,61 +15,59 @@ import Foundation
 {% macro documentBlock file document %}
   {% set rootType %}{% call typeBlock document.metadata %}{% endset %}
   {% if document.metadata.type == "Array" %}
-  {{accessModifier}} static let items: {{rootType}} = {% call valueBlock document.data document.metadata %}
+  {{accessModifier}} static let items: {{rootType}} = {%+ call valueBlock document.data document.metadata +%}
   {% elif document.metadata.type == "Dictionary" %}
   {% for key,value in document.metadata.properties %}
-  {{accessModifier}} {% call propertyBlock key value document.data %}
+  {{accessModifier}} {%+ call propertyBlock key value document.data %}
   {% endfor %}
   {% else %}
-  {{accessModifier}} static let value: {{rootType}} = {% call valueBlock document.data document.metadata %}
+  {{accessModifier}} static let value: {{rootType}} = {%+ call valueBlock document.data document.metadata +%}
   {% endif %}
 {% endmacro %}
-{% macro typeBlock metadata %}{% filter removeNewlines:"leading" %}
-  {% if metadata.type == "Array" %}
+{% macro typeBlock metadata %}
+  {%- if metadata.type == "Array" -%}
     [{% call typeBlock metadata.element %}]
-  {% elif metadata.type == "Dictionary" %}
+  {%- elif metadata.type == "Dictionary" -%}
     [String: Any]
-  {% else %}
+  {%- else -%}
     {{metadata.type}}
-  {% endif %}
-{% endfilter %}{% endmacro %}
-{% macro propertyBlock key metadata data %}{% filter removeNewlines:"leading" %}
-  {% set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset %}
-  {% set propertyType %}{% call typeBlock metadata %}{% endset %}
-  static let {{propertyName}}: {{propertyType}} = {% call valueBlock data[key] metadata %}
-{% endfilter %}{% endmacro %}
-{% macro valueBlock value metadata %}{% filter removeNewlines:"leading" %}
-  {% if metadata.type == "String" %}
+  {%- endif -%}
+{% endmacro %}
+{% macro propertyBlock key metadata data %}
+  {%- set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset -%}
+  {%- set propertyType %}{% call typeBlock metadata %}{% endset -%}
+  static let {{propertyName}}: {{propertyType}} = {%+ call valueBlock data[key] metadata +%}
+{% endmacro %}
+{% macro valueBlock value metadata %}
+  {%- if metadata.type == "String" -%}
     "{{ value }}"
-  {% elif metadata.type == "Date" %}
+  {%- elif metadata.type == "Date" -%}
     Date(timeIntervalSinceReferenceDate: {{ value.timeIntervalSinceReferenceDate }})
-  {% elif metadata.type == "Optional" %}
+  {%- elif metadata.type == "Optional" -%}
     nil
-  {% elif metadata.type == "Array" and value %}
-    [{% for value in value %}
-      {% call valueBlock value metadata.element.items[forloop.counter0]|default:metadata.element %}
+  {%- elif metadata.type == "Array" and value -%}
+    [{% for value in value -%}
+      {%- call valueBlock value metadata.element.items[forloop.counter0]|default:metadata.element -%}
       {{ ", " if not forloop.last }}
-    {% endfor %}]
-  {% elif metadata.type == "Dictionary" %}
-    [{% for key,value in value %}
-      "{{key}}": {% call valueBlock value metadata.properties[key] %}
+    {%- endfor %}]
+  {%- elif metadata.type == "Dictionary" -%}
+    [{% for key,value in value -%}
+      "{{key}}": {%+ call valueBlock value metadata.properties[key] -%}
       {{ ", " if not forloop.last }}
-    {% empty %}
+    {%- empty -%}
       :
-    {% endfor %}]
-  {% elif metadata.type == "Bool" %}
-    {% if value %}true{% else %}false{% endif %}
-  {% else %}
+    {%- endfor %}]
+  {%- else -%}
     {{ value }}
-  {% endif %}
-{% endfilter %}{% endmacro %}
+  {%- endif -%}
+{% endmacro %}
 
 // swiftlint:disable identifier_name line_length number_separator type_body_length
 {{accessModifier}} enum {{param.enumName|default:"PlistFiles"}} {
   {% if files.count > 1 or param.forceFileNameEnum %}
   {% for file in files %}
   {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call fileBlock file %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call fileBlock file %}{% endfilter %}
   }
   {% endfor %}
   {% else %}

--- a/Sources/SwiftGenCLI/templates/plist/inline-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/plist/inline-swift5.stencil
@@ -15,61 +15,59 @@ import Foundation
 {% macro documentBlock file document %}
   {% set rootType %}{% call typeBlock document.metadata %}{% endset %}
   {% if document.metadata.type == "Array" %}
-  {{accessModifier}} static let items: {{rootType}} = {% call valueBlock document.data document.metadata %}
+  {{accessModifier}} static let items: {{rootType}} = {%+ call valueBlock document.data document.metadata +%}
   {% elif document.metadata.type == "Dictionary" %}
   {% for key,value in document.metadata.properties %}
-  {{accessModifier}} {% call propertyBlock key value document.data %}
+  {{accessModifier}} {%+ call propertyBlock key value document.data %}
   {% endfor %}
   {% else %}
-  {{accessModifier}} static let value: {{rootType}} = {% call valueBlock document.data document.metadata %}
+  {{accessModifier}} static let value: {{rootType}} = {%+ call valueBlock document.data document.metadata +%}
   {% endif %}
 {% endmacro %}
-{% macro typeBlock metadata %}{% filter removeNewlines:"leading" %}
-  {% if metadata.type == "Array" %}
+{% macro typeBlock metadata %}
+  {%- if metadata.type == "Array" -%}
     [{% call typeBlock metadata.element %}]
-  {% elif metadata.type == "Dictionary" %}
+  {%- elif metadata.type == "Dictionary" -%}
     [String: Any]
-  {% else %}
+  {%- else -%}
     {{metadata.type}}
-  {% endif %}
-{% endfilter %}{% endmacro %}
-{% macro propertyBlock key metadata data %}{% filter removeNewlines:"leading" %}
-  {% set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset %}
-  {% set propertyType %}{% call typeBlock metadata %}{% endset %}
-  static let {{propertyName}}: {{propertyType}} = {% call valueBlock data[key] metadata %}
-{% endfilter %}{% endmacro %}
-{% macro valueBlock value metadata %}{% filter removeNewlines:"leading" %}
-  {% if metadata.type == "String" %}
+  {%- endif -%}
+{% endmacro %}
+{% macro propertyBlock key metadata data %}
+  {%- set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset -%}
+  {%- set propertyType %}{% call typeBlock metadata %}{% endset -%}
+  static let {{propertyName}}: {{propertyType}} = {%+ call valueBlock data[key] metadata +%}
+{% endmacro %}
+{% macro valueBlock value metadata %}
+  {%- if metadata.type == "String" -%}
     "{{ value }}"
-  {% elif metadata.type == "Date" %}
+  {%- elif metadata.type == "Date" -%}
     Date(timeIntervalSinceReferenceDate: {{ value.timeIntervalSinceReferenceDate }})
-  {% elif metadata.type == "Optional" %}
+  {%- elif metadata.type == "Optional" -%}
     nil
-  {% elif metadata.type == "Array" and value %}
-    [{% for value in value %}
-      {% call valueBlock value metadata.element.items[forloop.counter0]|default:metadata.element %}
+  {%- elif metadata.type == "Array" and value -%}
+    [{% for value in value -%}
+      {%- call valueBlock value metadata.element.items[forloop.counter0]|default:metadata.element -%}
       {{ ", " if not forloop.last }}
-    {% endfor %}]
-  {% elif metadata.type == "Dictionary" %}
-    [{% for key,value in value %}
-      "{{key}}": {% call valueBlock value metadata.properties[key] %}
+    {%- endfor %}]
+  {%- elif metadata.type == "Dictionary" -%}
+    [{% for key,value in value -%}
+      "{{key}}": {%+ call valueBlock value metadata.properties[key] -%}
       {{ ", " if not forloop.last }}
-    {% empty %}
+    {%- empty -%}
       :
-    {% endfor %}]
-  {% elif metadata.type == "Bool" %}
-    {% if value %}true{% else %}false{% endif %}
-  {% else %}
+    {%- endfor %}]
+  {%- else -%}
     {{ value }}
-  {% endif %}
-{% endfilter %}{% endmacro %}
+  {%- endif -%}
+{% endmacro %}
 
 // swiftlint:disable identifier_name line_length number_separator type_body_length
 {{accessModifier}} enum {{param.enumName|default:"PlistFiles"}} {
   {% if files.count > 1 or param.forceFileNameEnum %}
   {% for file in files %}
   {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call fileBlock file %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call fileBlock file %}{% endfilter %}
   }
   {% endfor %}
   {% else %}

--- a/Sources/SwiftGenCLI/templates/plist/runtime-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/plist/runtime-swift4.stencil
@@ -18,42 +18,41 @@ import Foundation
   {{accessModifier}} static let items: {{rootType}} = arrayFromPlist(at: "{% call transformPath file.path %}")
   {% elif document.metadata.type == "Dictionary" %}
   private static let _document = PlistDocument(path: "{% call transformPath file.path %}")
-
   {% for key,value in document.metadata.properties %}
-  {{accessModifier}} {% call propertyBlock key value %}
+  {{accessModifier}} {%+ call propertyBlock key value %}
   {% endfor %}
   {% else %}
   // Unsupported root type `{{rootType}}`
   {% endif %}
 {% endmacro %}
-{% macro typeBlock metadata %}{% filter removeNewlines:"leading" %}
-  {% if metadata.type == "Array" %}
+{% macro typeBlock metadata %}
+  {%- if metadata.type == "Array" -%}
     [{% call typeBlock metadata.element %}]
-  {% elif metadata.type == "Dictionary" %}
+  {%- elif metadata.type == "Dictionary" -%}
     [String: Any]
-  {% else %}
+  {%- else -%}
     {{metadata.type}}
-  {% endif %}
-{% endfilter %}{% endmacro %}
-{% macro propertyBlock key metadata %}{% filter removeNewlines:"leading" %}
-  {% set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset %}
-  {% set propertyType %}{% call typeBlock metadata %}{% endset %}
+  {%- endif -%}
+{% endmacro %}
+{% macro propertyBlock key metadata %}
+  {%- set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset -%}
+  {%- set propertyType %}{% call typeBlock metadata %}{% endset -%}
   static let {{propertyName}}: {{propertyType}} = _document["{{key}}"]
-{% endfilter %}{% endmacro %}
-{% macro transformPath path %}{% filter removeNewlines %}
-  {% if param.preservePath %}
+{% endmacro %}
+{% macro transformPath path %}
+  {%- if param.preservePath -%}
     {{path}}
-  {% else %}
+  {%- else -%}
     {{path|basename}}
-  {% endif %}
-{% endfilter %}{% endmacro %}
+  {%- endif -%}
+{% endmacro %}
 
 // swiftlint:disable identifier_name line_length type_body_length
 {{accessModifier}} enum {{param.enumName|default:"PlistFiles"}} {
   {% if files.count > 1 or param.forceFileNameEnum %}
   {% for file in files %}
   {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call fileBlock file %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call fileBlock file %}{% endfilter %}
   }
   {% endfor %}
   {% else %}

--- a/Sources/SwiftGenCLI/templates/plist/runtime-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/plist/runtime-swift5.stencil
@@ -18,42 +18,41 @@ import Foundation
   {{accessModifier}} static let items: {{rootType}} = arrayFromPlist(at: "{% call transformPath file.path %}")
   {% elif document.metadata.type == "Dictionary" %}
   private static let _document = PlistDocument(path: "{% call transformPath file.path %}")
-
   {% for key,value in document.metadata.properties %}
-  {{accessModifier}} {% call propertyBlock key value %}
+  {{accessModifier}} {%+ call propertyBlock key value %}
   {% endfor %}
   {% else %}
   // Unsupported root type `{{rootType}}`
   {% endif %}
 {% endmacro %}
-{% macro typeBlock metadata %}{% filter removeNewlines:"leading" %}
-  {% if metadata.type == "Array" %}
+{% macro typeBlock metadata %}
+  {%- if metadata.type == "Array" -%}
     [{% call typeBlock metadata.element %}]
-  {% elif metadata.type == "Dictionary" %}
+  {%- elif metadata.type == "Dictionary" -%}
     [String: Any]
-  {% else %}
+  {%- else -%}
     {{metadata.type}}
-  {% endif %}
-{% endfilter %}{% endmacro %}
-{% macro propertyBlock key metadata %}{% filter removeNewlines:"leading" %}
-  {% set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset %}
-  {% set propertyType %}{% call typeBlock metadata %}{% endset %}
+  {%- endif -%}
+{% endmacro %}
+{% macro propertyBlock key metadata %}
+  {%- set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset -%}
+  {%- set propertyType %}{% call typeBlock metadata %}{% endset -%}
   static let {{propertyName}}: {{propertyType}} = _document["{{key}}"]
-{% endfilter %}{% endmacro %}
-{% macro transformPath path %}{% filter removeNewlines %}
-  {% if param.preservePath %}
+{% endmacro %}
+{% macro transformPath path %}
+  {%- if param.preservePath -%}
     {{path}}
-  {% else %}
+  {%- else -%}
     {{path|basename}}
-  {% endif %}
-{% endfilter %}{% endmacro %}
+  {%- endif -%}
+{% endmacro %}
 
 // swiftlint:disable identifier_name line_length type_body_length
 {{accessModifier}} enum {{param.enumName|default:"PlistFiles"}} {
   {% if files.count > 1 or param.forceFileNameEnum %}
   {% for file in files %}
   {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call fileBlock file %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call fileBlock file %}{% endfilter %}
   }
   {% endfor %}
   {% else %}

--- a/Sources/SwiftGenCLI/templates/strings/flat-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/flat-swift4.stencil
@@ -9,28 +9,28 @@ import Foundation
 
 // MARK: - Strings
 
-{% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
-  {% for type in types %}
-    {% if type == "String" %}
+{% macro parametersBlock types %}
+  {%- for type in types -%}
+    {%- if type == "String" -%}
     _ p{{forloop.counter}}: Any
-    {% else %}
+    {%- else -%}
     _ p{{forloop.counter}}: {{type}}
-    {% endif %}
+    {%- endif -%}
     {{ ", " if not forloop.last }}
-  {% endfor %}
-{% endfilter %}{% endmacro %}
-{% macro argumentsBlock types %}{% filter removeNewlines:"leading" %}
-  {% for type in types %}
-    {% if type == "String" %}
+  {%- endfor -%}
+{% endmacro %}
+{% macro argumentsBlock types %}
+  {%- for type in types -%}
+    {%- if type == "String" -%}
     String(describing: p{{forloop.counter}})
-    {% elif type == "UnsafeRawPointer" %}
+    {%- elif type == "UnsafeRawPointer" -%}
     Int(bitPattern: p{{forloop.counter}})
-    {% else %}
+    {%- else -%}
     p{{forloop.counter}}
-    {% endif %}
+    {%- endif -%}
     {{ ", " if not forloop.last }}
-  {% endfor %}
-{% endfilter %}{% endmacro %}
+  {%- endfor -%}
+{% endmacro %}
 {% macro recursiveBlock table item %}
   {% for string in item.strings %}
   {% if not param.noComments %}
@@ -40,10 +40,9 @@ import Foundation
   {% endif %}
   {% if string.types %}
   {{accessModifier}} static func {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}({% call parametersBlock string.types %}) -> String {
-    return {{enumName}}.tr("{{table}}", "{{string.key}}", {% call argumentsBlock string.types %}, fallback: "{{string.translation|replace:'"','\"'}}")
+    return {{enumName}}.tr("{{table}}", "{{string.key}}", {%+ call argumentsBlock string.types %}, fallback: "{{string.translation|replace:'"','\"'}}")
   }
   {% elif param.lookupFunction %}
-  {# custom localization function is mostly used for in-app lang selection, so we want the loc to be recomputed at each call for those (hence the computed var) #}
   {{accessModifier}} static var {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: "{{string.translation|replace:'"','\"'}}") }
   {% else %}
   {{accessModifier}} static let {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: "{{string.translation|replace:'"','\"'}}")
@@ -59,7 +58,7 @@ import Foundation
   {% if tables.count > 1 or param.forceFileNameEnum %}
   {% for table in tables %}
   {{accessModifier}} enum {{table.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call recursiveBlock table.name table.levels %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call recursiveBlock table.name table.levels %}{% endfilter %}
   }
   {% endfor %}
   {% else %}

--- a/Sources/SwiftGenCLI/templates/strings/flat-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/flat-swift5.stencil
@@ -9,28 +9,28 @@ import Foundation
 
 // MARK: - Strings
 
-{% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
-  {% for type in types %}
-    {% if type == "String" %}
+{% macro parametersBlock types %}
+  {%- for type in types -%}
+    {%- if type == "String" -%}
     _ p{{forloop.counter}}: Any
-    {% else %}
+    {%- else -%}
     _ p{{forloop.counter}}: {{type}}
-    {% endif %}
+    {%- endif -%}
     {{ ", " if not forloop.last }}
-  {% endfor %}
-{% endfilter %}{% endmacro %}
-{% macro argumentsBlock types %}{% filter removeNewlines:"leading" %}
-  {% for type in types %}
-    {% if type == "String" %}
+  {%- endfor -%}
+{% endmacro %}
+{% macro argumentsBlock types %}
+  {%- for type in types -%}
+    {%- if type == "String" -%}
     String(describing: p{{forloop.counter}})
-    {% elif type == "UnsafeRawPointer" %}
+    {%- elif type == "UnsafeRawPointer" -%}
     Int(bitPattern: p{{forloop.counter}})
-    {% else %}
+    {%- else -%}
     p{{forloop.counter}}
-    {% endif %}
+    {%- endif -%}
     {{ ", " if not forloop.last }}
-  {% endfor %}
-{% endfilter %}{% endmacro %}
+  {%- endfor -%}
+{% endmacro %}
 {% macro recursiveBlock table item %}
   {% for string in item.strings %}
   {% if not param.noComments %}
@@ -40,10 +40,9 @@ import Foundation
   {% endif %}
   {% if string.types %}
   {{accessModifier}} static func {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}({% call parametersBlock string.types %}) -> String {
-    return {{enumName}}.tr("{{table}}", "{{string.key}}", {% call argumentsBlock string.types %}, fallback: #"{{string.translation}}"#)
+    return {{enumName}}.tr("{{table}}", "{{string.key}}", {%+ call argumentsBlock string.types %}, fallback: #"{{string.translation}}"#)
   }
   {% elif param.lookupFunction %}
-  {# custom localization function is mostly used for in-app lang selection, so we want the loc to be recomputed at each call for those (hence the computed var) #}
   {{accessModifier}} static var {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: #"{{string.translation}}"#) }
   {% else %}
   {{accessModifier}} static let {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: #"{{string.translation}}"#)
@@ -59,7 +58,7 @@ import Foundation
   {% if tables.count > 1 or param.forceFileNameEnum %}
   {% for table in tables %}
   {{accessModifier}} enum {{table.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call recursiveBlock table.name table.levels %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call recursiveBlock table.name table.levels %}{% endfilter %}
   }
   {% endfor %}
   {% else %}

--- a/Sources/SwiftGenCLI/templates/strings/objc-h.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/objc-h.stencil
@@ -5,34 +5,34 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-{% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
-  {% for type in types %}
+{% macro parametersBlock types %}
+  {%- for type in types -%}
     ({% call paramTranslate type %})p{{ forloop.counter }}{{ " :" if not forloop.last }}
-  {% endfor %}
-{% endfilter %}{% endmacro %}
-{% macro argumentsBlock types %}{% filter removeNewlines:"leading" %}
-  {% for type in types %}
+  {%- endfor -%}
+{% endmacro %}
+{% macro argumentsBlock types %}
+  {%- for type in types -%}
     p{{forloop.counter}}{{ ", " if not forloop.last }}
-  {% endfor %}
-{% endfilter %}{% endmacro %}
+  {%- endfor -%}
+{% endmacro %}
 {% macro paramTranslate swiftType %}
-  {% if swiftType == "Any" %}
+  {%- if swiftType == "Any" -%}
     id
-  {% elif swiftType == "CChar" %}
+  {%- elif swiftType == "CChar" -%}
     char
-  {% elif swiftType == "Float" %}
+  {%- elif swiftType == "Float" -%}
     float
-  {% elif swiftType == "Int" %}
+  {%- elif swiftType == "Int" -%}
     NSInteger
-  {% elif swiftType == "String" %}
+  {%- elif swiftType == "String" -%}
     id
-  {% elif swiftType == "UnsafePointer<CChar>" %}
+  {%- elif swiftType == "UnsafePointer<CChar>" -%}
     char*
-  {% elif swiftType == "UnsafeRawPointer" %}
+  {%- elif swiftType == "UnsafeRawPointer" -%}
     void*
-  {% else %}
+  {%- else -%}
     objc-h.stencil is missing '{{swiftType}}'
-  {% endif %}
+  {%- endif -%}
 {% endmacro %}
 {% macro emitOneMethod table item %}
 {% for string in item.strings %}

--- a/Sources/SwiftGenCLI/templates/strings/objc-m.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/objc-m.stencil
@@ -28,45 +28,45 @@ static NSString* tr(NSString *tableName, NSString *key, NSString *value, ...) {
 };
 #pragma clang diagnostic pop
 
-{% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
-  {% for type in types %}
+{% macro parametersBlock types %}
+  {%- for type in types -%}
     ({% call paramTranslate type %})p{{ forloop.counter }}{{ " :" if not forloop.last }}
-  {% endfor %}
-{% endfilter %}{% endmacro %}
-{% macro argumentsBlock types %}{% filter removeNewlines:"leading" %}
-  {% for type in types %}
+  {%- endfor -%}
+{% endmacro %}
+{% macro argumentsBlock types %}
+  {%- for type in types -%}
     p{{forloop.counter}}{{ ", " if not forloop.last }}
-  {% endfor %}
-{% endfilter %}{% endmacro %}
+  {%- endfor -%}
+{% endmacro %}
 {% macro paramTranslate swiftType %}
-  {% if swiftType == "Any" %}
+  {%- if swiftType == "Any" -%}
     id
-  {% elif swiftType == "CChar" %}
+  {%- elif swiftType == "CChar" -%}
     char
-  {% elif swiftType == "Float" %}
+  {%- elif swiftType == "Float" -%}
     float
-  {% elif swiftType == "Int" %}
+  {%- elif swiftType == "Int" -%}
     NSInteger
-  {% elif swiftType == "String" %}
+  {%- elif swiftType == "String" -%}
     id
-  {% elif swiftType == "UnsafePointer<CChar>" %}
+  {%- elif swiftType == "UnsafePointer<CChar>" -%}
     char*
-  {% elif swiftType == "UnsafeRawPointer" %}
+  {%- elif swiftType == "UnsafeRawPointer" -%}
     void*
-  {% else %}
+  {%- else -%}
     objc-m.stencil is missing '{{swiftType}}'
-  {% endif %}
+  {%- endif -%}
 {% endmacro %}
 {% macro tableContents table item %}
   {% for string in item.strings %}
   {% if string.types %}
     {% if string.types.count == 1 %}
-+ (NSString*){{string.key|swiftIdentifier:"pretty"|lowerFirstWord}}WithValue:{% call parametersBlock string.types %}
++ (NSString*){{string.key|swiftIdentifier:"pretty"|lowerFirstWord}}WithValue:{% call parametersBlock string.types +%}
     {% else %}
-+ (NSString*){{string.key|swiftIdentifier:"pretty"|lowerFirstWord}}WithValues:{% call parametersBlock string.types %}
++ (NSString*){{string.key|swiftIdentifier:"pretty"|lowerFirstWord}}WithValues:{% call parametersBlock string.types +%}
     {% endif %}
 {
-    return tr(@"{{table}}", @"{{string.key}}", @"{{string.translation|replace:'"','\"'}}", {% call argumentsBlock string.types %});
+    return tr(@"{{table}}", @"{{string.key}}", @"{{string.translation|replace:'"','\"'}}", {%+ call argumentsBlock string.types %});
 }
 {% else %}
 + (NSString*){{string.key|swiftIdentifier:"pretty"|lowerFirstWord}} {

--- a/Sources/SwiftGenCLI/templates/strings/structured-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/structured-swift4.stencil
@@ -9,28 +9,28 @@ import Foundation
 
 // MARK: - Strings
 
-{% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
-  {% for type in types %}
-    {% if type == "String" %}
+{% macro parametersBlock types %}
+  {%- for type in types -%}
+    {%- if type == "String" -%}
     _ p{{forloop.counter}}: Any
-    {% else %}
+    {%- else -%}
     _ p{{forloop.counter}}: {{type}}
-    {% endif %}
+    {%- endif -%}
     {{ ", " if not forloop.last }}
-  {% endfor %}
-{% endfilter %}{% endmacro %}
-{% macro argumentsBlock types %}{% filter removeNewlines:"leading" %}
-  {% for type in types %}
-    {% if type == "String" %}
+  {%- endfor -%}
+{% endmacro %}
+{% macro argumentsBlock types %}
+  {%- for type in types -%}
+    {%- if type == "String" -%}
     String(describing: p{{forloop.counter}})
-    {% elif type == "UnsafeRawPointer" %}
+    {%- elif type == "UnsafeRawPointer" -%}
     Int(bitPattern: p{{forloop.counter}})
-    {% else %}
+    {%- else -%}
     p{{forloop.counter}}
-    {% endif %}
+    {%- endif -%}
     {{ ", " if not forloop.last }}
-  {% endfor %}
-{% endfilter %}{% endmacro %}
+  {%- endfor -%}
+{% endmacro %}
 {% macro recursiveBlock table item %}
   {% for string in item.strings %}
   {% if not param.noComments %}
@@ -40,19 +40,17 @@ import Foundation
   {% endif %}
   {% if string.types %}
   {{accessModifier}} static func {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}({% call parametersBlock string.types %}) -> String {
-    return {{enumName}}.tr("{{table}}", "{{string.key}}", {% call argumentsBlock string.types %}, fallback: "{{string.translation|replace:'"','\"'}}")
+    return {{enumName}}.tr("{{table}}", "{{string.key}}", {%+ call argumentsBlock string.types %}, fallback: "{{string.translation|replace:'"','\"'}}")
   }
   {% elif param.lookupFunction %}
-  {# custom localization function is mostly used for in-app lang selection, so we want the loc to be recomputed at each call for those (hence the computed var) #}
   {{accessModifier}} static var {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: "{{string.translation|replace:'"','\"'}}") }
   {% else %}
   {{accessModifier}} static let {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: "{{string.translation|replace:'"','\"'}}")
   {% endif %}
   {% endfor %}
   {% for child in item.children %}
-
   {{accessModifier}} enum {{child.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call recursiveBlock table child %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call recursiveBlock table child %}{% endfilter %}
   }
   {% endfor %}
 {% endmacro %}
@@ -63,7 +61,7 @@ import Foundation
   {% if tables.count > 1 or param.forceFileNameEnum %}
   {% for table in tables %}
   {{accessModifier}} enum {{table.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call recursiveBlock table.name table.levels %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call recursiveBlock table.name table.levels %}{% endfilter %}
   }
   {% endfor %}
   {% else %}

--- a/Sources/SwiftGenCLI/templates/strings/structured-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/structured-swift5.stencil
@@ -5,32 +5,32 @@
 {% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references 
+// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references
 
 // MARK: - Strings
 
-{% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
-  {% for type in types %}
-    {% if type == "String" %}
+{% macro parametersBlock types %}
+  {%- for type in types -%}
+    {%- if type == "String" -%}
     _ p{{forloop.counter}}: Any
-    {% else %}
+    {%- else -%}
     _ p{{forloop.counter}}: {{type}}
-    {% endif %}
+    {%- endif -%}
     {{ ", " if not forloop.last }}
-  {% endfor %}
-{% endfilter %}{% endmacro %}
-{% macro argumentsBlock types %}{% filter removeNewlines:"leading" %}
-  {% for type in types %}
-    {% if type == "String" %}
+  {%- endfor -%}
+{% endmacro %}
+{% macro argumentsBlock types %}
+  {%- for type in types -%}
+    {%- if type == "String" -%}
     String(describing: p{{forloop.counter}})
-    {% elif type == "UnsafeRawPointer" %}
+    {%- elif type == "UnsafeRawPointer" -%}
     Int(bitPattern: p{{forloop.counter}})
-    {% else %}
+    {%- else -%}
     p{{forloop.counter}}
-    {% endif %}
+    {%- endif -%}
     {{ ", " if not forloop.last }}
-  {% endfor %}
-{% endfilter %}{% endmacro %}
+  {%- endfor -%}
+{% endmacro %}
 {% macro recursiveBlock table item %}
   {% for string in item.strings %}
   {% if not param.noComments %}
@@ -40,19 +40,17 @@ import Foundation
   {% endif %}
   {% if string.types %}
   {{accessModifier}} static func {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}({% call parametersBlock string.types %}) -> String {
-    return {{enumName}}.tr("{{table}}", "{{string.key}}", {% call argumentsBlock string.types %}, fallback: #"{{string.translation}}"#)
+    return {{enumName}}.tr("{{table}}", "{{string.key}}", {%+ call argumentsBlock string.types %}, fallback: #"{{string.translation}}"#)
   }
   {% elif param.lookupFunction %}
-  {# custom localization function is mostly used for in-app lang selection, so we want the loc to be recomputed at each call for those (hence the computed var) #}
   {{accessModifier}} static var {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: #"{{string.translation}}"#) }
   {% else %}
   {{accessModifier}} static let {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: #"{{string.translation}}"#)
   {% endif %}
   {% endfor %}
   {% for child in item.children %}
-
   {{accessModifier}} enum {{child.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call recursiveBlock table child %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call recursiveBlock table child %}{% endfilter %}
   }
   {% endfor %}
 {% endmacro %}
@@ -63,7 +61,7 @@ import Foundation
   {% if tables.count > 1 or param.forceFileNameEnum %}
   {% for table in tables %}
   {{accessModifier}} enum {{table.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call recursiveBlock table.name table.levels %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call recursiveBlock table.name table.levels %}{% endfilter %}
   }
   {% endfor %}
   {% else %}

--- a/Sources/SwiftGenCLI/templates/xcassets/swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/xcassets/swift4.stencil
@@ -40,29 +40,34 @@
   {% if param.allValues %}
 
   // swiftlint:disable trailing_comma
-  {% if resourceCount.arresourcegroup > 0 %}
+  {% set hasItems %}{% call hasValuesBlock assets "arresourcegroup" %}{% endset %}
+  {% if hasItems %}
   {{accessModifier}} static let allResourceGroups: [{{arResourceGroupType}}] = [
-    {% filter indent:2 %}{% call allValuesBlock assets "arresourcegroup" "" %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call allValuesBlock assets "arresourcegroup" "" %}{% endfilter %}
   ]
   {% endif %}
-  {% if resourceCount.color > 0 %}
+  {% set hasItems %}{% call hasValuesBlock assets "color" %}{% endset %}
+  {% if hasItems %}
   {{accessModifier}} static let allColors: [{{colorType}}] = [
-    {% filter indent:2 %}{% call allValuesBlock assets "color" "" %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call allValuesBlock assets "color" "" %}{% endfilter %}
   ]
   {% endif %}
-  {% if resourceCount.data > 0 %}
+  {% set hasItems %}{% call hasValuesBlock assets "data" %}{% endset %}
+  {% if hasItems %}
   {{accessModifier}} static let allDataAssets: [{{dataType}}] = [
-    {% filter indent:2 %}{% call allValuesBlock assets "data" "" %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call allValuesBlock assets "data" "" %}{% endfilter %}
   ]
   {% endif %}
-  {% if resourceCount.image > 0 %}
+  {% set hasItems %}{% call hasValuesBlock assets "image" %}{% endset %}
+  {% if hasItems %}
   {{accessModifier}} static let allImages: [{{imageType}}] = [
-    {% filter indent:2 %}{% call allValuesBlock assets "image" "" %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call allValuesBlock assets "image" "" %}{% endfilter %}
   ]
   {% endif %}
-  {% if resourceCount.symbol > 0 %}
+  {% set hasItems %}{% call hasValuesBlock assets "symbol" %}{% endset %}
+  {% if hasItems %}
   {{accessModifier}} static let allSymbols: [{{symbolType}}] = [
-    {% filter indent:2 %}{% call allValuesBlock assets "symbol" "" %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call allValuesBlock assets "symbol" "" %}{% endfilter %}
   ]
   {% endif %}
   // swiftlint:enable trailing_comma
@@ -82,12 +87,21 @@
   {{accessModifier}} static let {{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{symbolType}}(name: "{{asset.value}}")
   {% elif asset.items and ( forceNamespaces == "true" or asset.isNamespaced == "true" ) %}
   {{accessModifier}} enum {{asset.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call casesBlock asset.items %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call casesBlock asset.items %}{% endfilter %}
   }
   {% elif asset.items %}
   {% call casesBlock asset.items %}
   {% endif %}
   {% endfor %}
+{% endmacro %}
+{% macro hasValuesBlock assets filter %}
+  {%- for asset in assets -%}
+    {%- if asset.type == filter -%}
+      1
+    {%- elif asset.items -%}
+      {% call hasValuesBlock asset.items filter %}
+    {%- endif -%}
+  {%- endfor -%}
 {% endmacro %}
 {% macro allValuesBlock assets filter prefix %}
   {% for asset in assets %}
@@ -106,7 +120,9 @@
   {% if catalogs.count > 1 or param.forceFileNameEnum %}
   {% for catalog in catalogs %}
   {{accessModifier}} enum {{catalog.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call enumBlock catalog.assets %}{% endfilter %}
+    {% if catalog.assets %}
+    {% filter indent:2," ",true %}{% call enumBlock catalog.assets %}{% endfilter %}
+    {% endif %}
   }
   {% endfor %}
   {% else %}

--- a/Sources/SwiftGenCLI/templates/xcassets/swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/xcassets/swift5.stencil
@@ -40,29 +40,34 @@
   {% if param.allValues %}
 
   // swiftlint:disable trailing_comma
-  {% if resourceCount.arresourcegroup > 0 %}
+  {% set hasItems %}{% call hasValuesBlock assets "arresourcegroup" %}{% endset %}
+  {% if hasItems %}
   {{accessModifier}} static let allResourceGroups: [{{arResourceGroupType}}] = [
-    {% filter indent:2 %}{% call allValuesBlock assets "arresourcegroup" "" %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call allValuesBlock assets "arresourcegroup" "" %}{% endfilter %}
   ]
   {% endif %}
-  {% if resourceCount.color > 0 %}
+  {% set hasItems %}{% call hasValuesBlock assets "color" %}{% endset %}
+  {% if hasItems %}
   {{accessModifier}} static let allColors: [{{colorType}}] = [
-    {% filter indent:2 %}{% call allValuesBlock assets "color" "" %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call allValuesBlock assets "color" "" %}{% endfilter %}
   ]
   {% endif %}
-  {% if resourceCount.data > 0 %}
+  {% set hasItems %}{% call hasValuesBlock assets "data" %}{% endset %}
+  {% if hasItems %}
   {{accessModifier}} static let allDataAssets: [{{dataType}}] = [
-    {% filter indent:2 %}{% call allValuesBlock assets "data" "" %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call allValuesBlock assets "data" "" %}{% endfilter %}
   ]
   {% endif %}
-  {% if resourceCount.image > 0 %}
+  {% set hasItems %}{% call hasValuesBlock assets "image" %}{% endset %}
+  {% if hasItems %}
   {{accessModifier}} static let allImages: [{{imageType}}] = [
-    {% filter indent:2 %}{% call allValuesBlock assets "image" "" %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call allValuesBlock assets "image" "" %}{% endfilter %}
   ]
   {% endif %}
-  {% if resourceCount.symbol > 0 %}
+  {% set hasItems %}{% call hasValuesBlock assets "symbol" %}{% endset %}
+  {% if hasItems %}
   {{accessModifier}} static let allSymbols: [{{symbolType}}] = [
-    {% filter indent:2 %}{% call allValuesBlock assets "symbol" "" %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call allValuesBlock assets "symbol" "" %}{% endfilter %}
   ]
   {% endif %}
   // swiftlint:enable trailing_comma
@@ -82,12 +87,21 @@
   {{accessModifier}} static let {{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{symbolType}}(name: "{{asset.value}}")
   {% elif asset.items and ( forceNamespaces == "true" or asset.isNamespaced == "true" ) %}
   {{accessModifier}} enum {{asset.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call casesBlock asset.items %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call casesBlock asset.items %}{% endfilter %}
   }
   {% elif asset.items %}
   {% call casesBlock asset.items %}
   {% endif %}
   {% endfor %}
+{% endmacro %}
+{% macro hasValuesBlock assets filter %}
+  {%- for asset in assets -%}
+    {%- if asset.type == filter -%}
+      1
+    {%- elif asset.items -%}
+      {% call hasValuesBlock asset.items filter %}
+    {%- endif -%}
+  {%- endfor -%}
 {% endmacro %}
 {% macro allValuesBlock assets filter prefix %}
   {% for asset in assets %}
@@ -106,7 +120,9 @@
   {% if catalogs.count > 1 or param.forceFileNameEnum %}
   {% for catalog in catalogs %}
   {{accessModifier}} enum {{catalog.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call enumBlock catalog.assets %}{% endfilter %}
+    {% if catalog.assets %}
+    {% filter indent:2," ",true %}{% call enumBlock catalog.assets %}{% endfilter %}
+    {% endif %}
   }
   {% endfor %}
   {% else %}

--- a/Sources/SwiftGenCLI/templates/yaml/inline-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/yaml/inline-swift4.stencil
@@ -15,7 +15,7 @@ import Foundation
   {% for document in file.documents %}
   {% set documentName %}{{documentPrefix}}{{forloop.counter}}{% endset %}
   {{accessModifier}} enum {{documentName|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call documentBlock file document %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call documentBlock file document %}{% endfilter %}
   }
   {% endfor %}
   {% else %}
@@ -25,61 +25,59 @@ import Foundation
 {% macro documentBlock file document %}
   {% set rootType %}{% call typeBlock document.metadata %}{% endset %}
   {% if document.metadata.type == "Array" %}
-  {{accessModifier}} static let items: {{rootType}} = {% call valueBlock document.data document.metadata %}
+  {{accessModifier}} static let items: {{rootType}} = {%+ call valueBlock document.data document.metadata +%}
   {% elif document.metadata.type == "Dictionary" %}
   {% for key,value in document.metadata.properties %}
-  {{accessModifier}} {% call propertyBlock key value document.data %}
+  {{accessModifier}} {%+ call propertyBlock key value document.data %}
   {% endfor %}
   {% else %}
-  {{accessModifier}} static let value: {{rootType}} = {% call valueBlock document.data document.metadata %}
+  {{accessModifier}} static let value: {{rootType}} = {%+ call valueBlock document.data document.metadata +%}
   {% endif %}
 {% endmacro %}
-{% macro typeBlock metadata %}{% filter removeNewlines:"leading" %}
-  {% if metadata.type == "Array" %}
+{% macro typeBlock metadata %}
+  {%- if metadata.type == "Array" -%}
     [{% call typeBlock metadata.element %}]
-  {% elif metadata.type == "Dictionary" %}
+  {%- elif metadata.type == "Dictionary" -%}
     [String: Any]
-  {% elif metadata.type == "Optional" %}
+  {%- elif metadata.type == "Optional" -%}
     Any?
-  {% else %}
+  {%- else -%}
     {{metadata.type}}
-  {% endif %}
-{% endfilter %}{% endmacro %}
-{% macro propertyBlock key metadata data %}{% filter removeNewlines:"leading" %}
-  {% set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset %}
-  {% set propertyType %}{% call typeBlock metadata %}{% endset %}
-  static let {{propertyName}}: {{propertyType}} = {% call valueBlock data[key] metadata %}
-{% endfilter %}{% endmacro %}
-{% macro valueBlock value metadata %}{% filter removeNewlines:"leading" %}
-  {% if metadata.type == "String" %}
+  {%- endif -%}
+{% endmacro %}
+{% macro propertyBlock key metadata data %}
+  {%- set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset -%}
+  {%- set propertyType %}{% call typeBlock metadata %}{% endset -%}
+  static let {{propertyName}}: {{propertyType}} = {%+ call valueBlock data[key] metadata +%}
+{% endmacro %}
+{% macro valueBlock value metadata %}
+  {%- if metadata.type == "String" -%}
     "{{ value }}"
-  {% elif metadata.type == "Optional" %}
+  {%- elif metadata.type == "Optional" -%}
     nil
-  {% elif metadata.type == "Array" and value %}
-    [{% for value in value %}
-      {% call valueBlock value metadata.element.items[forloop.counter0]|default:metadata.element %}
+  {%- elif metadata.type == "Array" and value -%}
+    [{% for value in value -%}
+      {%- call valueBlock value metadata.element.items[forloop.counter0]|default:metadata.element -%}
       {{ ", " if not forloop.last }}
-    {% endfor %}]
-  {% elif metadata.type == "Dictionary" %}
-    [{% for key,value in value %}
-      "{{key}}": {% call valueBlock value metadata.properties[key] %}
+    {%- endfor %}]
+  {%- elif metadata.type == "Dictionary" -%}
+    [{% for key,value in value -%}
+      "{{key}}": {%+ call valueBlock value metadata.properties[key] -%}
       {{ ", " if not forloop.last }}
-    {% empty %}
+    {%- empty -%}
       :
-    {% endfor %}]
-  {% elif metadata.type == "Bool" %}
-    {% if value %}true{% else %}false{% endif %}
-  {% else %}
+    {%- endfor %}]
+  {%- else -%}
     {{ value }}
-  {% endif %}
-{% endfilter %}{% endmacro %}
+  {%- endif -%}
+{% endmacro %}
 
 // swiftlint:disable identifier_name line_length number_separator type_body_length
 {{accessModifier}} enum {{param.enumName|default:"YAMLFiles"}} {
   {% if files.count > 1 or param.forceFileNameEnum %}
   {% for file in files %}
   {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call fileBlock file %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call fileBlock file %}{% endfilter %}
   }
   {% endfor %}
   {% else %}

--- a/Sources/SwiftGenCLI/templates/yaml/inline-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/yaml/inline-swift5.stencil
@@ -15,7 +15,7 @@ import Foundation
   {% for document in file.documents %}
   {% set documentName %}{{documentPrefix}}{{forloop.counter}}{% endset %}
   {{accessModifier}} enum {{documentName|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call documentBlock file document %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call documentBlock file document %}{% endfilter %}
   }
   {% endfor %}
   {% else %}
@@ -25,61 +25,59 @@ import Foundation
 {% macro documentBlock file document %}
   {% set rootType %}{% call typeBlock document.metadata %}{% endset %}
   {% if document.metadata.type == "Array" %}
-  {{accessModifier}} static let items: {{rootType}} = {% call valueBlock document.data document.metadata %}
+  {{accessModifier}} static let items: {{rootType}} = {%+ call valueBlock document.data document.metadata +%}
   {% elif document.metadata.type == "Dictionary" %}
   {% for key,value in document.metadata.properties %}
-  {{accessModifier}} {% call propertyBlock key value document.data %}
+  {{accessModifier}} {%+ call propertyBlock key value document.data %}
   {% endfor %}
   {% else %}
-  {{accessModifier}} static let value: {{rootType}} = {% call valueBlock document.data document.metadata %}
+  {{accessModifier}} static let value: {{rootType}} = {%+ call valueBlock document.data document.metadata +%}
   {% endif %}
 {% endmacro %}
-{% macro typeBlock metadata %}{% filter removeNewlines:"leading" %}
-  {% if metadata.type == "Array" %}
+{% macro typeBlock metadata %}
+  {%- if metadata.type == "Array" -%}
     [{% call typeBlock metadata.element %}]
-  {% elif metadata.type == "Dictionary" %}
+  {%- elif metadata.type == "Dictionary" -%}
     [String: Any]
-  {% elif metadata.type == "Optional" %}
+  {%- elif metadata.type == "Optional" -%}
     Any?
-  {% else %}
+  {%- else -%}
     {{metadata.type}}
-  {% endif %}
-{% endfilter %}{% endmacro %}
-{% macro propertyBlock key metadata data %}{% filter removeNewlines:"leading" %}
-  {% set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset %}
-  {% set propertyType %}{% call typeBlock metadata %}{% endset %}
-  static let {{propertyName}}: {{propertyType}} = {% call valueBlock data[key] metadata %}
-{% endfilter %}{% endmacro %}
-{% macro valueBlock value metadata %}{% filter removeNewlines:"leading" %}
-  {% if metadata.type == "String" %}
+  {%- endif -%}
+{% endmacro %}
+{% macro propertyBlock key metadata data %}
+  {%- set propertyName %}{{key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}{% endset -%}
+  {%- set propertyType %}{% call typeBlock metadata %}{% endset -%}
+  static let {{propertyName}}: {{propertyType}} = {%+ call valueBlock data[key] metadata +%}
+{% endmacro %}
+{% macro valueBlock value metadata %}
+  {%- if metadata.type == "String" -%}
     "{{ value }}"
-  {% elif metadata.type == "Optional" %}
+  {%- elif metadata.type == "Optional" -%}
     nil
-  {% elif metadata.type == "Array" and value %}
-    [{% for value in value %}
-      {% call valueBlock value metadata.element.items[forloop.counter0]|default:metadata.element %}
+  {%- elif metadata.type == "Array" and value -%}
+    [{% for value in value -%}
+      {%- call valueBlock value metadata.element.items[forloop.counter0]|default:metadata.element -%}
       {{ ", " if not forloop.last }}
-    {% endfor %}]
-  {% elif metadata.type == "Dictionary" %}
-    [{% for key,value in value %}
-      "{{key}}": {% call valueBlock value metadata.properties[key] %}
+    {%- endfor %}]
+  {%- elif metadata.type == "Dictionary" -%}
+    [{% for key,value in value -%}
+      "{{key}}": {%+ call valueBlock value metadata.properties[key] -%}
       {{ ", " if not forloop.last }}
-    {% empty %}
+    {%- empty -%}
       :
-    {% endfor %}]
-  {% elif metadata.type == "Bool" %}
-    {% if value %}true{% else %}false{% endif %}
-  {% else %}
+    {%- endfor %}]
+  {%- else -%}
     {{ value }}
-  {% endif %}
-{% endfilter %}{% endmacro %}
+  {%- endif -%}
+{% endmacro %}
 
 // swiftlint:disable identifier_name line_length number_separator type_body_length
 {{accessModifier}} enum {{param.enumName|default:"YAMLFiles"}} {
   {% if files.count > 1 or param.forceFileNameEnum %}
   {% for file in files %}
   {{accessModifier}} enum {{file.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
-    {% filter indent:2 %}{% call fileBlock file %}{% endfilter %}
+    {% filter indent:2," ",true %}{% call fileBlock file %}{% endfilter %}
   }
   {% endfor %}
   {% else %}

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-customBundle.swift
@@ -30,26 +30,22 @@ internal enum L10n {
   internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
     return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: "Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'")
   }
-
   internal enum Apples {
     /// You have %d apples
     internal static func count(_ p1: Int) -> String {
       return L10n.tr("Localizable", "apples.count", p1, fallback: "You have %d apples")
     }
   }
-
   internal enum Bananas {
     /// A comment with no space above it
     internal static func owner(_ p1: Int, _ p2: Any) -> String {
       return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: "Those %d bananas belong to %@.")
     }
   }
-
   internal enum Key1 {
     /// Same as "key1" = "value1"; but in the context of user not logged in
     internal static let anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: "value2")
   }
-
   internal enum Many {
     internal enum Placeholders {
       /// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
@@ -62,7 +58,6 @@ internal enum L10n {
       }
     }
   }
-
   internal enum Settings {
     internal enum NavigationBar {
       /// Some Reserved Keyword there
@@ -101,7 +96,6 @@ internal enum L10n {
       internal static let headerTitle = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: "User Profile Settings")
     }
   }
-
   internal enum What {
     internal enum Happens {
       /// some comment

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-customName.swift
@@ -30,26 +30,22 @@ internal enum XCTLoc {
   internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
     return XCTLoc.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: "Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'")
   }
-
   internal enum Apples {
     /// You have %d apples
     internal static func count(_ p1: Int) -> String {
       return XCTLoc.tr("Localizable", "apples.count", p1, fallback: "You have %d apples")
     }
   }
-
   internal enum Bananas {
     /// A comment with no space above it
     internal static func owner(_ p1: Int, _ p2: Any) -> String {
       return XCTLoc.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: "Those %d bananas belong to %@.")
     }
   }
-
   internal enum Key1 {
     /// Same as "key1" = "value1"; but in the context of user not logged in
     internal static let anonymous = XCTLoc.tr("Localizable", "key1.anonymous", fallback: "value2")
   }
-
   internal enum Many {
     internal enum Placeholders {
       /// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
@@ -62,7 +58,6 @@ internal enum XCTLoc {
       }
     }
   }
-
   internal enum Settings {
     internal enum NavigationBar {
       /// Some Reserved Keyword there
@@ -101,7 +96,6 @@ internal enum XCTLoc {
       internal static let headerTitle = XCTLoc.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: "User Profile Settings")
     }
   }
-
   internal enum What {
     internal enum Happens {
       /// some comment

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-lookupFunction.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-lookupFunction.swift
@@ -30,26 +30,22 @@ internal enum L10n {
   internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
     return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: "Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'")
   }
-
   internal enum Apples {
     /// You have %d apples
     internal static func count(_ p1: Int) -> String {
       return L10n.tr("Localizable", "apples.count", p1, fallback: "You have %d apples")
     }
   }
-
   internal enum Bananas {
     /// A comment with no space above it
     internal static func owner(_ p1: Int, _ p2: Any) -> String {
       return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: "Those %d bananas belong to %@.")
     }
   }
-
   internal enum Key1 {
     /// Same as "key1" = "value1"; but in the context of user not logged in
     internal static var anonymous: String { return L10n.tr("Localizable", "key1.anonymous", fallback: "value2") }
   }
-
   internal enum Many {
     internal enum Placeholders {
       /// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
@@ -62,7 +58,6 @@ internal enum L10n {
       }
     }
   }
-
   internal enum Settings {
     internal enum NavigationBar {
       /// Some Reserved Keyword there
@@ -101,7 +96,6 @@ internal enum L10n {
       internal static var headerTitle: String { return L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: "User Profile Settings") }
     }
   }
-
   internal enum What {
     internal enum Happens {
       /// some comment

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-noComments.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-noComments.swift
@@ -23,23 +23,19 @@ internal enum L10n {
   internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
     return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: "Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'")
   }
-
   internal enum Apples {
     internal static func count(_ p1: Int) -> String {
       return L10n.tr("Localizable", "apples.count", p1, fallback: "You have %d apples")
     }
   }
-
   internal enum Bananas {
     internal static func owner(_ p1: Int, _ p2: Any) -> String {
       return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: "Those %d bananas belong to %@.")
     }
   }
-
   internal enum Key1 {
     internal static let anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: "value2")
   }
-
   internal enum Many {
     internal enum Placeholders {
       internal static func base(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
@@ -50,7 +46,6 @@ internal enum L10n {
       }
     }
   }
-
   internal enum Settings {
     internal enum NavigationBar {
       internal static let `self` = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: "Some Reserved Keyword there")
@@ -84,7 +79,6 @@ internal enum L10n {
       internal static let headerTitle = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: "User Profile Settings")
     }
   }
-
   internal enum What {
     internal enum Happens {
       internal static let here = L10n.tr("Localizable", "what./*happens*/.here", fallback: "hello world! /* still in string */")

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-publicAccess.swift
@@ -30,26 +30,22 @@ public enum L10n {
   public static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
     return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: "Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'")
   }
-
   public enum Apples {
     /// You have %d apples
     public static func count(_ p1: Int) -> String {
       return L10n.tr("Localizable", "apples.count", p1, fallback: "You have %d apples")
     }
   }
-
   public enum Bananas {
     /// A comment with no space above it
     public static func owner(_ p1: Int, _ p2: Any) -> String {
       return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: "Those %d bananas belong to %@.")
     }
   }
-
   public enum Key1 {
     /// Same as "key1" = "value1"; but in the context of user not logged in
     public static let anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: "value2")
   }
-
   public enum Many {
     public enum Placeholders {
       /// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
@@ -62,7 +58,6 @@ public enum L10n {
       }
     }
   }
-
   public enum Settings {
     public enum NavigationBar {
       /// Some Reserved Keyword there
@@ -101,7 +96,6 @@ public enum L10n {
       public static let headerTitle = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: "User Profile Settings")
     }
   }
-
   public enum What {
     public enum Happens {
       /// some comment

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable.swift
@@ -30,26 +30,22 @@ internal enum L10n {
   internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
     return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: "Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'")
   }
-
   internal enum Apples {
     /// You have %d apples
     internal static func count(_ p1: Int) -> String {
       return L10n.tr("Localizable", "apples.count", p1, fallback: "You have %d apples")
     }
   }
-
   internal enum Bananas {
     /// A comment with no space above it
     internal static func owner(_ p1: Int, _ p2: Any) -> String {
       return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: "Those %d bananas belong to %@.")
     }
   }
-
   internal enum Key1 {
     /// Same as "key1" = "value1"; but in the context of user not logged in
     internal static let anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: "value2")
   }
-
   internal enum Many {
     internal enum Placeholders {
       /// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
@@ -62,7 +58,6 @@ internal enum L10n {
       }
     }
   }
-
   internal enum Settings {
     internal enum NavigationBar {
       /// Some Reserved Keyword there
@@ -101,7 +96,6 @@ internal enum L10n {
       internal static let headerTitle = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: "User Profile Settings")
     }
   }
-
   internal enum What {
     internal enum Happens {
       /// some comment

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/plurals-advanced.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/plurals-advanced.swift
@@ -10,7 +10,6 @@ import Foundation
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
 internal enum L10n {
-
   internal enum Many {
     internal enum Placeholders {
       internal enum Plurals {
@@ -25,7 +24,6 @@ internal enum L10n {
       }
     }
   }
-
   internal enum Mixed {
     internal enum PlaceholdersAndVariables {
       /// Plural format key: "%1$@ %3$#@has_rating@"
@@ -46,7 +44,6 @@ internal enum L10n {
       }
     }
   }
-
   internal enum Multiple {
     internal enum PlaceholdersAndVariables {
       /// Plural format key: "Your %3$@ list contains %1$#@first@ %2$@."

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/plurals-same-table.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/plurals-same-table.swift
@@ -30,21 +30,18 @@ internal enum L10n {
   internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
     return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: "Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'")
   }
-
   internal enum Apples {
     /// Plural format key: "%#@apples@"
     internal static func count(_ p1: Int) -> String {
       return L10n.tr("Localizable", "apples.count", p1, fallback: "Plural format key: \"%#@apples@\"")
     }
   }
-
   internal enum Bananas {
     /// A comment with no space above it
     internal static func owner(_ p1: Int, _ p2: Any) -> String {
       return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: "Those %d bananas belong to %@.")
     }
   }
-
   internal enum Competition {
     internal enum Event {
       /// Plural format key: "%#@Matches@"
@@ -53,7 +50,6 @@ internal enum L10n {
       }
     }
   }
-
   internal enum Feed {
     internal enum Subscription {
       /// Plural format key: "%#@Subscriptions@"
@@ -62,12 +58,10 @@ internal enum L10n {
       }
     }
   }
-
   internal enum Key1 {
     /// Same as "key1" = "value1"; but in the context of user not logged in
     internal static let anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: "value2")
   }
-
   internal enum Many {
     internal enum Placeholders {
       /// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
@@ -80,7 +74,6 @@ internal enum L10n {
       }
     }
   }
-
   internal enum Settings {
     internal enum NavigationBar {
       /// Some Reserved Keyword there
@@ -119,7 +112,6 @@ internal enum L10n {
       internal static let headerTitle = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: "User Profile Settings")
     }
   }
-
   internal enum What {
     internal enum Happens {
       /// some comment

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/plurals-unsupported.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/plurals-unsupported.swift
@@ -10,7 +10,6 @@ import Foundation
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
 internal enum L10n {
-
   internal enum UnsupportedUse {
     internal enum PlaceholdersInVariableRule {
       /// Plural format key: "%#@elements@"

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/plurals.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/plurals.swift
@@ -10,14 +10,12 @@ import Foundation
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
 internal enum L10n {
-
   internal enum Apples {
     /// Plural format key: "%#@apples@"
     internal static func count(_ p1: Int) -> String {
       return L10n.tr("Localizable", "apples.count", p1, fallback: "Plural format key: \"%#@apples@\"")
     }
   }
-
   internal enum Competition {
     internal enum Event {
       /// Plural format key: "%#@Matches@"
@@ -26,7 +24,6 @@ internal enum L10n {
       }
     }
   }
-
   internal enum Feed {
     internal enum Subscription {
       /// Plural format key: "%#@Subscriptions@"

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-customBundle.swift
@@ -3,7 +3,7 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references 
+// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references
 
 // MARK: - Strings
 
@@ -30,26 +30,22 @@ internal enum L10n {
   internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
     return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: #"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"#)
   }
-
   internal enum Apples {
     /// You have %d apples
     internal static func count(_ p1: Int) -> String {
       return L10n.tr("Localizable", "apples.count", p1, fallback: #"You have %d apples"#)
     }
   }
-
   internal enum Bananas {
     /// A comment with no space above it
     internal static func owner(_ p1: Int, _ p2: Any) -> String {
       return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: #"Those %d bananas belong to %@."#)
     }
   }
-
   internal enum Key1 {
     /// Same as "key1" = "value1"; but in the context of user not logged in
     internal static let anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: #"value2"#)
   }
-
   internal enum Many {
     internal enum Placeholders {
       /// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
@@ -62,7 +58,6 @@ internal enum L10n {
       }
     }
   }
-
   internal enum Settings {
     internal enum NavigationBar {
       /// Some Reserved Keyword there
@@ -101,7 +96,6 @@ internal enum L10n {
       internal static let headerTitle = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: #"User Profile Settings"#)
     }
   }
-
   internal enum What {
     internal enum Happens {
       /// some comment

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-customName.swift
@@ -3,7 +3,7 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references 
+// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references
 
 // MARK: - Strings
 
@@ -30,26 +30,22 @@ internal enum XCTLoc {
   internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
     return XCTLoc.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: #"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"#)
   }
-
   internal enum Apples {
     /// You have %d apples
     internal static func count(_ p1: Int) -> String {
       return XCTLoc.tr("Localizable", "apples.count", p1, fallback: #"You have %d apples"#)
     }
   }
-
   internal enum Bananas {
     /// A comment with no space above it
     internal static func owner(_ p1: Int, _ p2: Any) -> String {
       return XCTLoc.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: #"Those %d bananas belong to %@."#)
     }
   }
-
   internal enum Key1 {
     /// Same as "key1" = "value1"; but in the context of user not logged in
     internal static let anonymous = XCTLoc.tr("Localizable", "key1.anonymous", fallback: #"value2"#)
   }
-
   internal enum Many {
     internal enum Placeholders {
       /// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
@@ -62,7 +58,6 @@ internal enum XCTLoc {
       }
     }
   }
-
   internal enum Settings {
     internal enum NavigationBar {
       /// Some Reserved Keyword there
@@ -101,7 +96,6 @@ internal enum XCTLoc {
       internal static let headerTitle = XCTLoc.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: #"User Profile Settings"#)
     }
   }
-
   internal enum What {
     internal enum Happens {
       /// some comment

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-forceFileNameEnum.swift
@@ -3,7 +3,7 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references 
+// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references
 
 // MARK: - Strings
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-lookupFunction.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-lookupFunction.swift
@@ -3,7 +3,7 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references 
+// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references
 
 // MARK: - Strings
 
@@ -30,26 +30,22 @@ internal enum L10n {
   internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
     return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: #"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"#)
   }
-
   internal enum Apples {
     /// You have %d apples
     internal static func count(_ p1: Int) -> String {
       return L10n.tr("Localizable", "apples.count", p1, fallback: #"You have %d apples"#)
     }
   }
-
   internal enum Bananas {
     /// A comment with no space above it
     internal static func owner(_ p1: Int, _ p2: Any) -> String {
       return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: #"Those %d bananas belong to %@."#)
     }
   }
-
   internal enum Key1 {
     /// Same as "key1" = "value1"; but in the context of user not logged in
     internal static var anonymous: String { return L10n.tr("Localizable", "key1.anonymous", fallback: #"value2"#) }
   }
-
   internal enum Many {
     internal enum Placeholders {
       /// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
@@ -62,7 +58,6 @@ internal enum L10n {
       }
     }
   }
-
   internal enum Settings {
     internal enum NavigationBar {
       /// Some Reserved Keyword there
@@ -101,7 +96,6 @@ internal enum L10n {
       internal static var headerTitle: String { return L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: #"User Profile Settings"#) }
     }
   }
-
   internal enum What {
     internal enum Happens {
       /// some comment

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-noComments.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-noComments.swift
@@ -3,7 +3,7 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references 
+// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references
 
 // MARK: - Strings
 
@@ -23,23 +23,19 @@ internal enum L10n {
   internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
     return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: #"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"#)
   }
-
   internal enum Apples {
     internal static func count(_ p1: Int) -> String {
       return L10n.tr("Localizable", "apples.count", p1, fallback: #"You have %d apples"#)
     }
   }
-
   internal enum Bananas {
     internal static func owner(_ p1: Int, _ p2: Any) -> String {
       return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: #"Those %d bananas belong to %@."#)
     }
   }
-
   internal enum Key1 {
     internal static let anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: #"value2"#)
   }
-
   internal enum Many {
     internal enum Placeholders {
       internal static func base(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
@@ -50,7 +46,6 @@ internal enum L10n {
       }
     }
   }
-
   internal enum Settings {
     internal enum NavigationBar {
       internal static let `self` = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: #"Some Reserved Keyword there"#)
@@ -84,7 +79,6 @@ internal enum L10n {
       internal static let headerTitle = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: #"User Profile Settings"#)
     }
   }
-
   internal enum What {
     internal enum Happens {
       internal static let here = L10n.tr("Localizable", "what./*happens*/.here", fallback: #"hello world! /* still in string */"#)

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-publicAccess.swift
@@ -3,7 +3,7 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references 
+// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references
 
 // MARK: - Strings
 
@@ -30,26 +30,22 @@ public enum L10n {
   public static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
     return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: #"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"#)
   }
-
   public enum Apples {
     /// You have %d apples
     public static func count(_ p1: Int) -> String {
       return L10n.tr("Localizable", "apples.count", p1, fallback: #"You have %d apples"#)
     }
   }
-
   public enum Bananas {
     /// A comment with no space above it
     public static func owner(_ p1: Int, _ p2: Any) -> String {
       return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: #"Those %d bananas belong to %@."#)
     }
   }
-
   public enum Key1 {
     /// Same as "key1" = "value1"; but in the context of user not logged in
     public static let anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: #"value2"#)
   }
-
   public enum Many {
     public enum Placeholders {
       /// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
@@ -62,7 +58,6 @@ public enum L10n {
       }
     }
   }
-
   public enum Settings {
     public enum NavigationBar {
       /// Some Reserved Keyword there
@@ -101,7 +96,6 @@ public enum L10n {
       public static let headerTitle = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: #"User Profile Settings"#)
     }
   }
-
   public enum What {
     public enum Happens {
       /// some comment

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable.swift
@@ -3,7 +3,7 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references 
+// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references
 
 // MARK: - Strings
 
@@ -30,26 +30,22 @@ internal enum L10n {
   internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
     return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: #"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"#)
   }
-
   internal enum Apples {
     /// You have %d apples
     internal static func count(_ p1: Int) -> String {
       return L10n.tr("Localizable", "apples.count", p1, fallback: #"You have %d apples"#)
     }
   }
-
   internal enum Bananas {
     /// A comment with no space above it
     internal static func owner(_ p1: Int, _ p2: Any) -> String {
       return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: #"Those %d bananas belong to %@."#)
     }
   }
-
   internal enum Key1 {
     /// Same as "key1" = "value1"; but in the context of user not logged in
     internal static let anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: #"value2"#)
   }
-
   internal enum Many {
     internal enum Placeholders {
       /// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
@@ -62,7 +58,6 @@ internal enum L10n {
       }
     }
   }
-
   internal enum Settings {
     internal enum NavigationBar {
       /// Some Reserved Keyword there
@@ -101,7 +96,6 @@ internal enum L10n {
       internal static let headerTitle = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: #"User Profile Settings"#)
     }
   }
-
   internal enum What {
     internal enum Happens {
       /// some comment

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/multiple.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/multiple.swift
@@ -3,7 +3,7 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references 
+// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references
 
 // MARK: - Strings
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-advanced.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-advanced.swift
@@ -3,14 +3,13 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references 
+// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references
 
 // MARK: - Strings
 
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
 internal enum L10n {
-
   internal enum Many {
     internal enum Placeholders {
       internal enum Plurals {
@@ -25,7 +24,6 @@ internal enum L10n {
       }
     }
   }
-
   internal enum Mixed {
     internal enum PlaceholdersAndVariables {
       /// Plural format key: "%1$@ %3$#@has_rating@"
@@ -46,7 +44,6 @@ internal enum L10n {
       }
     }
   }
-
   internal enum Multiple {
     internal enum PlaceholdersAndVariables {
       /// Plural format key: "Your %3$@ list contains %1$#@first@ %2$@."

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-same-table.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-same-table.swift
@@ -3,7 +3,7 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references 
+// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references
 
 // MARK: - Strings
 
@@ -30,21 +30,18 @@ internal enum L10n {
   internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
     return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: #"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"#)
   }
-
   internal enum Apples {
     /// Plural format key: "%#@apples@"
     internal static func count(_ p1: Int) -> String {
       return L10n.tr("Localizable", "apples.count", p1, fallback: #"Plural format key: "%#@apples@""#)
     }
   }
-
   internal enum Bananas {
     /// A comment with no space above it
     internal static func owner(_ p1: Int, _ p2: Any) -> String {
       return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: #"Those %d bananas belong to %@."#)
     }
   }
-
   internal enum Competition {
     internal enum Event {
       /// Plural format key: "%#@Matches@"
@@ -53,7 +50,6 @@ internal enum L10n {
       }
     }
   }
-
   internal enum Feed {
     internal enum Subscription {
       /// Plural format key: "%#@Subscriptions@"
@@ -62,12 +58,10 @@ internal enum L10n {
       }
     }
   }
-
   internal enum Key1 {
     /// Same as "key1" = "value1"; but in the context of user not logged in
     internal static let anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: #"value2"#)
   }
-
   internal enum Many {
     internal enum Placeholders {
       /// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
@@ -80,7 +74,6 @@ internal enum L10n {
       }
     }
   }
-
   internal enum Settings {
     internal enum NavigationBar {
       /// Some Reserved Keyword there
@@ -119,7 +112,6 @@ internal enum L10n {
       internal static let headerTitle = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: #"User Profile Settings"#)
     }
   }
-
   internal enum What {
     internal enum Happens {
       /// some comment

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-unsupported.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-unsupported.swift
@@ -3,14 +3,13 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references 
+// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references
 
 // MARK: - Strings
 
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
 internal enum L10n {
-
   internal enum UnsupportedUse {
     internal enum PlaceholdersInVariableRule {
       /// Plural format key: "%#@elements@"

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals.swift
@@ -3,21 +3,19 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references 
+// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references
 
 // MARK: - Strings
 
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
 internal enum L10n {
-
   internal enum Apples {
     /// Plural format key: "%#@apples@"
     internal static func count(_ p1: Int) -> String {
       return L10n.tr("Localizable", "apples.count", p1, fallback: #"Plural format key: "%#@apples@""#)
     }
   }
-
   internal enum Competition {
     internal enum Event {
       /// Plural format key: "%#@Matches@"
@@ -26,7 +24,6 @@ internal enum L10n {
       }
     }
   }
-
   internal enum Feed {
     internal enum Subscription {
       /// Plural format key: "%#@Subscriptions@"

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift4/all-allValues.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift4/all-allValues.swift
@@ -28,19 +28,12 @@ internal enum Asset {
       internal static let data = DataAsset(name: "Json/Data")
     }
     internal static let readme = DataAsset(name: "README")
+
     // swiftlint:disable trailing_comma
-    internal static let allResourceGroups: [ARResourceGroupAsset] = [
-    ]
-    internal static let allColors: [ColorAsset] = [
-    ]
     internal static let allDataAssets: [DataAsset] = [
       data,
       Json.data,
       readme,
-    ]
-    internal static let allImages: [ImageAsset] = [
-    ]
-    internal static let allSymbols: [SymbolAsset] = [
     ]
     // swiftlint:enable trailing_comma
   }
@@ -58,13 +51,8 @@ internal enum Asset {
       internal static let tomato = ImageAsset(name: "Round/Tomato")
     }
     internal static let `private` = ImageAsset(name: "private")
+
     // swiftlint:disable trailing_comma
-    internal static let allResourceGroups: [ARResourceGroupAsset] = [
-    ]
-    internal static let allColors: [ColorAsset] = [
-    ]
-    internal static let allDataAssets: [DataAsset] = [
-    ]
     internal static let allImages: [ImageAsset] = [
       Exotic.banana,
       Exotic.mango,
@@ -74,23 +62,9 @@ internal enum Asset {
       Round.tomato,
       `private`,
     ]
-    internal static let allSymbols: [SymbolAsset] = [
-    ]
     // swiftlint:enable trailing_comma
   }
   internal enum Other {
-    // swiftlint:disable trailing_comma
-    internal static let allResourceGroups: [ARResourceGroupAsset] = [
-    ]
-    internal static let allColors: [ColorAsset] = [
-    ]
-    internal static let allDataAssets: [DataAsset] = [
-    ]
-    internal static let allImages: [ImageAsset] = [
-    ]
-    internal static let allSymbols: [SymbolAsset] = [
-    ]
-    // swiftlint:enable trailing_comma
   }
   internal enum Styles {
     internal enum _24Vision {
@@ -102,36 +76,24 @@ internal enum Asset {
       internal static let primary = ColorAsset(name: "Vengo/Primary")
       internal static let tint = ColorAsset(name: "Vengo/Tint")
     }
+
     // swiftlint:disable trailing_comma
-    internal static let allResourceGroups: [ARResourceGroupAsset] = [
-    ]
     internal static let allColors: [ColorAsset] = [
       _24Vision.background,
       _24Vision.primary,
       Vengo.primary,
       Vengo.tint,
     ]
-    internal static let allDataAssets: [DataAsset] = [
-    ]
     internal static let allImages: [ImageAsset] = [
       orange,
-    ]
-    internal static let allSymbols: [SymbolAsset] = [
     ]
     // swiftlint:enable trailing_comma
   }
   internal enum Symbols {
     internal static let exclamationMark = SymbolAsset(name: "Exclamation Mark")
     internal static let plus = SymbolAsset(name: "Plus")
+
     // swiftlint:disable trailing_comma
-    internal static let allResourceGroups: [ARResourceGroupAsset] = [
-    ]
-    internal static let allColors: [ColorAsset] = [
-    ]
-    internal static let allDataAssets: [DataAsset] = [
-    ]
-    internal static let allImages: [ImageAsset] = [
-    ]
     internal static let allSymbols: [SymbolAsset] = [
       exclamationMark,
       plus,
@@ -142,19 +104,12 @@ internal enum Asset {
     internal static let bottles = ARResourceGroupAsset(name: "Bottles")
     internal static let paintings = ARResourceGroupAsset(name: "Paintings")
     internal static let posters = ARResourceGroupAsset(name: "Posters")
+
     // swiftlint:disable trailing_comma
     internal static let allResourceGroups: [ARResourceGroupAsset] = [
       bottles,
       paintings,
       posters,
-    ]
-    internal static let allColors: [ColorAsset] = [
-    ]
-    internal static let allDataAssets: [DataAsset] = [
-    ]
-    internal static let allImages: [ImageAsset] = [
-    ]
-    internal static let allSymbols: [SymbolAsset] = [
     ]
     // swiftlint:enable trailing_comma
   }

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-allValues.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-allValues.swift
@@ -28,19 +28,12 @@ internal enum Asset {
       internal static let data = DataAsset(name: "Json/Data")
     }
     internal static let readme = DataAsset(name: "README")
+
     // swiftlint:disable trailing_comma
-    internal static let allResourceGroups: [ARResourceGroupAsset] = [
-    ]
-    internal static let allColors: [ColorAsset] = [
-    ]
     internal static let allDataAssets: [DataAsset] = [
       data,
       Json.data,
       readme,
-    ]
-    internal static let allImages: [ImageAsset] = [
-    ]
-    internal static let allSymbols: [SymbolAsset] = [
     ]
     // swiftlint:enable trailing_comma
   }
@@ -58,13 +51,8 @@ internal enum Asset {
       internal static let tomato = ImageAsset(name: "Round/Tomato")
     }
     internal static let `private` = ImageAsset(name: "private")
+
     // swiftlint:disable trailing_comma
-    internal static let allResourceGroups: [ARResourceGroupAsset] = [
-    ]
-    internal static let allColors: [ColorAsset] = [
-    ]
-    internal static let allDataAssets: [DataAsset] = [
-    ]
     internal static let allImages: [ImageAsset] = [
       Exotic.banana,
       Exotic.mango,
@@ -74,23 +62,9 @@ internal enum Asset {
       Round.tomato,
       `private`,
     ]
-    internal static let allSymbols: [SymbolAsset] = [
-    ]
     // swiftlint:enable trailing_comma
   }
   internal enum Other {
-    // swiftlint:disable trailing_comma
-    internal static let allResourceGroups: [ARResourceGroupAsset] = [
-    ]
-    internal static let allColors: [ColorAsset] = [
-    ]
-    internal static let allDataAssets: [DataAsset] = [
-    ]
-    internal static let allImages: [ImageAsset] = [
-    ]
-    internal static let allSymbols: [SymbolAsset] = [
-    ]
-    // swiftlint:enable trailing_comma
   }
   internal enum Styles {
     internal enum _24Vision {
@@ -102,36 +76,24 @@ internal enum Asset {
       internal static let primary = ColorAsset(name: "Vengo/Primary")
       internal static let tint = ColorAsset(name: "Vengo/Tint")
     }
+
     // swiftlint:disable trailing_comma
-    internal static let allResourceGroups: [ARResourceGroupAsset] = [
-    ]
     internal static let allColors: [ColorAsset] = [
       _24Vision.background,
       _24Vision.primary,
       Vengo.primary,
       Vengo.tint,
     ]
-    internal static let allDataAssets: [DataAsset] = [
-    ]
     internal static let allImages: [ImageAsset] = [
       orange,
-    ]
-    internal static let allSymbols: [SymbolAsset] = [
     ]
     // swiftlint:enable trailing_comma
   }
   internal enum Symbols {
     internal static let exclamationMark = SymbolAsset(name: "Exclamation Mark")
     internal static let plus = SymbolAsset(name: "Plus")
+
     // swiftlint:disable trailing_comma
-    internal static let allResourceGroups: [ARResourceGroupAsset] = [
-    ]
-    internal static let allColors: [ColorAsset] = [
-    ]
-    internal static let allDataAssets: [DataAsset] = [
-    ]
-    internal static let allImages: [ImageAsset] = [
-    ]
     internal static let allSymbols: [SymbolAsset] = [
       exclamationMark,
       plus,
@@ -142,19 +104,12 @@ internal enum Asset {
     internal static let bottles = ARResourceGroupAsset(name: "Bottles")
     internal static let paintings = ARResourceGroupAsset(name: "Paintings")
     internal static let posters = ARResourceGroupAsset(name: "Posters")
+
     // swiftlint:disable trailing_comma
     internal static let allResourceGroups: [ARResourceGroupAsset] = [
       bottles,
       paintings,
       posters,
-    ]
-    internal static let allColors: [ColorAsset] = [
-    ]
-    internal static let allDataAssets: [DataAsset] = [
-    ]
-    internal static let allImages: [ImageAsset] = [
-    ]
-    internal static let allSymbols: [SymbolAsset] = [
     ]
     // swiftlint:enable trailing_comma
   }

--- a/Sources/TestUtils/VariationGenerator.swift
+++ b/Sources/TestUtils/VariationGenerator.swift
@@ -43,7 +43,7 @@ public extension XCTestCase {
     let template: Template
     do {
       let templateRealPath = Fixtures.template(for: "\(templateName).stencil", sub: directory)
-      template = try Template.load(from: templateRealPath, modernSpacing: false)
+      template = try Template.load(from: templateRealPath, modernSpacing: true)
     } catch {
       fatalError("Unable to load fixture \(templateName)'s content: \(error)")
     }

--- a/Sources/TestUtils/VariationGenerator.swift
+++ b/Sources/TestUtils/VariationGenerator.swift
@@ -5,6 +5,7 @@
 //
 
 import PathKit
+import Stencil
 import StencilSwiftKit
 import SwiftGenKit
 import XCTest
@@ -39,13 +40,10 @@ public extension XCTestCase {
     contextVariations: VariationGenerator? = nil,
     outputExtension: String = "swift"
   ) {
-    let template: StencilSwiftTemplate
+    let template: Template
     do {
       let templateRealPath = Fixtures.template(for: "\(templateName).stencil", sub: directory)
-      template = StencilSwiftTemplate(
-        templateString: try templateRealPath.read(),
-        environment: stencilSwiftEnvironment(templatePaths: [templateRealPath.parent()])
-      )
+      template = try Template.load(from: templateRealPath, modernSpacing: false)
     } catch {
       fatalError("Unable to load fixture \(templateName)'s content: \(error)")
     }

--- a/Tests/SwiftGenTests/ConfigRunTests.swift
+++ b/Tests/SwiftGenTests/ConfigRunTests.swift
@@ -27,7 +27,7 @@ final class ConfigRunTests: XCTestCase {
     do {
       let config = try Config(file: configFile, logger: logger.log)
       try configFile.parent().chdir {
-        try config.runCommands(logLevel: .verbose, logger: logger.log)
+        try config.runCommands(modernSpacing: true, logLevel: .verbose, logger: logger.log)
       }
     } catch Config.Error.multipleErrors(let errors) {
       errors.forEach(logger.handleError)

--- a/rakelib/utils.rake
+++ b/rakelib/utils.rake
@@ -49,19 +49,19 @@ class Utils
   def self.pod_trunk_last_version(pod)
     require 'yaml'
     stdout, _, _ = Open3.capture3('bundle', 'exec', 'pod', 'trunk', 'info', pod)
-    stdout.sub!("\n#{pod}\n", '')
-    last_version_line = YAML.safe_load(stdout).first['Versions'].last
-    /^[0-9.]*/.match(last_version_line)[0] # Just the 'x.y.z' part
+    stdout.sub!("\n#{pod}\n", '').gsub!(/ \(\d+-\d+-\d+ \d+:\d+:\d+ .+\)/, '')
+    versions = YAML.safe_load(stdout).first['Versions']
+    versions.sort_by { |v| Gem::Version.new(v) }.last
   end
 
   def self.spm_own_version(dep)
-    dependencies = JSON.load(File.new('Package.resolved'))['object']['pins']
-    dependencies.find { |d| d['package'] == dep }['state']['version']
+    dependencies = JSON.load(File.new('Package.resolved'))['pins']
+    dependencies.find { |d| d['identity'] == dep.downcase }['state']['version']
   end  
 
   def self.spm_resolved_version(dep)
-    dependencies = JSON.load(File.new('Package.resolved'))['object']['pins']
-    dependencies.find { |d| d['package'] == dep }['state']['version']
+    dependencies = JSON.load(File.new('Package.resolved'))['pins']
+    dependencies.find { |d| d['identity'] == dep.downcase }['state']['version']
   end
 
   def self.last_git_tag_version


### PR DESCRIPTION
* Updates to Stencil 0.15 and SSK 2.10
* Our spacing & trimming "hack" is now considered deprecated, and in the next major version we'll switch to Stencil's new "smart" trimming behaviour (see [Stencil documentation](https://stencil.fuller.li/en/latest/templates.html#whitespace-control) for more information)
* Our built-in templates have already switched to this modern behaviour
* Users can try it with their own templates by using the `--experimental-modern-spacing` flag.  

From SSK 2.10:
* Deprecates custom template class workaround
* Deprecates `removeNewlines` filter