### PR TITLE
Basic SwiftUI support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@
 * Added an experimental flag `--experimental-modern-spacing` to enable modern spacing control, see [Stencil documentation](https://stencil.fuller.li/en/latest/templates.html#whitespace-control) for more information. It will disable our own trimming "hack", and enable Stencil's "smart" trimming.  
   [David Jennes](https://github.com/djbe)
   [#977](https://github.com/SwiftGen/SwiftGen/pull/977)
+* XCAssets & Fonts: added support for SwiftUI. You can now easily access colors images, symbols and custom fonts from your SwiftUI code.  
+  [David Jennes](https://github.com/djbe)
+  [#979](https://github.com/SwiftGen/SwiftGen/pull/979)
 
 ### Bug Fixes
 

--- a/Sources/SwiftGenCLI/templates/fonts/swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/fonts/swift5.stencil
@@ -9,13 +9,15 @@
 #elseif os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIFont
 #endif
+#if canImport(SwiftUI)
+  import SwiftUI
+#endif
 
 // Deprecated typealiases
 @available(*, deprecated, renamed: "{{fontType}}.Font", message: "This typealias will be removed in SwiftGen 7.0")
 {{accessModifier}} typealias {{param.fontAliasName|default:"Font"}} = {{fontType}}.Font
 
-// swiftlint:disable superfluous_disable_command
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length implicit_return
 
 // MARK: - Fonts
 
@@ -63,10 +65,39 @@
     return font
   }
 
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  {{accessModifier}} func swiftUIFont(size: CGFloat) -> SwiftUI.Font {
+    return SwiftUI.Font.custom(self, size: size)
+  }
+
+  @available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
+  {{accessModifier}} func swiftUIFont(fixedSize: CGFloat) -> SwiftUI.Font {
+    return SwiftUI.Font.custom(self, fixedSize: fixedSize)
+  }
+
+  @available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
+  {{accessModifier}} func swiftUIFont(size: CGFloat, relativeTo textStyle: SwiftUI.Font.TextStyle) -> SwiftUI.Font {
+    return SwiftUI.Font.custom(self, size: size, relativeTo: textStyle)
+  }
+  #endif
+
   {{accessModifier}} func register() {
     // swiftlint:disable:next conditional_returns_on_newline
     guard let url = url else { return }
     CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
+  }
+
+  fileprivate func registerIfNeeded() {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    if !UIFont.fontNames(forFamilyName: family).contains(name) {
+      register()
+    }
+    #elseif os(macOS)
+    if let url = url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
+      register()
+    }
+    #endif
   }
 
   fileprivate var url: URL? {
@@ -81,19 +112,37 @@
 
 {{accessModifier}} extension {{fontType}}.Font {
   convenience init?(font: {{fontType}}, size: CGFloat) {
-    #if os(iOS) || os(tvOS) || os(watchOS)
-    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
-      font.register()
-    }
-    #elseif os(macOS)
-    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
-      font.register()
-    }
-    #endif
-
+    font.registerIfNeeded()
     self.init(name: font.name, size: size)
   }
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+{{accessModifier}} extension SwiftUI.Font {
+  static func custom(_ font: {{fontType}}, size: CGFloat) -> SwiftUI.Font {
+    font.registerIfNeeded()
+    return custom(font.name, size: size)
+  }
+}
+
+@available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
+{{accessModifier}} extension SwiftUI.Font {
+  static func custom(_ font: {{fontType}}, fixedSize: CGFloat) -> SwiftUI.Font {
+    font.registerIfNeeded()
+    return custom(font.name, fixedSize: fixedSize)
+  }
+
+  static func custom(
+    _ font: {{fontType}},
+    size: CGFloat,
+    relativeTo textStyle: SwiftUI.Font.TextStyle
+  ) -> SwiftUI.Font {
+    font.registerIfNeeded()
+    return custom(font.name, size: size, relativeTo: textStyle)
+  }
+}
+#endif
 {% if not param.bundle and not param.lookupFunction %}
 
 // swiftlint:disable convenience_type

--- a/Sources/SwiftGenCLI/templates/xcassets/swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/xcassets/swift4.stencil
@@ -2,6 +2,15 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 {% if catalogs %}
+{% macro hasValuesBlock assets filter %}
+  {%- for asset in assets -%}
+    {%- if asset.type == filter -%}
+      1
+    {%- elif asset.items -%}
+      {% call hasValuesBlock asset.items filter %}
+    {%- endif -%}
+  {%- endfor -%}
+{% endmacro %}
 {% set enumName %}{{param.enumName|default:"Asset"}}{% endset %}
 {% set arResourceGroupType %}{{param.arResourceGroupTypeName|default:"ARResourceGroupAsset"}}{% endset %}
 {% set colorType %}{{param.colorTypeName|default:"ColorAsset"}}{% endset %}
@@ -10,10 +19,15 @@
 {% set symbolType %}{{param.symbolTypeName|default:"SymbolAsset"}}{% endset %}
 {% set forceNamespaces %}{{param.forceProvidesNamespaces|default:"false"}}{% endset %}
 {% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+{% set hasARResourceGroup %}{% for catalog in catalogs %}{% call hasValuesBlock catalog.assets "arresourcegroup" %}{% endfor %}{% endset %}
+{% set hasColor %}{% for catalog in catalogs %}{% call hasValuesBlock catalog.assets "color" %}{% endfor %}{% endset %}
+{% set hasData %}{% for catalog in catalogs %}{% call hasValuesBlock catalog.assets "data" %}{% endfor %}{% endset %}
+{% set hasImage %}{% for catalog in catalogs %}{% call hasValuesBlock catalog.assets "image" %}{% endfor %}{% endset %}
+{% set hasSymbol %}{% for catalog in catalogs %}{% call hasValuesBlock catalog.assets "symbol" %}{% endfor %}{% endset %}
 #if os(macOS)
   import AppKit
 #elseif os(iOS)
-{% if resourceCount.arresourcegroup > 0 %}
+{% if hasARResourceGroup %}
   import ARKit
 {% endif %}
   import UIKit
@@ -22,11 +36,11 @@
 #endif
 
 // Deprecated typealiases
-{% if resourceCount.color > 0 %}
+{% if hasColor %}
 @available(*, deprecated, renamed: "{{colorType}}.Color", message: "This typealias will be removed in SwiftGen 7.0")
 {{accessModifier}} typealias {{param.colorAliasName|default:"AssetColorTypeAlias"}} = {{colorType}}.Color
 {% endif %}
-{% if resourceCount.image > 0 %}
+{% if hasImage %}
 @available(*, deprecated, renamed: "{{imageType}}.Image", message: "This typealias will be removed in SwiftGen 7.0")
 {{accessModifier}} typealias {{param.imageAliasName|default:"AssetImageTypeAlias"}} = {{imageType}}.Image
 {% endif %}
@@ -99,15 +113,6 @@
   {% endif %}
   {% endfor %}
 {% endmacro %}
-{% macro hasValuesBlock assets filter %}
-  {%- for asset in assets -%}
-    {%- if asset.type == filter -%}
-      1
-    {%- elif asset.items -%}
-      {% call hasValuesBlock asset.items filter %}
-    {%- endif -%}
-  {%- endfor -%}
-{% endmacro %}
 {% macro allValuesBlock assets filter prefix %}
   {% for asset in assets %}
   {% if asset.type == filter %}
@@ -137,7 +142,7 @@
 // swiftlint:enable identifier_name line_length nesting type_body_length type_name
 
 // MARK: - Implementation Details
-{% if resourceCount.arresourcegroup > 0 %}
+{% if hasARResourceGroup %}
 
 {{accessModifier}} struct {{arResourceGroupType}} {
   {{accessModifier}} fileprivate(set) var name: String
@@ -173,7 +178,7 @@
 }
 #endif
 {% endif %}
-{% if resourceCount.color > 0 %}
+{% if hasColor %}
 
 {{accessModifier}} final class {{colorType}} {
   {{accessModifier}} fileprivate(set) var name: String
@@ -217,7 +222,7 @@
   }
 }
 {% endif %}
-{% if resourceCount.data > 0 %}
+{% if hasData %}
 
 {{accessModifier}} struct {{dataType}} {
   {{accessModifier}} fileprivate(set) var name: String
@@ -240,7 +245,7 @@
   }
 }
 {% endif %}
-{% if resourceCount.image > 0 %}
+{% if hasImage %}
 
 {{accessModifier}} struct {{imageType}} {
   {{accessModifier}} fileprivate(set) var name: String
@@ -296,7 +301,7 @@
   }
 }
 {% endif %}
-{% if resourceCount.symbol > 0 %}
+{% if hasSymbol %}
 
 {{accessModifier}} struct {{symbolType}} {
   {{accessModifier}} fileprivate(set) var name: String

--- a/Sources/SwiftGenCLI/templates/xcassets/swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/xcassets/swift5.stencil
@@ -34,6 +34,9 @@
 #elseif os(tvOS) || os(watchOS)
   import UIKit
 #endif
+#if canImport(SwiftUI)
+  import SwiftUI
+#endif
 
 // Deprecated typealiases
 {% if hasColor %}
@@ -208,6 +211,13 @@
   }
   #endif
 
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  {{accessModifier}} private(set) lazy var swiftUIColor: SwiftUI.Color = {
+    SwiftUI.Color(asset: self)
+  }()
+  #endif
+
   fileprivate init(name: String) {
     self.name = name
   }
@@ -226,6 +236,16 @@
     #endif
   }
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+{{accessModifier}} extension SwiftUI.Color {
+  init(asset: {{colorType}}) {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    self.init(asset.name, bundle: bundle)
+  }
+}
+#endif
 {% endif %}
 {% if hasData %}
 

