### PR TITLE
6.6.0 bugfixes

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -34,6 +34,9 @@ jobs:
         run: |
             ./standalone/swiftgen --version
             ./standalone/swiftgen templates list
+      -
+        name: Test binary output
+        run: bundle exec rake cli:test[./standalone,./standalone/frameworks,./standalone/stencils]
 
   zip:
     name: Zip
@@ -56,8 +59,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-spm-
       -
-        name: Create zip
-        run: bundle exec rake release:zip
+        name: Create zip & artifactbundle
+        run: bundle exec rake release:artifactbundle
       -
         name: Upload artifact
         uses: actions/upload-artifact@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,12 @@ _None_
 
 ### Bug Fixes
 
-_None_
+* CLI: fixed `run parser` when no `params` or `options` are provided (broken in 6.6.0).  
+  [David Jennes](https://github.com/djbe)
+  [#983](https://github.com/SwiftGen/SwiftGen/pull/983)
+* JSON/Plist/YAML: fixed code generation (broken in 6.6.0).  
+  [David Jennes](https://github.com/djbe)
+  [#983](https://github.com/SwiftGen/SwiftGen/pull/983)
 
 ### Internal Changes
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stencilproject/Stencil.git",
       "state" : {
-        "revision" : "8989f8a18998bd67b1727c2c0798b7c0436aa481",
-        "version" : "0.15.0"
+        "revision" : "4f222ac85d673f35df29962fc4c36ccfdaf9da5b",
+        "version" : "0.15.1"
       }
     },
     {

--- a/Rakefile
+++ b/Rakefile
@@ -54,6 +54,41 @@ namespace :cli do
   task :clean do
     sh %(rm -fr #{BUILD_DIR}/swiftgen)
   end
+
+  desc "Test the binary in $bindir\n" \
+       "(defaults $bindir=#{BUILD_DIR}/swiftgen/bin/)"
+  task :test, %i[bindir universal] => :install do |task, args|
+    args.with_defaults(bindir: "#{BUILD_DIR}/swiftgen/bin/", universal: false)
+    swiftgen = Pathname.new(args.bindir).expand_path + "swiftgen"
+
+    tests = {
+      colors:   {template: 'swift5',            resource_group: 'Colors',   generated: 'defaults.swift',    fixture: 'colors.xml'},
+      coredata: {template: 'swift5',            resource_group: 'CoreData', generated: 'defaults.swift',    fixture: 'Model.xcdatamodeld'},
+      files:    {template: 'structured-swift5', resource_group: 'Files',    generated: 'defaults.swift',    fixture: ''},
+      fonts:    {template: 'swift5',            resource_group: 'Fonts',    generated: 'defaults.swift',    fixture: ''},
+      ib:       {template: 'scenes-swift5',     resource_group: 'IB-iOS',   generated: 'all.swift',         fixture: '', params: '--param module=SwiftGen'},
+      json:     {template: 'runtime-swift5',    resource_group: 'JSON',     generated: 'all.swift',         fixture: ''},
+      plist:    {template: 'runtime-swift5',    resource_group: 'Plist',    generated: 'all.swift',         fixture: 'good'},
+      strings:  {template: 'structured-swift5', resource_group: 'Strings',  generated: 'localizable.swift', fixture: 'Localizable.strings'},
+      xcassets: {template: 'swift5',            resource_group: 'XCAssets', generated: 'all.swift',         fixture: ''},
+      yaml:     {template: 'inline-swift5',     resource_group: 'YAML',     generated: 'all.swift',         fixture: 'good'}
+    }
+
+    results = []
+    Utils.table_header('Check', 'Status')
+
+    tests.each do |command, info|
+      output = %x(#{swiftgen.to_s} run #{command} --templateName #{info[:template]} #{info[:params]} Sources/TestUtils/Fixtures/Resources/#{info[:resource_group]}/#{info[:fixture]}).strip
+      generated = File.read("Sources/TestUtils/Fixtures/Generated/#{info[:resource_group]}/#{info[:template]}/#{info[:generated]}").strip
+      results << Utils.table_result(
+        output == generated,
+        command.to_s,
+        %Q(swiftgen run #{command} --templateName #{info[:template]} #{info[:params]} Sources/TestUtils/Fixtures/Resources/#{info[:resource_group]}/#{info[:fixture]})
+      )
+    end
+
+    exit 1 unless results.all?
+  end
 end
 
 task :default => 'cli:build'

--- a/Sources/SwiftGen/Commands/Run.swift
+++ b/Sources/SwiftGen/Commands/Run.swift
@@ -47,13 +47,13 @@ extension Commands.Run {
     var filter: String = Parser.self.defaultFilter
 
     @Option(name: [.customLong("option")], help: "List of parser options. \(Parser.self.allOptions)")
-    var options: [String]
+    var options: [String] = []
 
     @OptionGroup
     var template: TemplateOptions
 
     @Option(name: [.customLong("param")], help: "List of template parameters.")
-    var templateParameters: [String]
+    var templateParameters: [String] = []
 
     @OptionGroup
     var output: Commands.OutputDestination

--- a/Sources/SwiftGen/Version.swift
+++ b/Sources/SwiftGen/Version.swift
@@ -7,6 +7,6 @@
 enum Version {
   static let swiftgen = "6.6.0"
   static let swiftGenKit = "6.6.0"
-  static let stencil = "0.15.0"
+  static let stencil = "0.15.1"
   static let stencilSwiftKit = "2.10.0"
 }

--- a/Sources/SwiftGenCLI/templates/json/inline-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/json/inline-swift4.stencil
@@ -57,6 +57,8 @@ import Foundation
     {%- empty -%}
       :
     {%- endfor %}]
+  {%- elif metadata.type == "Bool" -%}
+    {%- if value %}true{% else %}false{% endif -%}
   {%- else -%}
     {{ value }}
   {%- endif -%}

--- a/Sources/SwiftGenCLI/templates/json/inline-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/json/inline-swift5.stencil
@@ -57,6 +57,8 @@ import Foundation
     {%- empty -%}
       :
     {%- endfor %}]
+  {%- elif metadata.type == "Bool" -%}
+    {%- if value %}true{% else %}false{% endif -%}
   {%- else -%}
     {{ value }}
   {%- endif -%}

--- a/Sources/SwiftGenCLI/templates/plist/inline-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/plist/inline-swift4.stencil
@@ -57,6 +57,8 @@ import Foundation
     {%- empty -%}
       :
     {%- endfor %}]
+  {%- elif metadata.type == "Bool" -%}
+    {%- if value %}true{% else %}false{% endif -%}
   {%- else -%}
     {{ value }}
   {%- endif -%}

--- a/Sources/SwiftGenCLI/templates/plist/inline-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/plist/inline-swift5.stencil
@@ -57,6 +57,8 @@ import Foundation
     {%- empty -%}
       :
     {%- endfor %}]
+  {%- elif metadata.type == "Bool" -%}
+    {%- if value %}true{% else %}false{% endif -%}
   {%- else -%}
     {{ value }}
   {%- endif -%}

--- a/Sources/SwiftGenCLI/templates/yaml/inline-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/yaml/inline-swift4.stencil
@@ -67,6 +67,8 @@ import Foundation
     {%- empty -%}
       :
     {%- endfor %}]
+  {%- elif metadata.type == "Bool" -%}
+    {%- if value %}true{% else %}false{% endif -%}
   {%- else -%}
     {{ value }}
   {%- endif -%}

--- a/Sources/SwiftGenCLI/templates/yaml/inline-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/yaml/inline-swift5.stencil
@@ -67,6 +67,8 @@ import Foundation
     {%- empty -%}
       :
     {%- endfor %}]
+  {%- elif metadata.type == "Bool" -%}
+    {%- if value %}true{% else %}false{% endif -%}
   {%- else -%}
     {{ value }}
   {%- endif -%}


### PR DESCRIPTION
Hit some snags after 6.6 release:

- Yet again hit by differences in our tests & running the full pipeline of swiftgen (see #741)
- Lazy value wrapper was broken (fixed in stencil 0.15.1)
- json/plist/yaml: code generation for inline booleans was broken
- CLI interface for `run parser` wasn't working correctly (it **required** params & options)

For now I've added some extra tests that run the same tests as homebrew (the full pipeline), it should catch some of these issues earlier.