--- a/Sources/SwiftGenCLI/templates/xcassets/swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/xcassets/swift5.stencil
@@ -389,7 +389,34 @@
     return result
   }
   #endif
+
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  {{accessModifier}} var swiftUIImage: SwiftUI.Image {
+    SwiftUI.Image(asset: self)
+  }
+  #endif
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+{{accessModifier}} extension SwiftUI.Image {
+  init(asset: {{symbolType}}) {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    self.init(asset.name, bundle: bundle)
+  }
+
+  init(asset: {{symbolType}}, label: Text) {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    self.init(asset.name, bundle: bundle, label: label)
+  }
+
+  init(decorative asset: {{symbolType}}) {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    self.init(decorative: asset.name, bundle: bundle)
+  }
+}
+#endif
 {% endif %}
 {% if not param.bundle %}
 

--- a/Sources/SwiftGenCLI/templates/xcassets/swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/xcassets/swift5.stencil
@@ -2,6 +2,15 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 {% if catalogs %}
+{% macro hasValuesBlock assets filter %}
+  {%- for asset in assets -%}
+    {%- if asset.type == filter -%}
+      1
+    {%- elif asset.items -%}
+      {% call hasValuesBlock asset.items filter %}
+    {%- endif -%}
+  {%- endfor -%}
+{% endmacro %}
 {% set enumName %}{{param.enumName|default:"Asset"}}{% endset %}
 {% set arResourceGroupType %}{{param.arResourceGroupTypeName|default:"ARResourceGroupAsset"}}{% endset %}
 {% set colorType %}{{param.colorTypeName|default:"ColorAsset"}}{% endset %}
@@ -10,10 +19,15 @@
 {% set symbolType %}{{param.symbolTypeName|default:"SymbolAsset"}}{% endset %}
 {% set forceNamespaces %}{{param.forceProvidesNamespaces|default:"false"}}{% endset %}
 {% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+{% set hasARResourceGroup %}{% for catalog in catalogs %}{% call hasValuesBlock catalog.assets "arresourcegroup" %}{% endfor %}{% endset %}
+{% set hasColor %}{% for catalog in catalogs %}{% call hasValuesBlock catalog.assets "color" %}{% endfor %}{% endset %}
+{% set hasData %}{% for catalog in catalogs %}{% call hasValuesBlock catalog.assets "data" %}{% endfor %}{% endset %}
+{% set hasImage %}{% for catalog in catalogs %}{% call hasValuesBlock catalog.assets "image" %}{% endfor %}{% endset %}
+{% set hasSymbol %}{% for catalog in catalogs %}{% call hasValuesBlock catalog.assets "symbol" %}{% endfor %}{% endset %}
 #if os(macOS)
   import AppKit
 #elseif os(iOS)
-{% if resourceCount.arresourcegroup > 0 %}
+{% if hasARResourceGroup %}
   import ARKit
 {% endif %}
   import UIKit
@@ -22,11 +36,11 @@
 #endif
 
 // Deprecated typealiases
-{% if resourceCount.color > 0 %}
+{% if hasColor %}
 @available(*, deprecated, renamed: "{{colorType}}.Color", message: "This typealias will be removed in SwiftGen 7.0")
 {{accessModifier}} typealias {{param.colorAliasName|default:"AssetColorTypeAlias"}} = {{colorType}}.Color
 {% endif %}
-{% if resourceCount.image > 0 %}
+{% if hasImage %}
 @available(*, deprecated, renamed: "{{imageType}}.Image", message: "This typealias will be removed in SwiftGen 7.0")
 {{accessModifier}} typealias {{param.imageAliasName|default:"AssetImageTypeAlias"}} = {{imageType}}.Image
 {% endif %}
@@ -99,15 +113,6 @@
   {% endif %}
   {% endfor %}
 {% endmacro %}
-{% macro hasValuesBlock assets filter %}
-  {%- for asset in assets -%}
-    {%- if asset.type == filter -%}
-      1
-    {%- elif asset.items -%}
-      {% call hasValuesBlock asset.items filter %}
-    {%- endif -%}
-  {%- endfor -%}
-{% endmacro %}
 {% macro allValuesBlock assets filter prefix %}
   {% for asset in assets %}
   {% if asset.type == filter %}
@@ -137,7 +142,7 @@
 // swiftlint:enable identifier_name line_length nesting type_body_length type_name
 
 // MARK: - Implementation Details
-{% if resourceCount.arresourcegroup > 0 %}
+{% if hasARResourceGroup %}
 
 {{accessModifier}} struct {{arResourceGroupType}} {
   {{accessModifier}} fileprivate(set) var name: String
@@ -173,7 +178,7 @@
 }
 #endif
 {% endif %}
-{% if resourceCount.color > 0 %}
+{% if hasColor %}
 
 {{accessModifier}} final class {{colorType}} {
   {{accessModifier}} fileprivate(set) var name: String
@@ -222,7 +227,7 @@
   }
 }
 {% endif %}
-{% if resourceCount.data > 0 %}
+{% if hasData %}
 
 {{accessModifier}} struct {{dataType}} {
   {{accessModifier}} fileprivate(set) var name: String
@@ -248,7 +253,7 @@
   }
 }
 {% endif %}
-{% if resourceCount.image > 0 %}
+{% if hasImage %}
 
 {{accessModifier}} struct {{imageType}} {
   {{accessModifier}} fileprivate(set) var name: String
@@ -304,7 +309,7 @@
   }
 }
 {% endif %}
-{% if resourceCount.symbol > 0 %}
+{% if hasSymbol %}
 
 {{accessModifier}} struct {{symbolType}} {
   {{accessModifier}} fileprivate(set) var name: String

--- a/Sources/SwiftGenCLI/templates/xcassets/swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/xcassets/swift5.stencil
@@ -311,6 +311,13 @@
     return result
   }
   #endif
+
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  {{accessModifier}} var swiftUIImage: SwiftUI.Image {
+    SwiftUI.Image(asset: self)
+  }
+  #endif
 }
 
 {{accessModifier}} extension {{imageType}}.Image {
@@ -328,6 +335,26 @@
     #endif
   }
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+{{accessModifier}} extension SwiftUI.Image {
+  init(asset: {{imageType}}) {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    self.init(asset.name, bundle: bundle)
+  }
+
+  init(asset: {{imageType}}, label: Text) {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    self.init(asset.name, bundle: bundle, label: label)
+  }
+
+  init(decorative asset: {{imageType}}) {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    self.init(decorative: asset.name, bundle: bundle)
+  }
+}
+#endif
 {% endif %}
 {% if hasSymbol %}
 

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults-customName.swift
@@ -6,13 +6,15 @@
 #elseif os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIFont
 #endif
+#if canImport(SwiftUI)
+  import SwiftUI
+#endif
 
 // Deprecated typealiases
 @available(*, deprecated, renamed: "MyFontConvertible.Font", message: "This typealias will be removed in SwiftGen 7.0")
 internal typealias MyFont = MyFontConvertible.Font
 
-// swiftlint:disable superfluous_disable_command
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length implicit_return
 
 // MARK: - Fonts
 
@@ -81,10 +83,39 @@ internal struct MyFontConvertible {
     return font
   }
 
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal func swiftUIFont(size: CGFloat) -> SwiftUI.Font {
+    return SwiftUI.Font.custom(self, size: size)
+  }
+
+  @available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
+  internal func swiftUIFont(fixedSize: CGFloat) -> SwiftUI.Font {
+    return SwiftUI.Font.custom(self, fixedSize: fixedSize)
+  }
+
+  @available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
+  internal func swiftUIFont(size: CGFloat, relativeTo textStyle: SwiftUI.Font.TextStyle) -> SwiftUI.Font {
+    return SwiftUI.Font.custom(self, size: size, relativeTo: textStyle)
+  }
+  #endif
+
   internal func register() {
     // swiftlint:disable:next conditional_returns_on_newline
     guard let url = url else { return }
     CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
+  }
+
+  fileprivate func registerIfNeeded() {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    if !UIFont.fontNames(forFamilyName: family).contains(name) {
+      register()
+    }
+    #elseif os(macOS)
+    if let url = url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
+      register()
+    }
+    #endif
   }
 
   fileprivate var url: URL? {
@@ -95,19 +126,37 @@ internal struct MyFontConvertible {
 
 internal extension MyFontConvertible.Font {
   convenience init?(font: MyFontConvertible, size: CGFloat) {
-    #if os(iOS) || os(tvOS) || os(watchOS)
-    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
-      font.register()
-    }
-    #elseif os(macOS)
-    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
-      font.register()
-    }
-    #endif
-
+    font.registerIfNeeded()
     self.init(name: font.name, size: size)
   }
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+internal extension SwiftUI.Font {
+  static func custom(_ font: MyFontConvertible, size: CGFloat) -> SwiftUI.Font {
+    font.registerIfNeeded()
+    return custom(font.name, size: size)
+  }
+}
+
+@available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
+internal extension SwiftUI.Font {
+  static func custom(_ font: MyFontConvertible, fixedSize: CGFloat) -> SwiftUI.Font {
+    font.registerIfNeeded()
+    return custom(font.name, fixedSize: fixedSize)
+  }
+
+  static func custom(
+    _ font: MyFontConvertible,
+    size: CGFloat,
+    relativeTo textStyle: SwiftUI.Font.TextStyle
+  ) -> SwiftUI.Font {
+    font.registerIfNeeded()
+    return custom(font.name, size: size, relativeTo: textStyle)
+  }
+}
+#endif
 
 // swiftlint:disable convenience_type
 private final class BundleToken {

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults-preservePath.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults-preservePath.swift
@@ -6,13 +6,15 @@
 #elseif os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIFont
 #endif
+#if canImport(SwiftUI)
+  import SwiftUI
+#endif
 
 // Deprecated typealiases
 @available(*, deprecated, renamed: "FontConvertible.Font", message: "This typealias will be removed in SwiftGen 7.0")
 internal typealias Font = FontConvertible.Font
 
-// swiftlint:disable superfluous_disable_command
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length implicit_return
 
 // MARK: - Fonts
 
@@ -81,10 +83,39 @@ internal struct FontConvertible {
     return font
   }
 
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal func swiftUIFont(size: CGFloat) -> SwiftUI.Font {
+    return SwiftUI.Font.custom(self, size: size)
+  }
+
+  @available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
+  internal func swiftUIFont(fixedSize: CGFloat) -> SwiftUI.Font {
+    return SwiftUI.Font.custom(self, fixedSize: fixedSize)
+  }
+
+  @available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
+  internal func swiftUIFont(size: CGFloat, relativeTo textStyle: SwiftUI.Font.TextStyle) -> SwiftUI.Font {
+    return SwiftUI.Font.custom(self, size: size, relativeTo: textStyle)
+  }
+  #endif
+
   internal func register() {
     // swiftlint:disable:next conditional_returns_on_newline
     guard let url = url else { return }
     CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
+  }
+
+  fileprivate func registerIfNeeded() {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    if !UIFont.fontNames(forFamilyName: family).contains(name) {
+      register()
+    }
+    #elseif os(macOS)
+    if let url = url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
+      register()
+    }
+    #endif
   }
 
   fileprivate var url: URL? {
@@ -95,19 +126,37 @@ internal struct FontConvertible {
 
 internal extension FontConvertible.Font {
   convenience init?(font: FontConvertible, size: CGFloat) {
-    #if os(iOS) || os(tvOS) || os(watchOS)
-    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
-      font.register()
-    }
-    #elseif os(macOS)
-    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
-      font.register()
-    }
-    #endif
-
+    font.registerIfNeeded()
     self.init(name: font.name, size: size)
   }
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+internal extension SwiftUI.Font {
+  static func custom(_ font: FontConvertible, size: CGFloat) -> SwiftUI.Font {
+    font.registerIfNeeded()
+    return custom(font.name, size: size)
+  }
+}
+
+@available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
+internal extension SwiftUI.Font {
+  static func custom(_ font: FontConvertible, fixedSize: CGFloat) -> SwiftUI.Font {
+    font.registerIfNeeded()
+    return custom(font.name, fixedSize: fixedSize)
+  }
+
+  static func custom(
+    _ font: FontConvertible,
+    size: CGFloat,
+    relativeTo textStyle: SwiftUI.Font.TextStyle
+  ) -> SwiftUI.Font {
+    font.registerIfNeeded()
+    return custom(font.name, size: size, relativeTo: textStyle)
+  }
+}
+#endif
 
 // swiftlint:disable convenience_type
 private final class BundleToken {

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults-publicAccess.swift
@@ -6,13 +6,15 @@
 #elseif os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIFont
 #endif
+#if canImport(SwiftUI)
+  import SwiftUI
+#endif
 
 // Deprecated typealiases
 @available(*, deprecated, renamed: "FontConvertible.Font", message: "This typealias will be removed in SwiftGen 7.0")
 public typealias Font = FontConvertible.Font
 
-// swiftlint:disable superfluous_disable_command
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length implicit_return
 
 // MARK: - Fonts
 
@@ -81,10 +83,39 @@ public struct FontConvertible {
     return font
   }
 
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  public func swiftUIFont(size: CGFloat) -> SwiftUI.Font {
+    return SwiftUI.Font.custom(self, size: size)
+  }
+
+  @available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
+  public func swiftUIFont(fixedSize: CGFloat) -> SwiftUI.Font {
+    return SwiftUI.Font.custom(self, fixedSize: fixedSize)
+  }
+
+  @available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
+  public func swiftUIFont(size: CGFloat, relativeTo textStyle: SwiftUI.Font.TextStyle) -> SwiftUI.Font {
+    return SwiftUI.Font.custom(self, size: size, relativeTo: textStyle)
+  }
+  #endif
+
   public func register() {
     // swiftlint:disable:next conditional_returns_on_newline
     guard let url = url else { return }
     CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
+  }
+
+  fileprivate func registerIfNeeded() {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    if !UIFont.fontNames(forFamilyName: family).contains(name) {
+      register()
+    }
+    #elseif os(macOS)
+    if let url = url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
+      register()
+    }
+    #endif
   }
 
   fileprivate var url: URL? {
@@ -95,19 +126,37 @@ public struct FontConvertible {
 
 public extension FontConvertible.Font {
   convenience init?(font: FontConvertible, size: CGFloat) {
-    #if os(iOS) || os(tvOS) || os(watchOS)
-    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
-      font.register()
-    }
-    #elseif os(macOS)
-    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
-      font.register()
-    }
-    #endif
-
+    font.registerIfNeeded()
     self.init(name: font.name, size: size)
   }
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+public extension SwiftUI.Font {
+  static func custom(_ font: FontConvertible, size: CGFloat) -> SwiftUI.Font {
+    font.registerIfNeeded()
+    return custom(font.name, size: size)
+  }
+}
+
+@available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
+public extension SwiftUI.Font {
+  static func custom(_ font: FontConvertible, fixedSize: CGFloat) -> SwiftUI.Font {
+    font.registerIfNeeded()
+    return custom(font.name, fixedSize: fixedSize)
+  }
+
+  static func custom(
+    _ font: FontConvertible,
+    size: CGFloat,
+    relativeTo textStyle: SwiftUI.Font.TextStyle
+  ) -> SwiftUI.Font {
+    font.registerIfNeeded()
+    return custom(font.name, size: size, relativeTo: textStyle)
+  }
+}
+#endif
 
 // swiftlint:disable convenience_type
 private final class BundleToken {

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults.swift
@@ -6,13 +6,15 @@
 #elseif os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIFont
 #endif
+#if canImport(SwiftUI)
+  import SwiftUI
+#endif
 
 // Deprecated typealiases
 @available(*, deprecated, renamed: "FontConvertible.Font", message: "This typealias will be removed in SwiftGen 7.0")
 internal typealias Font = FontConvertible.Font
 
-// swiftlint:disable superfluous_disable_command
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length implicit_return
 
 // MARK: - Fonts
 
@@ -81,10 +83,39 @@ internal struct FontConvertible {
     return font
   }
 
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal func swiftUIFont(size: CGFloat) -> SwiftUI.Font {
+    return SwiftUI.Font.custom(self, size: size)
+  }
+
+  @available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
+  internal func swiftUIFont(fixedSize: CGFloat) -> SwiftUI.Font {
+    return SwiftUI.Font.custom(self, fixedSize: fixedSize)
+  }
+
+  @available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
+  internal func swiftUIFont(size: CGFloat, relativeTo textStyle: SwiftUI.Font.TextStyle) -> SwiftUI.Font {
+    return SwiftUI.Font.custom(self, size: size, relativeTo: textStyle)
+  }
+  #endif
+
   internal func register() {
     // swiftlint:disable:next conditional_returns_on_newline
     guard let url = url else { return }
     CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
+  }
+
+  fileprivate func registerIfNeeded() {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    if !UIFont.fontNames(forFamilyName: family).contains(name) {
+      register()
+    }
+    #elseif os(macOS)
+    if let url = url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
+      register()
+    }
+    #endif
   }
 
   fileprivate var url: URL? {
@@ -95,19 +126,37 @@ internal struct FontConvertible {
 
 internal extension FontConvertible.Font {
   convenience init?(font: FontConvertible, size: CGFloat) {
-    #if os(iOS) || os(tvOS) || os(watchOS)
-    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
-      font.register()
-    }
-    #elseif os(macOS)
-    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
-      font.register()
-    }
-    #endif
-
+    font.registerIfNeeded()
     self.init(name: font.name, size: size)
   }
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+internal extension SwiftUI.Font {
+  static func custom(_ font: FontConvertible, size: CGFloat) -> SwiftUI.Font {
+    font.registerIfNeeded()
+    return custom(font.name, size: size)
+  }
+}
+
+@available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
+internal extension SwiftUI.Font {
+  static func custom(_ font: FontConvertible, fixedSize: CGFloat) -> SwiftUI.Font {
+    font.registerIfNeeded()
+    return custom(font.name, fixedSize: fixedSize)
+  }
+
+  static func custom(
+    _ font: FontConvertible,
+    size: CGFloat,
+    relativeTo textStyle: SwiftUI.Font.TextStyle
+  ) -> SwiftUI.Font {
+    font.registerIfNeeded()
+    return custom(font.name, size: size, relativeTo: textStyle)
+  }
+}
+#endif
 
 // swiftlint:disable convenience_type
 private final class BundleToken {

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-allValues.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-allValues.swift
@@ -9,6 +9,9 @@
 #elseif os(tvOS) || os(watchOS)
   import UIKit
 #endif
+#if canImport(SwiftUI)
+  import SwiftUI
+#endif
 
 // Deprecated typealiases
 @available(*, deprecated, renamed: "ColorAsset.Color", message: "This typealias will be removed in SwiftGen 7.0")
@@ -186,6 +189,13 @@ internal final class ColorAsset {
   }
   #endif
 
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal private(set) lazy var swiftUIColor: SwiftUI.Color = {
+    SwiftUI.Color(asset: self)
+  }()
+  #endif
+
   fileprivate init(name: String) {
     self.name = name
   }
@@ -204,6 +214,16 @@ internal extension ColorAsset.Color {
     #endif
   }
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+internal extension SwiftUI.Color {
+  init(asset: ColorAsset) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle)
+  }
+}
+#endif
 
 internal struct DataAsset {
   internal fileprivate(set) var name: String

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-allValues.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-allValues.swift
@@ -361,7 +361,34 @@ internal struct SymbolAsset {
     return result
   }
   #endif
+
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal var swiftUIImage: SwiftUI.Image {
+    SwiftUI.Image(asset: self)
+  }
+  #endif
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+internal extension SwiftUI.Image {
+  init(asset: SymbolAsset) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle)
+  }
+
+  init(asset: SymbolAsset, label: Text) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle, label: label)
+  }
+
+  init(decorative asset: SymbolAsset) {
+    let bundle = BundleToken.bundle
+    self.init(decorative: asset.name, bundle: bundle)
+  }
+}
+#endif
 
 // swiftlint:disable convenience_type
 private final class BundleToken {

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-allValues.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-allValues.swift
@@ -285,6 +285,13 @@ internal struct ImageAsset {
     return result
   }
   #endif
+
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal var swiftUIImage: SwiftUI.Image {
+    SwiftUI.Image(asset: self)
+  }
+  #endif
 }
 
 internal extension ImageAsset.Image {
@@ -302,6 +309,26 @@ internal extension ImageAsset.Image {
     #endif
   }
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+internal extension SwiftUI.Image {
+  init(asset: ImageAsset) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle)
+  }
+
+  init(asset: ImageAsset, label: Text) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle, label: label)
+  }
+
+  init(decorative asset: ImageAsset) {
+    let bundle = BundleToken.bundle
+    self.init(decorative: asset.name, bundle: bundle)
+  }
+}
+#endif
 
 internal struct SymbolAsset {
   internal fileprivate(set) var name: String

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-customBundle.swift
@@ -9,6 +9,9 @@
 #elseif os(tvOS) || os(watchOS)
   import UIKit
 #endif
+#if canImport(SwiftUI)
+  import SwiftUI
+#endif
 
 // Deprecated typealiases
 @available(*, deprecated, renamed: "ColorAsset.Color", message: "This typealias will be removed in SwiftGen 7.0")
@@ -133,6 +136,13 @@ internal final class ColorAsset {
   }
   #endif
 
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal private(set) lazy var swiftUIColor: SwiftUI.Color = {
+    SwiftUI.Color(asset: self)
+  }()
+  #endif
+
   fileprivate init(name: String) {
     self.name = name
   }
@@ -151,6 +161,16 @@ internal extension ColorAsset.Color {
     #endif
   }
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+internal extension SwiftUI.Color {
+  init(asset: ColorAsset) {
+    let bundle = ResourcesBundle.bundle
+    self.init(asset.name, bundle: bundle)
+  }
+}
+#endif
 
 internal struct DataAsset {
   internal fileprivate(set) var name: String

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-customBundle.swift
@@ -308,4 +308,31 @@ internal struct SymbolAsset {
     return result
   }
   #endif
+
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal var swiftUIImage: SwiftUI.Image {
+    SwiftUI.Image(asset: self)
+  }
+  #endif
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+internal extension SwiftUI.Image {
+  init(asset: SymbolAsset) {
+    let bundle = ResourcesBundle.bundle
+    self.init(asset.name, bundle: bundle)
+  }
+
+  init(asset: SymbolAsset, label: Text) {
+    let bundle = ResourcesBundle.bundle
+    self.init(asset.name, bundle: bundle, label: label)
+  }
+
+  init(decorative asset: SymbolAsset) {
+    let bundle = ResourcesBundle.bundle
+    self.init(decorative: asset.name, bundle: bundle)
+  }
+}
+#endif

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-customBundle.swift
@@ -232,6 +232,13 @@ internal struct ImageAsset {
     return result
   }
   #endif
+
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal var swiftUIImage: SwiftUI.Image {
+    SwiftUI.Image(asset: self)
+  }
+  #endif
 }
 
 internal extension ImageAsset.Image {
@@ -249,6 +256,26 @@ internal extension ImageAsset.Image {
     #endif
   }
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+internal extension SwiftUI.Image {
+  init(asset: ImageAsset) {
+    let bundle = ResourcesBundle.bundle
+    self.init(asset.name, bundle: bundle)
+  }
+
+  init(asset: ImageAsset, label: Text) {
+    let bundle = ResourcesBundle.bundle
+    self.init(asset.name, bundle: bundle, label: label)
+  }
+
+  init(decorative asset: ImageAsset) {
+    let bundle = ResourcesBundle.bundle
+    self.init(decorative: asset.name, bundle: bundle)
+  }
+}
+#endif
 
 internal struct SymbolAsset {
   internal fileprivate(set) var name: String

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-customName.swift
@@ -232,6 +232,13 @@ internal struct XCTImageAsset {
     return result
   }
   #endif
+
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal var swiftUIImage: SwiftUI.Image {
+    SwiftUI.Image(asset: self)
+  }
+  #endif
 }
 
 internal extension XCTImageAsset.Image {
@@ -249,6 +256,26 @@ internal extension XCTImageAsset.Image {
     #endif
   }
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+internal extension SwiftUI.Image {
+  init(asset: XCTImageAsset) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle)
+  }
+
+  init(asset: XCTImageAsset, label: Text) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle, label: label)
+  }
+
+  init(decorative asset: XCTImageAsset) {
+    let bundle = BundleToken.bundle
+    self.init(decorative: asset.name, bundle: bundle)
+  }
+}
+#endif
 
 internal struct XCTSymbolAsset {
   internal fileprivate(set) var name: String

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-customName.swift
@@ -9,6 +9,9 @@
 #elseif os(tvOS) || os(watchOS)
   import UIKit
 #endif
+#if canImport(SwiftUI)
+  import SwiftUI
+#endif
 
 // Deprecated typealiases
 @available(*, deprecated, renamed: "XCTColorAsset.Color", message: "This typealias will be removed in SwiftGen 7.0")
@@ -133,6 +136,13 @@ internal final class XCTColorAsset {
   }
   #endif
 
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal private(set) lazy var swiftUIColor: SwiftUI.Color = {
+    SwiftUI.Color(asset: self)
+  }()
+  #endif
+
   fileprivate init(name: String) {
     self.name = name
   }
@@ -151,6 +161,16 @@ internal extension XCTColorAsset.Color {
     #endif
   }
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+internal extension SwiftUI.Color {
+  init(asset: XCTColorAsset) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle)
+  }
+}
+#endif
 
 internal struct XCTDataAsset {
   internal fileprivate(set) var name: String

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-customName.swift
@@ -308,7 +308,34 @@ internal struct XCTSymbolAsset {
     return result
   }
   #endif
+
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal var swiftUIImage: SwiftUI.Image {
+    SwiftUI.Image(asset: self)
+  }
+  #endif
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+internal extension SwiftUI.Image {
+  init(asset: XCTSymbolAsset) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle)
+  }
+
+  init(asset: XCTSymbolAsset, label: Text) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle, label: label)
+  }
+
+  init(decorative asset: XCTSymbolAsset) {
+    let bundle = BundleToken.bundle
+    self.init(decorative: asset.name, bundle: bundle)
+  }
+}
+#endif
 
 // swiftlint:disable convenience_type
 private final class BundleToken {

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-forceFileNameEnum.swift
@@ -9,6 +9,9 @@
 #elseif os(tvOS) || os(watchOS)
   import UIKit
 #endif
+#if canImport(SwiftUI)
+  import SwiftUI
+#endif
 
 // Deprecated typealiases
 @available(*, deprecated, renamed: "ColorAsset.Color", message: "This typealias will be removed in SwiftGen 7.0")
@@ -133,6 +136,13 @@ internal final class ColorAsset {
   }
   #endif
 
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal private(set) lazy var swiftUIColor: SwiftUI.Color = {
+    SwiftUI.Color(asset: self)
+  }()
+  #endif
+
   fileprivate init(name: String) {
     self.name = name
   }
@@ -151,6 +161,16 @@ internal extension ColorAsset.Color {
     #endif
   }
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+internal extension SwiftUI.Color {
+  init(asset: ColorAsset) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle)
+  }
+}
+#endif
 
 internal struct DataAsset {
   internal fileprivate(set) var name: String

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-forceFileNameEnum.swift
@@ -308,7 +308,34 @@ internal struct SymbolAsset {
     return result
   }
   #endif
+
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal var swiftUIImage: SwiftUI.Image {
+    SwiftUI.Image(asset: self)
+  }
+  #endif
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+internal extension SwiftUI.Image {
+  init(asset: SymbolAsset) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle)
+  }
+
+  init(asset: SymbolAsset, label: Text) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle, label: label)
+  }
+
+  init(decorative asset: SymbolAsset) {
+    let bundle = BundleToken.bundle
+    self.init(decorative: asset.name, bundle: bundle)
+  }
+}
+#endif
 
 // swiftlint:disable convenience_type
 private final class BundleToken {

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-forceFileNameEnum.swift
@@ -232,6 +232,13 @@ internal struct ImageAsset {
     return result
   }
   #endif
+
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal var swiftUIImage: SwiftUI.Image {
+    SwiftUI.Image(asset: self)
+  }
+  #endif
 }
 
 internal extension ImageAsset.Image {
@@ -249,6 +256,26 @@ internal extension ImageAsset.Image {
     #endif
   }
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+internal extension SwiftUI.Image {
+  init(asset: ImageAsset) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle)
+  }
+
+  init(asset: ImageAsset, label: Text) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle, label: label)
+  }
+
+  init(decorative asset: ImageAsset) {
+    let bundle = BundleToken.bundle
+    self.init(decorative: asset.name, bundle: bundle)
+  }
+}
+#endif
 
 internal struct SymbolAsset {
   internal fileprivate(set) var name: String

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-forceNamespaces.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-forceNamespaces.swift
@@ -310,7 +310,34 @@ internal struct SymbolAsset {
     return result
   }
   #endif
+
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal var swiftUIImage: SwiftUI.Image {
+    SwiftUI.Image(asset: self)
+  }
+  #endif
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+internal extension SwiftUI.Image {
+  init(asset: SymbolAsset) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle)
+  }
+
+  init(asset: SymbolAsset, label: Text) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle, label: label)
+  }
+
+  init(decorative asset: SymbolAsset) {
+    let bundle = BundleToken.bundle
+    self.init(decorative: asset.name, bundle: bundle)
+  }
+}
+#endif
 
 // swiftlint:disable convenience_type
 private final class BundleToken {

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-forceNamespaces.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-forceNamespaces.swift
@@ -234,6 +234,13 @@ internal struct ImageAsset {
     return result
   }
   #endif
+
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal var swiftUIImage: SwiftUI.Image {
+    SwiftUI.Image(asset: self)
+  }
+  #endif
 }
 
 internal extension ImageAsset.Image {
@@ -251,6 +258,26 @@ internal extension ImageAsset.Image {
     #endif
   }
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+internal extension SwiftUI.Image {
+  init(asset: ImageAsset) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle)
+  }
+
+  init(asset: ImageAsset, label: Text) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle, label: label)
+  }
+
+  init(decorative asset: ImageAsset) {
+    let bundle = BundleToken.bundle
+    self.init(decorative: asset.name, bundle: bundle)
+  }
+}
+#endif
 
 internal struct SymbolAsset {
   internal fileprivate(set) var name: String

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-forceNamespaces.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-forceNamespaces.swift
@@ -9,6 +9,9 @@
 #elseif os(tvOS) || os(watchOS)
   import UIKit
 #endif
+#if canImport(SwiftUI)
+  import SwiftUI
+#endif
 
 // Deprecated typealiases
 @available(*, deprecated, renamed: "ColorAsset.Color", message: "This typealias will be removed in SwiftGen 7.0")
@@ -135,6 +138,13 @@ internal final class ColorAsset {
   }
   #endif
 
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal private(set) lazy var swiftUIColor: SwiftUI.Color = {
+    SwiftUI.Color(asset: self)
+  }()
+  #endif
+
   fileprivate init(name: String) {
     self.name = name
   }
@@ -153,6 +163,16 @@ internal extension ColorAsset.Color {
     #endif
   }
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+internal extension SwiftUI.Color {
+  init(asset: ColorAsset) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle)
+  }
+}
+#endif
 
 internal struct DataAsset {
   internal fileprivate(set) var name: String

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-publicAccess.swift
@@ -232,6 +232,13 @@ public struct ImageAsset {
     return result
   }
   #endif
+
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  public var swiftUIImage: SwiftUI.Image {
+    SwiftUI.Image(asset: self)
+  }
+  #endif
 }
 
 public extension ImageAsset.Image {
@@ -249,6 +256,26 @@ public extension ImageAsset.Image {
     #endif
   }
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+public extension SwiftUI.Image {
+  init(asset: ImageAsset) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle)
+  }
+
+  init(asset: ImageAsset, label: Text) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle, label: label)
+  }
+
+  init(decorative asset: ImageAsset) {
+    let bundle = BundleToken.bundle
+    self.init(decorative: asset.name, bundle: bundle)
+  }
+}
+#endif
 
 public struct SymbolAsset {
   public fileprivate(set) var name: String

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-publicAccess.swift
@@ -9,6 +9,9 @@
 #elseif os(tvOS) || os(watchOS)
   import UIKit
 #endif
+#if canImport(SwiftUI)
+  import SwiftUI
+#endif
 
 // Deprecated typealiases
 @available(*, deprecated, renamed: "ColorAsset.Color", message: "This typealias will be removed in SwiftGen 7.0")
@@ -133,6 +136,13 @@ public final class ColorAsset {
   }
   #endif
 
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  public private(set) lazy var swiftUIColor: SwiftUI.Color = {
+    SwiftUI.Color(asset: self)
+  }()
+  #endif
+
   fileprivate init(name: String) {
     self.name = name
   }
@@ -151,6 +161,16 @@ public extension ColorAsset.Color {
     #endif
   }
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+public extension SwiftUI.Color {
+  init(asset: ColorAsset) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle)
+  }
+}
+#endif
 
 public struct DataAsset {
   public fileprivate(set) var name: String

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-publicAccess.swift
@@ -308,7 +308,34 @@ public struct SymbolAsset {
     return result
   }
   #endif
+
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  public var swiftUIImage: SwiftUI.Image {
+    SwiftUI.Image(asset: self)
+  }
+  #endif
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+public extension SwiftUI.Image {
+  init(asset: SymbolAsset) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle)
+  }
+
+  init(asset: SymbolAsset, label: Text) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle, label: label)
+  }
+
+  init(decorative asset: SymbolAsset) {
+    let bundle = BundleToken.bundle
+    self.init(decorative: asset.name, bundle: bundle)
+  }
+}
+#endif
 
 // swiftlint:disable convenience_type
 private final class BundleToken {

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all.swift
@@ -9,6 +9,9 @@
 #elseif os(tvOS) || os(watchOS)
   import UIKit
 #endif
+#if canImport(SwiftUI)
+  import SwiftUI
+#endif
 
 // Deprecated typealiases
 @available(*, deprecated, renamed: "ColorAsset.Color", message: "This typealias will be removed in SwiftGen 7.0")
@@ -133,6 +136,13 @@ internal final class ColorAsset {
   }
   #endif
 
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal private(set) lazy var swiftUIColor: SwiftUI.Color = {
+    SwiftUI.Color(asset: self)
+  }()
+  #endif
+
   fileprivate init(name: String) {
     self.name = name
   }
@@ -151,6 +161,16 @@ internal extension ColorAsset.Color {
     #endif
   }
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+internal extension SwiftUI.Color {
+  init(asset: ColorAsset) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle)
+  }
+}
+#endif
 
 internal struct DataAsset {
   internal fileprivate(set) var name: String

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all.swift
@@ -308,7 +308,34 @@ internal struct SymbolAsset {
     return result
   }
   #endif
+
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal var swiftUIImage: SwiftUI.Image {
+    SwiftUI.Image(asset: self)
+  }
+  #endif
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+internal extension SwiftUI.Image {
+  init(asset: SymbolAsset) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle)
+  }
+
+  init(asset: SymbolAsset, label: Text) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle, label: label)
+  }
+
+  init(decorative asset: SymbolAsset) {
+    let bundle = BundleToken.bundle
+    self.init(decorative: asset.name, bundle: bundle)
+  }
+}
+#endif
 
 // swiftlint:disable convenience_type
 private final class BundleToken {

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all.swift
@@ -232,6 +232,13 @@ internal struct ImageAsset {
     return result
   }
   #endif
+
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal var swiftUIImage: SwiftUI.Image {
+    SwiftUI.Image(asset: self)
+  }
+  #endif
 }
 
 internal extension ImageAsset.Image {
@@ -249,6 +256,26 @@ internal extension ImageAsset.Image {
     #endif
   }
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+internal extension SwiftUI.Image {
+  init(asset: ImageAsset) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle)
+  }
+
+  init(asset: ImageAsset, label: Text) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle, label: label)
+  }
+
+  init(decorative asset: ImageAsset) {
+    let bundle = BundleToken.bundle
+    self.init(decorative: asset.name, bundle: bundle)
+  }
+}
+#endif
 
 internal struct SymbolAsset {
   internal fileprivate(set) var name: String

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/food.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/food.swift
@@ -8,6 +8,9 @@
 #elseif os(tvOS) || os(watchOS)
   import UIKit
 #endif
+#if canImport(SwiftUI)
+  import SwiftUI
+#endif
 
 // Deprecated typealiases
 @available(*, deprecated, renamed: "ImageAsset.Image", message: "This typealias will be removed in SwiftGen 7.0")

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/food.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/food.swift
@@ -76,6 +76,13 @@ internal struct ImageAsset {
     return result
   }
   #endif
+
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal var swiftUIImage: SwiftUI.Image {
+    SwiftUI.Image(asset: self)
+  }
+  #endif
 }
 
 internal extension ImageAsset.Image {
@@ -93,6 +100,26 @@ internal extension ImageAsset.Image {
     #endif
   }
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+internal extension SwiftUI.Image {
+  init(asset: ImageAsset) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle)
+  }
+
+  init(asset: ImageAsset, label: Text) {
+    let bundle = BundleToken.bundle
+    self.init(asset.name, bundle: bundle, label: label)
+  }
+
+  init(decorative asset: ImageAsset) {
+    let bundle = BundleToken.bundle
+    self.init(decorative: asset.name, bundle: bundle)
+  }
+}
+#endif
 
 // swiftlint:disable convenience_type
 private final class BundleToken {


### PR DESCRIPTION
Add support for SwiftUI in:
- `xcassets`: colors, images and symbols
- `fonts`

It does **not** add support for `strings` yet, as the whole issue with key format hasn't been resolved yet.