### PR TITLE
Strings: escape translation strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,11 @@ _None_
 
 ### Internal Changes
 
-_None_
+* Strings: correctly handle strings containing `\t` (tabs) and `"#`.  
+  [David Jennes](https://github.com/djbe)
+  [#985](https://github.com/SwiftGen/SwiftGen/issues/985)
+  [#986](https://github.com/SwiftGen/SwiftGen/issues/986)
+  [#988](https://github.com/SwiftGen/SwiftGen/pull/988)
 
 ## 6.6.1
 

--- a/Sources/SwiftGenCLI/templates/strings/flat-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/flat-swift4.stencil
@@ -40,12 +40,12 @@ import Foundation
   {% endif %}
   {% if string.types %}
   {{accessModifier}} static func {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}({% call parametersBlock string.types %}) -> String {
-    return {{enumName}}.tr("{{table}}", "{{string.key}}", {%+ call argumentsBlock string.types %}, fallback: "{{string.translation|replace:'"','\"'}}")
+    return {{enumName}}.tr("{{table}}", "{{string.key}}", {%+ call argumentsBlock string.types %}, fallback: "{{string.translation|replace:'"','\"'|replace:'	','\t'}}")
   }
   {% elif param.lookupFunction %}
-  {{accessModifier}} static var {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: "{{string.translation|replace:'"','\"'}}") }
+  {{accessModifier}} static var {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: "{{string.translation|replace:'"','\"'|replace:'	','\t'}}") }
   {% else %}
-  {{accessModifier}} static let {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: "{{string.translation|replace:'"','\"'}}")
+  {{accessModifier}} static let {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: "{{string.translation|replace:'"','\"'|replace:'	','\t'}}")
   {% endif %}
   {% endfor %}
   {% for child in item.children %}

--- a/Sources/SwiftGenCLI/templates/strings/flat-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/flat-swift5.stencil
@@ -40,12 +40,12 @@ import Foundation
   {% endif %}
   {% if string.types %}
   {{accessModifier}} static func {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}({% call parametersBlock string.types %}) -> String {
-    return {{enumName}}.tr("{{table}}", "{{string.key}}", {%+ call argumentsBlock string.types %}, fallback: ###"{{string.translation}}"###)
+    return {{enumName}}.tr("{{table}}", "{{string.key}}", {%+ call argumentsBlock string.types %}, fallback: ###"{{string.translation|replace:'	','\t'}}"###)
   }
   {% elif param.lookupFunction %}
-  {{accessModifier}} static var {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: ###"{{string.translation}}"###) }
+  {{accessModifier}} static var {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: ###"{{string.translation|replace:'	','\t'}}"###) }
   {% else %}
-  {{accessModifier}} static let {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: ###"{{string.translation}}"###)
+  {{accessModifier}} static let {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: ###"{{string.translation|replace:'	','\t'}}"###)
   {% endif %}
   {% endfor %}
   {% for child in item.children %}

--- a/Sources/SwiftGenCLI/templates/strings/flat-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/flat-swift5.stencil
@@ -40,12 +40,12 @@ import Foundation
   {% endif %}
   {% if string.types %}
   {{accessModifier}} static func {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}({% call parametersBlock string.types %}) -> String {
-    return {{enumName}}.tr("{{table}}", "{{string.key}}", {%+ call argumentsBlock string.types %}, fallback: #"{{string.translation}}"#)
+    return {{enumName}}.tr("{{table}}", "{{string.key}}", {%+ call argumentsBlock string.types %}, fallback: ###"{{string.translation}}"###)
   }
   {% elif param.lookupFunction %}
-  {{accessModifier}} static var {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: #"{{string.translation}}"#) }
+  {{accessModifier}} static var {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: ###"{{string.translation}}"###) }
   {% else %}
-  {{accessModifier}} static let {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: #"{{string.translation}}"#)
+  {{accessModifier}} static let {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: ###"{{string.translation}}"###)
   {% endif %}
   {% endfor %}
   {% for child in item.children %}

--- a/Sources/SwiftGenCLI/templates/strings/objc-m.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/objc-m.stencil
@@ -66,11 +66,11 @@ static NSString* tr(NSString *tableName, NSString *key, NSString *value, ...) {
 + (NSString*){{string.key|swiftIdentifier:"pretty"|lowerFirstWord}}WithValues:{% call parametersBlock string.types +%}
     {% endif %}
 {
-    return tr(@"{{table}}", @"{{string.key}}", @"{{string.translation|replace:'"','\"'}}", {%+ call argumentsBlock string.types %});
+    return tr(@"{{table}}", @"{{string.key}}", @"{{string.translation|replace:'"','\"'|replace:'	','\t'}}", {%+ call argumentsBlock string.types %});
 }
 {% else %}
 + (NSString*){{string.key|swiftIdentifier:"pretty"|lowerFirstWord}} {
-    return tr(@"{{table}}", @"{{string.key}}", @"{{string.translation|replace:'"','\"'}}");
+    return tr(@"{{table}}", @"{{string.key}}", @"{{string.translation|replace:'"','\"'|replace:'	','\t'}}");
 }
   {% endif %}
   {% endfor %}

--- a/Sources/SwiftGenCLI/templates/strings/structured-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/structured-swift4.stencil
@@ -40,12 +40,12 @@ import Foundation
   {% endif %}
   {% if string.types %}
   {{accessModifier}} static func {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}({% call parametersBlock string.types %}) -> String {
-    return {{enumName}}.tr("{{table}}", "{{string.key}}", {%+ call argumentsBlock string.types %}, fallback: "{{string.translation|replace:'"','\"'}}")
+    return {{enumName}}.tr("{{table}}", "{{string.key}}", {%+ call argumentsBlock string.types %}, fallback: "{{string.translation|replace:'"','\"'|replace:'	','\t'}}")
   }
   {% elif param.lookupFunction %}
-  {{accessModifier}} static var {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: "{{string.translation|replace:'"','\"'}}") }
+  {{accessModifier}} static var {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: "{{string.translation|replace:'"','\"'|replace:'	','\t'}}") }
   {% else %}
-  {{accessModifier}} static let {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: "{{string.translation|replace:'"','\"'}}")
+  {{accessModifier}} static let {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: "{{string.translation|replace:'"','\"'|replace:'	','\t'}}")
   {% endif %}
   {% endfor %}
   {% for child in item.children %}

--- a/Sources/SwiftGenCLI/templates/strings/structured-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/structured-swift5.stencil
@@ -40,12 +40,12 @@ import Foundation
   {% endif %}
   {% if string.types %}
   {{accessModifier}} static func {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}({% call parametersBlock string.types %}) -> String {
-    return {{enumName}}.tr("{{table}}", "{{string.key}}", {%+ call argumentsBlock string.types %}, fallback: ###"{{string.translation}}"###)
+    return {{enumName}}.tr("{{table}}", "{{string.key}}", {%+ call argumentsBlock string.types %}, fallback: ###"{{string.translation|replace:'	','\t'}}"###)
   }
   {% elif param.lookupFunction %}
-  {{accessModifier}} static var {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: ###"{{string.translation}}"###) }
+  {{accessModifier}} static var {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: ###"{{string.translation|replace:'	','\t'}}"###) }
   {% else %}
-  {{accessModifier}} static let {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: ###"{{string.translation}}"###)
+  {{accessModifier}} static let {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: ###"{{string.translation|replace:'	','\t'}}"###)
   {% endif %}
   {% endfor %}
   {% for child in item.children %}

--- a/Sources/SwiftGenCLI/templates/strings/structured-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/structured-swift5.stencil
@@ -40,12 +40,12 @@ import Foundation
   {% endif %}
   {% if string.types %}
   {{accessModifier}} static func {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}({% call parametersBlock string.types %}) -> String {
-    return {{enumName}}.tr("{{table}}", "{{string.key}}", {%+ call argumentsBlock string.types %}, fallback: #"{{string.translation}}"#)
+    return {{enumName}}.tr("{{table}}", "{{string.key}}", {%+ call argumentsBlock string.types %}, fallback: ###"{{string.translation}}"###)
   }
   {% elif param.lookupFunction %}
-  {{accessModifier}} static var {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: #"{{string.translation}}"#) }
+  {{accessModifier}} static var {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: ###"{{string.translation}}"###) }
   {% else %}
-  {{accessModifier}} static let {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: #"{{string.translation}}"#)
+  {{accessModifier}} static let {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: ###"{{string.translation}}"###)
   {% endif %}
   {% endfor %}
   {% for child in item.children %}

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/localizable-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/localizable-customBundle.swift
@@ -13,8 +13,8 @@ internal enum L10n {
   internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: "Some alert body there")
   /// Title for an alert
   internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: "Title of the alert")
-  /// value1
-  internal static let key1 = L10n.tr("Localizable", "key1", fallback: "value1")
+  /// value1	value
+  internal static let key1 = L10n.tr("Localizable", "key1", fallback: "value1\tvalue")
   /// These are %3$@'s %1$d %2$@.
   internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
     return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: "These are %3$@'s %1$d %2$@.")

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/localizable-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/localizable-customName.swift
@@ -13,8 +13,8 @@ internal enum XCTLoc {
   internal static let alertMessage = XCTLoc.tr("Localizable", "alert__message", fallback: "Some alert body there")
   /// Title for an alert
   internal static let alertTitle = XCTLoc.tr("Localizable", "alert__title", fallback: "Title of the alert")
-  /// value1
-  internal static let key1 = XCTLoc.tr("Localizable", "key1", fallback: "value1")
+  /// value1	value
+  internal static let key1 = XCTLoc.tr("Localizable", "key1", fallback: "value1\tvalue")
   /// These are %3$@'s %1$d %2$@.
   internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
     return XCTLoc.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: "These are %3$@'s %1$d %2$@.")

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/localizable-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/localizable-forceFileNameEnum.swift
@@ -14,8 +14,8 @@ internal enum L10n {
     internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: "Some alert body there")
     /// Title for an alert
     internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: "Title of the alert")
-    /// value1
-    internal static let key1 = L10n.tr("Localizable", "key1", fallback: "value1")
+    /// value1	value
+    internal static let key1 = L10n.tr("Localizable", "key1", fallback: "value1\tvalue")
     /// These are %3$@'s %1$d %2$@.
     internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
       return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: "These are %3$@'s %1$d %2$@.")

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/localizable-lookupFunction.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/localizable-lookupFunction.swift
@@ -13,8 +13,8 @@ internal enum L10n {
   internal static var alertMessage: String { return L10n.tr("Localizable", "alert__message", fallback: "Some alert body there") }
   /// Title for an alert
   internal static var alertTitle: String { return L10n.tr("Localizable", "alert__title", fallback: "Title of the alert") }
-  /// value1
-  internal static var key1: String { return L10n.tr("Localizable", "key1", fallback: "value1") }
+  /// value1	value
+  internal static var key1: String { return L10n.tr("Localizable", "key1", fallback: "value1\tvalue") }
   /// These are %3$@'s %1$d %2$@.
   internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
     return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: "These are %3$@'s %1$d %2$@.")

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/localizable-noComments.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/localizable-noComments.swift
@@ -11,7 +11,7 @@ import Foundation
 internal enum L10n {
   internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: "Some alert body there")
   internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: "Title of the alert")
-  internal static let key1 = L10n.tr("Localizable", "key1", fallback: "value1")
+  internal static let key1 = L10n.tr("Localizable", "key1", fallback: "value1\tvalue")
   internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
     return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: "These are %3$@'s %1$d %2$@.")
   }

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/localizable-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/localizable-publicAccess.swift
@@ -13,8 +13,8 @@ public enum L10n {
   public static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: "Some alert body there")
   /// Title for an alert
   public static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: "Title of the alert")
-  /// value1
-  public static let key1 = L10n.tr("Localizable", "key1", fallback: "value1")
+  /// value1	value
+  public static let key1 = L10n.tr("Localizable", "key1", fallback: "value1\tvalue")
   /// These are %3$@'s %1$d %2$@.
   public static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
     return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: "These are %3$@'s %1$d %2$@.")

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/localizable.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/localizable.swift
@@ -13,8 +13,8 @@ internal enum L10n {
   internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: "Some alert body there")
   /// Title for an alert
   internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: "Title of the alert")
-  /// value1
-  internal static let key1 = L10n.tr("Localizable", "key1", fallback: "value1")
+  /// value1	value
+  internal static let key1 = L10n.tr("Localizable", "key1", fallback: "value1\tvalue")
   /// These are %3$@'s %1$d %2$@.
   internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
     return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: "These are %3$@'s %1$d %2$@.")

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/multiple.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/multiple.swift
@@ -14,8 +14,8 @@ internal enum L10n {
     internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: "Some alert body there")
     /// Title for an alert
     internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: "Title of the alert")
-    /// value1
-    internal static let key1 = L10n.tr("Localizable", "key1", fallback: "value1")
+    /// value1	value
+    internal static let key1 = L10n.tr("Localizable", "key1", fallback: "value1\tvalue")
     /// These are %3$@'s %1$d %2$@.
     internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
       return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: "These are %3$@'s %1$d %2$@.")

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/plurals-same-table.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/plurals-same-table.swift
@@ -13,8 +13,8 @@ internal enum L10n {
   internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: "Some alert body there")
   /// Title for an alert
   internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: "Title of the alert")
-  /// value1
-  internal static let key1 = L10n.tr("Localizable", "key1", fallback: "value1")
+  /// value1	value
+  internal static let key1 = L10n.tr("Localizable", "key1", fallback: "value1\tvalue")
   /// These are %3$@'s %1$d %2$@.
   internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
     return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: "These are %3$@'s %1$d %2$@.")

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/localizable-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/localizable-customBundle.swift
@@ -10,55 +10,55 @@ import Foundation
 // swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 internal enum L10n {
   /// Some alert body there
-  internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: #"Some alert body there"#)
+  internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: ###"Some alert body there"###)
   /// Title for an alert
-  internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: #"Title of the alert"#)
-  /// value1
-  internal static let key1 = L10n.tr("Localizable", "key1", fallback: #"value1"#)
+  internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: ###"Title of the alert"###)
+  /// value1	value
+  internal static let key1 = L10n.tr("Localizable", "key1", fallback: ###"value1\tvalue"###)
   /// These are %3$@'s %1$d %2$@.
   internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
-    return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: #"These are %3$@'s %1$d %2$@."#)
+    return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: ###"These are %3$@'s %1$d %2$@."###)
   }
   /// This is a %% character.
-  internal static let percent = L10n.tr("Localizable", "percent", fallback: #"This is a %% character."#)
+  internal static let percent = L10n.tr("Localizable", "percent", fallback: ###"This is a %% character."###)
   /// Hello, my name is "%@" and I'm %d
   internal static func `private`(_ p1: Any, _ p2: Int) -> String {
-    return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: #"Hello, my name is "%@" and I'm %d"#)
+    return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: ###"Hello, my name is "%@" and I'm %d"###)
   }
   /// Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'
   internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
-    return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: #"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"#)
+    return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: ###"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"###)
   }
   /// You have %d apples
   internal static func applesCount(_ p1: Int) -> String {
-    return L10n.tr("Localizable", "apples.count", p1, fallback: #"You have %d apples"#)
+    return L10n.tr("Localizable", "apples.count", p1, fallback: ###"You have %d apples"###)
   }
   /// A comment with no space above it
   internal static func bananasOwner(_ p1: Int, _ p2: Any) -> String {
-    return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: #"Those %d bananas belong to %@."#)
+    return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: ###"Those %d bananas belong to %@."###)
   }
   /// Same as "key1" = "value1"; but in the context of user not logged in
-  internal static let key1Anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: #"value2"#)
+  internal static let key1Anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: ###"value2"###)
   /// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
   internal static func manyPlaceholdersBase(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-    return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+    return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
   }
   /// %@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
   internal static func manyPlaceholdersZero(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-    return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+    return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
   }
   /// Some Reserved Keyword there
-  internal static let settingsNavigationBarSelf = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: #"Some Reserved Keyword there"#)
+  internal static let settingsNavigationBarSelf = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: ###"Some Reserved Keyword there"###)
   /// DeepSettings
-  internal static let settingsNavigationBarTitleDeeperThanWeCanHandleNoReallyThisIsDeep = L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: #"DeepSettings"#)
+  internal static let settingsNavigationBarTitleDeeperThanWeCanHandleNoReallyThisIsDeep = L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: ###"DeepSettings"###)
   /// Settings
-  internal static let settingsNavigationBarTitleEvenDeeper = L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: #"Settings"#)
+  internal static let settingsNavigationBarTitleEvenDeeper = L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: ###"Settings"###)
   /// Here you can change some user profile settings.
-  internal static let settingsUserProfileSectionFooterText = L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: #"Here you can change some user profile settings."#)
+  internal static let settingsUserProfileSectionFooterText = L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: ###"Here you can change some user profile settings."###)
   /// User Profile Settings
-  internal static let settingsUserProfileSectionHEADERTITLE = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: #"User Profile Settings"#)
+  internal static let settingsUserProfileSectionHEADERTITLE = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: ###"User Profile Settings"###)
   /// some comment
-  internal static let whatHappensHere = L10n.tr("Localizable", "what./*happens*/.here", fallback: #"hello world! /* still in string */"#)
+  internal static let whatHappensHere = L10n.tr("Localizable", "what./*happens*/.here", fallback: ###"hello world! /* still in string */"###)
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/localizable-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/localizable-customName.swift
@@ -10,55 +10,55 @@ import Foundation
 // swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 internal enum XCTLoc {
   /// Some alert body there
-  internal static let alertMessage = XCTLoc.tr("Localizable", "alert__message", fallback: #"Some alert body there"#)
+  internal static let alertMessage = XCTLoc.tr("Localizable", "alert__message", fallback: ###"Some alert body there"###)
   /// Title for an alert
-  internal static let alertTitle = XCTLoc.tr("Localizable", "alert__title", fallback: #"Title of the alert"#)
-  /// value1
-  internal static let key1 = XCTLoc.tr("Localizable", "key1", fallback: #"value1"#)
+  internal static let alertTitle = XCTLoc.tr("Localizable", "alert__title", fallback: ###"Title of the alert"###)
+  /// value1	value
+  internal static let key1 = XCTLoc.tr("Localizable", "key1", fallback: ###"value1\tvalue"###)
   /// These are %3$@'s %1$d %2$@.
   internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
-    return XCTLoc.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: #"These are %3$@'s %1$d %2$@."#)
+    return XCTLoc.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: ###"These are %3$@'s %1$d %2$@."###)
   }
   /// This is a %% character.
-  internal static let percent = XCTLoc.tr("Localizable", "percent", fallback: #"This is a %% character."#)
+  internal static let percent = XCTLoc.tr("Localizable", "percent", fallback: ###"This is a %% character."###)
   /// Hello, my name is "%@" and I'm %d
   internal static func `private`(_ p1: Any, _ p2: Int) -> String {
-    return XCTLoc.tr("Localizable", "private", String(describing: p1), p2, fallback: #"Hello, my name is "%@" and I'm %d"#)
+    return XCTLoc.tr("Localizable", "private", String(describing: p1), p2, fallback: ###"Hello, my name is "%@" and I'm %d"###)
   }
   /// Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'
   internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
-    return XCTLoc.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: #"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"#)
+    return XCTLoc.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: ###"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"###)
   }
   /// You have %d apples
   internal static func applesCount(_ p1: Int) -> String {
-    return XCTLoc.tr("Localizable", "apples.count", p1, fallback: #"You have %d apples"#)
+    return XCTLoc.tr("Localizable", "apples.count", p1, fallback: ###"You have %d apples"###)
   }
   /// A comment with no space above it
   internal static func bananasOwner(_ p1: Int, _ p2: Any) -> String {
-    return XCTLoc.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: #"Those %d bananas belong to %@."#)
+    return XCTLoc.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: ###"Those %d bananas belong to %@."###)
   }
   /// Same as "key1" = "value1"; but in the context of user not logged in
-  internal static let key1Anonymous = XCTLoc.tr("Localizable", "key1.anonymous", fallback: #"value2"#)
+  internal static let key1Anonymous = XCTLoc.tr("Localizable", "key1.anonymous", fallback: ###"value2"###)
   /// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
   internal static func manyPlaceholdersBase(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-    return XCTLoc.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+    return XCTLoc.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
   }
   /// %@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
   internal static func manyPlaceholdersZero(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-    return XCTLoc.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+    return XCTLoc.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
   }
   /// Some Reserved Keyword there
-  internal static let settingsNavigationBarSelf = XCTLoc.tr("Localizable", "settings.navigation-bar.self", fallback: #"Some Reserved Keyword there"#)
+  internal static let settingsNavigationBarSelf = XCTLoc.tr("Localizable", "settings.navigation-bar.self", fallback: ###"Some Reserved Keyword there"###)
   /// DeepSettings
-  internal static let settingsNavigationBarTitleDeeperThanWeCanHandleNoReallyThisIsDeep = XCTLoc.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: #"DeepSettings"#)
+  internal static let settingsNavigationBarTitleDeeperThanWeCanHandleNoReallyThisIsDeep = XCTLoc.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: ###"DeepSettings"###)
   /// Settings
-  internal static let settingsNavigationBarTitleEvenDeeper = XCTLoc.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: #"Settings"#)
+  internal static let settingsNavigationBarTitleEvenDeeper = XCTLoc.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: ###"Settings"###)
   /// Here you can change some user profile settings.
-  internal static let settingsUserProfileSectionFooterText = XCTLoc.tr("Localizable", "settings.user__profile_section.footer_text", fallback: #"Here you can change some user profile settings."#)
+  internal static let settingsUserProfileSectionFooterText = XCTLoc.tr("Localizable", "settings.user__profile_section.footer_text", fallback: ###"Here you can change some user profile settings."###)
   /// User Profile Settings
-  internal static let settingsUserProfileSectionHEADERTITLE = XCTLoc.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: #"User Profile Settings"#)
+  internal static let settingsUserProfileSectionHEADERTITLE = XCTLoc.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: ###"User Profile Settings"###)
   /// some comment
-  internal static let whatHappensHere = XCTLoc.tr("Localizable", "what./*happens*/.here", fallback: #"hello world! /* still in string */"#)
+  internal static let whatHappensHere = XCTLoc.tr("Localizable", "what./*happens*/.here", fallback: ###"hello world! /* still in string */"###)
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/localizable-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/localizable-forceFileNameEnum.swift
@@ -11,55 +11,55 @@ import Foundation
 internal enum L10n {
   internal enum Localizable {
     /// Some alert body there
-    internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: #"Some alert body there"#)
+    internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: ###"Some alert body there"###)
     /// Title for an alert
-    internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: #"Title of the alert"#)
-    /// value1
-    internal static let key1 = L10n.tr("Localizable", "key1", fallback: #"value1"#)
+    internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: ###"Title of the alert"###)
+    /// value1	value
+    internal static let key1 = L10n.tr("Localizable", "key1", fallback: ###"value1\tvalue"###)
     /// These are %3$@'s %1$d %2$@.
     internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
-      return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: #"These are %3$@'s %1$d %2$@."#)
+      return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: ###"These are %3$@'s %1$d %2$@."###)
     }
     /// This is a %% character.
-    internal static let percent = L10n.tr("Localizable", "percent", fallback: #"This is a %% character."#)
+    internal static let percent = L10n.tr("Localizable", "percent", fallback: ###"This is a %% character."###)
     /// Hello, my name is "%@" and I'm %d
     internal static func `private`(_ p1: Any, _ p2: Int) -> String {
-      return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: #"Hello, my name is "%@" and I'm %d"#)
+      return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: ###"Hello, my name is "%@" and I'm %d"###)
     }
     /// Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'
     internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
-      return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: #"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"#)
+      return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: ###"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"###)
     }
     /// You have %d apples
     internal static func applesCount(_ p1: Int) -> String {
-      return L10n.tr("Localizable", "apples.count", p1, fallback: #"You have %d apples"#)
+      return L10n.tr("Localizable", "apples.count", p1, fallback: ###"You have %d apples"###)
     }
     /// A comment with no space above it
     internal static func bananasOwner(_ p1: Int, _ p2: Any) -> String {
-      return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: #"Those %d bananas belong to %@."#)
+      return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: ###"Those %d bananas belong to %@."###)
     }
     /// Same as "key1" = "value1"; but in the context of user not logged in
-    internal static let key1Anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: #"value2"#)
+    internal static let key1Anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: ###"value2"###)
     /// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
     internal static func manyPlaceholdersBase(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-      return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+      return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
     }
     /// %@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
     internal static func manyPlaceholdersZero(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-      return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+      return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
     }
     /// Some Reserved Keyword there
-    internal static let settingsNavigationBarSelf = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: #"Some Reserved Keyword there"#)
+    internal static let settingsNavigationBarSelf = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: ###"Some Reserved Keyword there"###)
     /// DeepSettings
-    internal static let settingsNavigationBarTitleDeeperThanWeCanHandleNoReallyThisIsDeep = L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: #"DeepSettings"#)
+    internal static let settingsNavigationBarTitleDeeperThanWeCanHandleNoReallyThisIsDeep = L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: ###"DeepSettings"###)
     /// Settings
-    internal static let settingsNavigationBarTitleEvenDeeper = L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: #"Settings"#)
+    internal static let settingsNavigationBarTitleEvenDeeper = L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: ###"Settings"###)
     /// Here you can change some user profile settings.
-    internal static let settingsUserProfileSectionFooterText = L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: #"Here you can change some user profile settings."#)
+    internal static let settingsUserProfileSectionFooterText = L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: ###"Here you can change some user profile settings."###)
     /// User Profile Settings
-    internal static let settingsUserProfileSectionHEADERTITLE = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: #"User Profile Settings"#)
+    internal static let settingsUserProfileSectionHEADERTITLE = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: ###"User Profile Settings"###)
     /// some comment
-    internal static let whatHappensHere = L10n.tr("Localizable", "what./*happens*/.here", fallback: #"hello world! /* still in string */"#)
+    internal static let whatHappensHere = L10n.tr("Localizable", "what./*happens*/.here", fallback: ###"hello world! /* still in string */"###)
   }
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/localizable-lookupFunction.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/localizable-lookupFunction.swift
@@ -10,55 +10,55 @@ import Foundation
 // swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 internal enum L10n {
   /// Some alert body there
-  internal static var alertMessage: String { return L10n.tr("Localizable", "alert__message", fallback: #"Some alert body there"#) }
+  internal static var alertMessage: String { return L10n.tr("Localizable", "alert__message", fallback: ###"Some alert body there"###) }
   /// Title for an alert
-  internal static var alertTitle: String { return L10n.tr("Localizable", "alert__title", fallback: #"Title of the alert"#) }
-  /// value1
-  internal static var key1: String { return L10n.tr("Localizable", "key1", fallback: #"value1"#) }
+  internal static var alertTitle: String { return L10n.tr("Localizable", "alert__title", fallback: ###"Title of the alert"###) }
+  /// value1	value
+  internal static var key1: String { return L10n.tr("Localizable", "key1", fallback: ###"value1\tvalue"###) }
   /// These are %3$@'s %1$d %2$@.
   internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
-    return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: #"These are %3$@'s %1$d %2$@."#)
+    return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: ###"These are %3$@'s %1$d %2$@."###)
   }
   /// This is a %% character.
-  internal static var percent: String { return L10n.tr("Localizable", "percent", fallback: #"This is a %% character."#) }
+  internal static var percent: String { return L10n.tr("Localizable", "percent", fallback: ###"This is a %% character."###) }
   /// Hello, my name is "%@" and I'm %d
   internal static func `private`(_ p1: Any, _ p2: Int) -> String {
-    return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: #"Hello, my name is "%@" and I'm %d"#)
+    return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: ###"Hello, my name is "%@" and I'm %d"###)
   }
   /// Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'
   internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
-    return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: #"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"#)
+    return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: ###"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"###)
   }
   /// You have %d apples
   internal static func applesCount(_ p1: Int) -> String {
-    return L10n.tr("Localizable", "apples.count", p1, fallback: #"You have %d apples"#)
+    return L10n.tr("Localizable", "apples.count", p1, fallback: ###"You have %d apples"###)
   }
   /// A comment with no space above it
   internal static func bananasOwner(_ p1: Int, _ p2: Any) -> String {
-    return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: #"Those %d bananas belong to %@."#)
+    return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: ###"Those %d bananas belong to %@."###)
   }
   /// Same as "key1" = "value1"; but in the context of user not logged in
-  internal static var key1Anonymous: String { return L10n.tr("Localizable", "key1.anonymous", fallback: #"value2"#) }
+  internal static var key1Anonymous: String { return L10n.tr("Localizable", "key1.anonymous", fallback: ###"value2"###) }
   /// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
   internal static func manyPlaceholdersBase(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-    return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+    return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
   }
   /// %@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
   internal static func manyPlaceholdersZero(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-    return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+    return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
   }
   /// Some Reserved Keyword there
-  internal static var settingsNavigationBarSelf: String { return L10n.tr("Localizable", "settings.navigation-bar.self", fallback: #"Some Reserved Keyword there"#) }
+  internal static var settingsNavigationBarSelf: String { return L10n.tr("Localizable", "settings.navigation-bar.self", fallback: ###"Some Reserved Keyword there"###) }
   /// DeepSettings
-  internal static var settingsNavigationBarTitleDeeperThanWeCanHandleNoReallyThisIsDeep: String { return L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: #"DeepSettings"#) }
+  internal static var settingsNavigationBarTitleDeeperThanWeCanHandleNoReallyThisIsDeep: String { return L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: ###"DeepSettings"###) }
   /// Settings
-  internal static var settingsNavigationBarTitleEvenDeeper: String { return L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: #"Settings"#) }
+  internal static var settingsNavigationBarTitleEvenDeeper: String { return L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: ###"Settings"###) }
   /// Here you can change some user profile settings.
-  internal static var settingsUserProfileSectionFooterText: String { return L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: #"Here you can change some user profile settings."#) }
+  internal static var settingsUserProfileSectionFooterText: String { return L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: ###"Here you can change some user profile settings."###) }
   /// User Profile Settings
-  internal static var settingsUserProfileSectionHEADERTITLE: String { return L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: #"User Profile Settings"#) }
+  internal static var settingsUserProfileSectionHEADERTITLE: String { return L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: ###"User Profile Settings"###) }
   /// some comment
-  internal static var whatHappensHere: String { return L10n.tr("Localizable", "what./*happens*/.here", fallback: #"hello world! /* still in string */"#) }
+  internal static var whatHappensHere: String { return L10n.tr("Localizable", "what./*happens*/.here", fallback: ###"hello world! /* still in string */"###) }
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/localizable-noComments.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/localizable-noComments.swift
@@ -9,38 +9,38 @@ import Foundation
 
 // swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 internal enum L10n {
-  internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: #"Some alert body there"#)
-  internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: #"Title of the alert"#)
-  internal static let key1 = L10n.tr("Localizable", "key1", fallback: #"value1"#)
+  internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: ###"Some alert body there"###)
+  internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: ###"Title of the alert"###)
+  internal static let key1 = L10n.tr("Localizable", "key1", fallback: ###"value1\tvalue"###)
   internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
-    return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: #"These are %3$@'s %1$d %2$@."#)
+    return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: ###"These are %3$@'s %1$d %2$@."###)
   }
-  internal static let percent = L10n.tr("Localizable", "percent", fallback: #"This is a %% character."#)
+  internal static let percent = L10n.tr("Localizable", "percent", fallback: ###"This is a %% character."###)
   internal static func `private`(_ p1: Any, _ p2: Int) -> String {
-    return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: #"Hello, my name is "%@" and I'm %d"#)
+    return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: ###"Hello, my name is "%@" and I'm %d"###)
   }
   internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
-    return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: #"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"#)
+    return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: ###"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"###)
   }
   internal static func applesCount(_ p1: Int) -> String {
-    return L10n.tr("Localizable", "apples.count", p1, fallback: #"You have %d apples"#)
+    return L10n.tr("Localizable", "apples.count", p1, fallback: ###"You have %d apples"###)
   }
   internal static func bananasOwner(_ p1: Int, _ p2: Any) -> String {
-    return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: #"Those %d bananas belong to %@."#)
+    return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: ###"Those %d bananas belong to %@."###)
   }
-  internal static let key1Anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: #"value2"#)
+  internal static let key1Anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: ###"value2"###)
   internal static func manyPlaceholdersBase(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-    return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+    return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
   }
   internal static func manyPlaceholdersZero(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-    return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+    return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
   }
-  internal static let settingsNavigationBarSelf = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: #"Some Reserved Keyword there"#)
-  internal static let settingsNavigationBarTitleDeeperThanWeCanHandleNoReallyThisIsDeep = L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: #"DeepSettings"#)
-  internal static let settingsNavigationBarTitleEvenDeeper = L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: #"Settings"#)
-  internal static let settingsUserProfileSectionFooterText = L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: #"Here you can change some user profile settings."#)
-  internal static let settingsUserProfileSectionHEADERTITLE = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: #"User Profile Settings"#)
-  internal static let whatHappensHere = L10n.tr("Localizable", "what./*happens*/.here", fallback: #"hello world! /* still in string */"#)
+  internal static let settingsNavigationBarSelf = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: ###"Some Reserved Keyword there"###)
+  internal static let settingsNavigationBarTitleDeeperThanWeCanHandleNoReallyThisIsDeep = L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: ###"DeepSettings"###)
+  internal static let settingsNavigationBarTitleEvenDeeper = L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: ###"Settings"###)
+  internal static let settingsUserProfileSectionFooterText = L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: ###"Here you can change some user profile settings."###)
+  internal static let settingsUserProfileSectionHEADERTITLE = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: ###"User Profile Settings"###)
+  internal static let whatHappensHere = L10n.tr("Localizable", "what./*happens*/.here", fallback: ###"hello world! /* still in string */"###)
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/localizable-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/localizable-publicAccess.swift
@@ -10,55 +10,55 @@ import Foundation
 // swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 public enum L10n {
   /// Some alert body there
-  public static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: #"Some alert body there"#)
+  public static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: ###"Some alert body there"###)
   /// Title for an alert
-  public static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: #"Title of the alert"#)
-  /// value1
-  public static let key1 = L10n.tr("Localizable", "key1", fallback: #"value1"#)
+  public static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: ###"Title of the alert"###)
+  /// value1	value
+  public static let key1 = L10n.tr("Localizable", "key1", fallback: ###"value1\tvalue"###)
   /// These are %3$@'s %1$d %2$@.
   public static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
-    return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: #"These are %3$@'s %1$d %2$@."#)
+    return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: ###"These are %3$@'s %1$d %2$@."###)
   }
   /// This is a %% character.
-  public static let percent = L10n.tr("Localizable", "percent", fallback: #"This is a %% character."#)
+  public static let percent = L10n.tr("Localizable", "percent", fallback: ###"This is a %% character."###)
   /// Hello, my name is "%@" and I'm %d
   public static func `private`(_ p1: Any, _ p2: Int) -> String {
-    return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: #"Hello, my name is "%@" and I'm %d"#)
+    return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: ###"Hello, my name is "%@" and I'm %d"###)
   }
   /// Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'
   public static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
-    return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: #"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"#)
+    return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: ###"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"###)
   }
   /// You have %d apples
   public static func applesCount(_ p1: Int) -> String {
-    return L10n.tr("Localizable", "apples.count", p1, fallback: #"You have %d apples"#)
+    return L10n.tr("Localizable", "apples.count", p1, fallback: ###"You have %d apples"###)
   }
   /// A comment with no space above it
   public static func bananasOwner(_ p1: Int, _ p2: Any) -> String {
-    return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: #"Those %d bananas belong to %@."#)
+    return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: ###"Those %d bananas belong to %@."###)
   }
   /// Same as "key1" = "value1"; but in the context of user not logged in
-  public static let key1Anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: #"value2"#)
+  public static let key1Anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: ###"value2"###)
   /// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
   public static func manyPlaceholdersBase(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-    return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+    return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
   }
   /// %@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
   public static func manyPlaceholdersZero(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-    return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+    return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
   }
   /// Some Reserved Keyword there
-  public static let settingsNavigationBarSelf = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: #"Some Reserved Keyword there"#)
+  public static let settingsNavigationBarSelf = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: ###"Some Reserved Keyword there"###)
   /// DeepSettings
-  public static let settingsNavigationBarTitleDeeperThanWeCanHandleNoReallyThisIsDeep = L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: #"DeepSettings"#)
+  public static let settingsNavigationBarTitleDeeperThanWeCanHandleNoReallyThisIsDeep = L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: ###"DeepSettings"###)
   /// Settings
-  public static let settingsNavigationBarTitleEvenDeeper = L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: #"Settings"#)
+  public static let settingsNavigationBarTitleEvenDeeper = L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: ###"Settings"###)
   /// Here you can change some user profile settings.
-  public static let settingsUserProfileSectionFooterText = L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: #"Here you can change some user profile settings."#)
+  public static let settingsUserProfileSectionFooterText = L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: ###"Here you can change some user profile settings."###)
   /// User Profile Settings
-  public static let settingsUserProfileSectionHEADERTITLE = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: #"User Profile Settings"#)
+  public static let settingsUserProfileSectionHEADERTITLE = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: ###"User Profile Settings"###)
   /// some comment
-  public static let whatHappensHere = L10n.tr("Localizable", "what./*happens*/.here", fallback: #"hello world! /* still in string */"#)
+  public static let whatHappensHere = L10n.tr("Localizable", "what./*happens*/.here", fallback: ###"hello world! /* still in string */"###)
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/localizable.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/localizable.swift
@@ -10,55 +10,55 @@ import Foundation
 // swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 internal enum L10n {
   /// Some alert body there
-  internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: #"Some alert body there"#)
+  internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: ###"Some alert body there"###)
   /// Title for an alert
-  internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: #"Title of the alert"#)
-  /// value1
-  internal static let key1 = L10n.tr("Localizable", "key1", fallback: #"value1"#)
+  internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: ###"Title of the alert"###)
+  /// value1	value
+  internal static let key1 = L10n.tr("Localizable", "key1", fallback: ###"value1\tvalue"###)
   /// These are %3$@'s %1$d %2$@.
   internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
-    return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: #"These are %3$@'s %1$d %2$@."#)
+    return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: ###"These are %3$@'s %1$d %2$@."###)
   }
   /// This is a %% character.
-  internal static let percent = L10n.tr("Localizable", "percent", fallback: #"This is a %% character."#)
+  internal static let percent = L10n.tr("Localizable", "percent", fallback: ###"This is a %% character."###)
   /// Hello, my name is "%@" and I'm %d
   internal static func `private`(_ p1: Any, _ p2: Int) -> String {
-    return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: #"Hello, my name is "%@" and I'm %d"#)
+    return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: ###"Hello, my name is "%@" and I'm %d"###)
   }
   /// Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'
   internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
-    return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: #"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"#)
+    return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: ###"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"###)
   }
   /// You have %d apples
   internal static func applesCount(_ p1: Int) -> String {
-    return L10n.tr("Localizable", "apples.count", p1, fallback: #"You have %d apples"#)
+    return L10n.tr("Localizable", "apples.count", p1, fallback: ###"You have %d apples"###)
   }
   /// A comment with no space above it
   internal static func bananasOwner(_ p1: Int, _ p2: Any) -> String {
-    return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: #"Those %d bananas belong to %@."#)
+    return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: ###"Those %d bananas belong to %@."###)
   }
   /// Same as "key1" = "value1"; but in the context of user not logged in
-  internal static let key1Anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: #"value2"#)
+  internal static let key1Anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: ###"value2"###)
   /// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
   internal static func manyPlaceholdersBase(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-    return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+    return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
   }
   /// %@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
   internal static func manyPlaceholdersZero(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-    return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+    return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
   }
   /// Some Reserved Keyword there
-  internal static let settingsNavigationBarSelf = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: #"Some Reserved Keyword there"#)
+  internal static let settingsNavigationBarSelf = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: ###"Some Reserved Keyword there"###)
   /// DeepSettings
-  internal static let settingsNavigationBarTitleDeeperThanWeCanHandleNoReallyThisIsDeep = L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: #"DeepSettings"#)
+  internal static let settingsNavigationBarTitleDeeperThanWeCanHandleNoReallyThisIsDeep = L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: ###"DeepSettings"###)
   /// Settings
-  internal static let settingsNavigationBarTitleEvenDeeper = L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: #"Settings"#)
+  internal static let settingsNavigationBarTitleEvenDeeper = L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: ###"Settings"###)
   /// Here you can change some user profile settings.
-  internal static let settingsUserProfileSectionFooterText = L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: #"Here you can change some user profile settings."#)
+  internal static let settingsUserProfileSectionFooterText = L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: ###"Here you can change some user profile settings."###)
   /// User Profile Settings
-  internal static let settingsUserProfileSectionHEADERTITLE = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: #"User Profile Settings"#)
+  internal static let settingsUserProfileSectionHEADERTITLE = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: ###"User Profile Settings"###)
   /// some comment
-  internal static let whatHappensHere = L10n.tr("Localizable", "what./*happens*/.here", fallback: #"hello world! /* still in string */"#)
+  internal static let whatHappensHere = L10n.tr("Localizable", "what./*happens*/.here", fallback: ###"hello world! /* still in string */"###)
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/multiple.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/multiple.swift
@@ -11,77 +11,77 @@ import Foundation
 internal enum L10n {
   internal enum Localizable {
     /// Some alert body there
-    internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: #"Some alert body there"#)
+    internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: ###"Some alert body there"###)
     /// Title for an alert
-    internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: #"Title of the alert"#)
-    /// value1
-    internal static let key1 = L10n.tr("Localizable", "key1", fallback: #"value1"#)
+    internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: ###"Title of the alert"###)
+    /// value1	value
+    internal static let key1 = L10n.tr("Localizable", "key1", fallback: ###"value1\tvalue"###)
     /// These are %3$@'s %1$d %2$@.
     internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
-      return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: #"These are %3$@'s %1$d %2$@."#)
+      return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: ###"These are %3$@'s %1$d %2$@."###)
     }
     /// This is a %% character.
-    internal static let percent = L10n.tr("Localizable", "percent", fallback: #"This is a %% character."#)
+    internal static let percent = L10n.tr("Localizable", "percent", fallback: ###"This is a %% character."###)
     /// Hello, my name is "%@" and I'm %d
     internal static func `private`(_ p1: Any, _ p2: Int) -> String {
-      return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: #"Hello, my name is "%@" and I'm %d"#)
+      return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: ###"Hello, my name is "%@" and I'm %d"###)
     }
     /// Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'
     internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
-      return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: #"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"#)
+      return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: ###"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"###)
     }
     /// You have %d apples
     internal static func applesCount(_ p1: Int) -> String {
-      return L10n.tr("Localizable", "apples.count", p1, fallback: #"You have %d apples"#)
+      return L10n.tr("Localizable", "apples.count", p1, fallback: ###"You have %d apples"###)
     }
     /// A comment with no space above it
     internal static func bananasOwner(_ p1: Int, _ p2: Any) -> String {
-      return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: #"Those %d bananas belong to %@."#)
+      return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: ###"Those %d bananas belong to %@."###)
     }
     /// Same as "key1" = "value1"; but in the context of user not logged in
-    internal static let key1Anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: #"value2"#)
+    internal static let key1Anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: ###"value2"###)
     /// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
     internal static func manyPlaceholdersBase(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-      return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+      return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
     }
     /// %@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
     internal static func manyPlaceholdersZero(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-      return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+      return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
     }
     /// Some Reserved Keyword there
-    internal static let settingsNavigationBarSelf = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: #"Some Reserved Keyword there"#)
+    internal static let settingsNavigationBarSelf = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: ###"Some Reserved Keyword there"###)
     /// DeepSettings
-    internal static let settingsNavigationBarTitleDeeperThanWeCanHandleNoReallyThisIsDeep = L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: #"DeepSettings"#)
+    internal static let settingsNavigationBarTitleDeeperThanWeCanHandleNoReallyThisIsDeep = L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: ###"DeepSettings"###)
     /// Settings
-    internal static let settingsNavigationBarTitleEvenDeeper = L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: #"Settings"#)
+    internal static let settingsNavigationBarTitleEvenDeeper = L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: ###"Settings"###)
     /// Here you can change some user profile settings.
-    internal static let settingsUserProfileSectionFooterText = L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: #"Here you can change some user profile settings."#)
+    internal static let settingsUserProfileSectionFooterText = L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: ###"Here you can change some user profile settings."###)
     /// User Profile Settings
-    internal static let settingsUserProfileSectionHEADERTITLE = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: #"User Profile Settings"#)
+    internal static let settingsUserProfileSectionHEADERTITLE = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: ###"User Profile Settings"###)
     /// some comment
-    internal static let whatHappensHere = L10n.tr("Localizable", "what./*happens*/.here", fallback: #"hello world! /* still in string */"#)
+    internal static let whatHappensHere = L10n.tr("Localizable", "what./*happens*/.here", fallback: ###"hello world! /* still in string */"###)
   }
   internal enum LocMultiline {
     /// multi
     /// line
-    internal static let multiline = L10n.tr("LocMultiline", "MULTILINE", fallback: #"multi\nline"#)
+    internal static let multiline = L10n.tr("LocMultiline", "MULTILINE", fallback: ###"multi\nline"###)
     /// test
-    internal static let multiLineNKey = L10n.tr("LocMultiline", "multiLine\nKey", fallback: #"test"#)
+    internal static let multiLineNKey = L10n.tr("LocMultiline", "multiLine\nKey", fallback: ###"test"###)
     /// A multiline
     ///    comment
-    internal static let multilineComment = L10n.tr("LocMultiline", "multiline-comment", fallback: #"This string should have a multiline comment"#)
+    internal static let multilineComment = L10n.tr("LocMultiline", "multiline-comment", fallback: ###"This string should have a multiline comment"###)
     /// another
     /// multi
     ///     line
-    internal static let multiline2 = L10n.tr("LocMultiline", "MULTILINE2", fallback: #"another\nmulti\n    line"#)
+    internal static let multiline2 = L10n.tr("LocMultiline", "MULTILINE2", fallback: ###"another\nmulti\n    line"###)
     /// single line
-    internal static let singleline = L10n.tr("LocMultiline", "SINGLELINE", fallback: #"single line"#)
+    internal static let singleline = L10n.tr("LocMultiline", "SINGLELINE", fallback: ###"single line"###)
     /// another single line
-    internal static let singleline2 = L10n.tr("LocMultiline", "SINGLELINE2", fallback: #"another single line"#)
+    internal static let singleline2 = L10n.tr("LocMultiline", "SINGLELINE2", fallback: ###"another single line"###)
     /// Ceci n'est pas une pipe.
-    internal static let endingWith = L10n.tr("LocMultiline", "ending.with.", fallback: #"Ceci n'est pas une pipe."#)
+    internal static let endingWith = L10n.tr("LocMultiline", "ending.with.", fallback: ###"Ceci n'est pas une pipe."###)
     /// Veni, vidi, vici
-    internal static let someDotsAndEmptyComponents = L10n.tr("LocMultiline", "..some..dots.and..empty..components..", fallback: #"Veni, vidi, vici"#)
+    internal static let someDotsAndEmptyComponents = L10n.tr("LocMultiline", "..some..dots.and..empty..components..", fallback: ###"Veni, vidi, vici"###)
   }
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/plurals-advanced.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/plurals-advanced.swift
@@ -11,35 +11,35 @@ import Foundation
 internal enum L10n {
   /// Plural format key: "%@ - %#@d2@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@"
   internal static func manyPlaceholdersPluralsBase(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Any, _ p9: Int, _ p10: Float) -> String {
-    return L10n.tr("LocPluralAdvanced", "many.placeholders.plurals.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), String(describing: p8), p9, p10, fallback: #"Plural format key: "%@ - %#@d2@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@""#)
+    return L10n.tr("LocPluralAdvanced", "many.placeholders.plurals.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), String(describing: p8), p9, p10, fallback: ###"Plural format key: "%@ - %#@d2@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@""###)
   }
   /// Plural format key: "%@ - %#@d2@ - %0$#@zero@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@"
   internal static func manyPlaceholdersPluralsZero(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Any, _ p9: Int, _ p10: Float) -> String {
-    return L10n.tr("LocPluralAdvanced", "many.placeholders.plurals.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), String(describing: p8), p9, p10, fallback: #"Plural format key: "%@ - %#@d2@ - %0$#@zero@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@""#)
+    return L10n.tr("LocPluralAdvanced", "many.placeholders.plurals.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), String(describing: p8), p9, p10, fallback: ###"Plural format key: "%@ - %#@d2@ - %0$#@zero@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@""###)
   }
   /// Plural format key: "%1$@ %3$#@has_rating@"
   internal static func mixedPlaceholdersAndVariablesPositionalstringPositional3int(_ p1: Any, _ p2: Int) -> String {
-    return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.positionalstring-positional3int", String(describing: p1), p2, fallback: #"Plural format key: "%1$@ %3$#@has_rating@""#)
+    return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.positionalstring-positional3int", String(describing: p1), p2, fallback: ###"Plural format key: "%1$@ %3$#@has_rating@""###)
   }
   /// Plural format key: "%@ %#@has_rating@"
   internal static func mixedPlaceholdersAndVariablesStringInt(_ p1: Any, _ p2: Int) -> String {
-    return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-int", String(describing: p1), p2, fallback: #"Plural format key: "%@ %#@has_rating@""#)
+    return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-int", String(describing: p1), p2, fallback: ###"Plural format key: "%@ %#@has_rating@""###)
   }
   /// Plural format key: "%@ %2$#@has_rating@"
   internal static func mixedPlaceholdersAndVariablesStringPositional2int(_ p1: Any, _ p2: Int) -> String {
-    return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-positional2int", String(describing: p1), p2, fallback: #"Plural format key: "%@ %2$#@has_rating@""#)
+    return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-positional2int", String(describing: p1), p2, fallback: ###"Plural format key: "%@ %2$#@has_rating@""###)
   }
   /// Plural format key: "%@ %3$#@has_rating@"
   internal static func mixedPlaceholdersAndVariablesStringPositional3int(_ p1: Any, _ p2: Int) -> String {
-    return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-positional3int", String(describing: p1), p2, fallback: #"Plural format key: "%@ %3$#@has_rating@""#)
+    return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-positional3int", String(describing: p1), p2, fallback: ###"Plural format key: "%@ %3$#@has_rating@""###)
   }
   /// Plural format key: "Your %3$@ list contains %1$#@first@ %2$@."
   internal static func multiplePlaceholdersAndVariablesIntStringString(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
-    return L10n.tr("LocPluralAdvanced", "multiple.placeholders-and-variables.int-string-string", p1, String(describing: p2), String(describing: p3), fallback: #"Plural format key: "Your %3$@ list contains %1$#@first@ %2$@.""#)
+    return L10n.tr("LocPluralAdvanced", "multiple.placeholders-and-variables.int-string-string", p1, String(describing: p2), String(describing: p3), fallback: ###"Plural format key: "Your %3$@ list contains %1$#@first@ %2$@.""###)
   }
   /// Plural format key: "%#@files@ (%#@bytes@, %#@minutes@)"
   internal static func multipleVariablesThreeVariablesInFormatkey(_ p1: Int, _ p2: Int, _ p3: Int) -> String {
-    return L10n.tr("LocPluralAdvanced", "multiple.variables.three-variables-in-formatkey", p1, p2, p3, fallback: #"Plural format key: "%#@files@ (%#@bytes@, %#@minutes@)""#)
+    return L10n.tr("LocPluralAdvanced", "multiple.variables.three-variables-in-formatkey", p1, p2, p3, fallback: ###"Plural format key: "%#@files@ (%#@bytes@, %#@minutes@)""###)
   }
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/plurals-same-table.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/plurals-same-table.swift
@@ -10,63 +10,63 @@ import Foundation
 // swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 internal enum L10n {
   /// Some alert body there
-  internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: #"Some alert body there"#)
+  internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: ###"Some alert body there"###)
   /// Title for an alert
-  internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: #"Title of the alert"#)
-  /// value1
-  internal static let key1 = L10n.tr("Localizable", "key1", fallback: #"value1"#)
+  internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: ###"Title of the alert"###)
+  /// value1	value
+  internal static let key1 = L10n.tr("Localizable", "key1", fallback: ###"value1\tvalue"###)
   /// These are %3$@'s %1$d %2$@.
   internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
-    return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: #"These are %3$@'s %1$d %2$@."#)
+    return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: ###"These are %3$@'s %1$d %2$@."###)
   }
   /// This is a %% character.
-  internal static let percent = L10n.tr("Localizable", "percent", fallback: #"This is a %% character."#)
+  internal static let percent = L10n.tr("Localizable", "percent", fallback: ###"This is a %% character."###)
   /// Hello, my name is "%@" and I'm %d
   internal static func `private`(_ p1: Any, _ p2: Int) -> String {
-    return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: #"Hello, my name is "%@" and I'm %d"#)
+    return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: ###"Hello, my name is "%@" and I'm %d"###)
   }
   /// Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'
   internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
-    return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: #"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"#)
+    return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: ###"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"###)
   }
   /// Plural format key: "%#@apples@"
   internal static func applesCount(_ p1: Int) -> String {
-    return L10n.tr("Localizable", "apples.count", p1, fallback: #"Plural format key: "%#@apples@""#)
+    return L10n.tr("Localizable", "apples.count", p1, fallback: ###"Plural format key: "%#@apples@""###)
   }
   /// A comment with no space above it
   internal static func bananasOwner(_ p1: Int, _ p2: Any) -> String {
-    return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: #"Those %d bananas belong to %@."#)
+    return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: ###"Those %d bananas belong to %@."###)
   }
   /// Plural format key: "%#@Matches@"
   internal static func competitionEventNumberOfMatches(_ p1: Int) -> String {
-    return L10n.tr("Localizable", "competition.event.number-of-matches", p1, fallback: #"Plural format key: "%#@Matches@""#)
+    return L10n.tr("Localizable", "competition.event.number-of-matches", p1, fallback: ###"Plural format key: "%#@Matches@""###)
   }
   /// Plural format key: "%#@Subscriptions@"
   internal static func feedSubscriptionCount(_ p1: Int) -> String {
-    return L10n.tr("Localizable", "feed.subscription.count", p1, fallback: #"Plural format key: "%#@Subscriptions@""#)
+    return L10n.tr("Localizable", "feed.subscription.count", p1, fallback: ###"Plural format key: "%#@Subscriptions@""###)
   }
   /// Same as "key1" = "value1"; but in the context of user not logged in
-  internal static let key1Anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: #"value2"#)
+  internal static let key1Anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: ###"value2"###)
   /// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
   internal static func manyPlaceholdersBase(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-    return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+    return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
   }
   /// %@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
   internal static func manyPlaceholdersZero(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-    return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+    return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
   }
   /// Some Reserved Keyword there
-  internal static let settingsNavigationBarSelf = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: #"Some Reserved Keyword there"#)
+  internal static let settingsNavigationBarSelf = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: ###"Some Reserved Keyword there"###)
   /// DeepSettings
-  internal static let settingsNavigationBarTitleDeeperThanWeCanHandleNoReallyThisIsDeep = L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: #"DeepSettings"#)
+  internal static let settingsNavigationBarTitleDeeperThanWeCanHandleNoReallyThisIsDeep = L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: ###"DeepSettings"###)
   /// Settings
-  internal static let settingsNavigationBarTitleEvenDeeper = L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: #"Settings"#)
+  internal static let settingsNavigationBarTitleEvenDeeper = L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: ###"Settings"###)
   /// Here you can change some user profile settings.
-  internal static let settingsUserProfileSectionFooterText = L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: #"Here you can change some user profile settings."#)
+  internal static let settingsUserProfileSectionFooterText = L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: ###"Here you can change some user profile settings."###)
   /// User Profile Settings
-  internal static let settingsUserProfileSectionHEADERTITLE = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: #"User Profile Settings"#)
+  internal static let settingsUserProfileSectionHEADERTITLE = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: ###"User Profile Settings"###)
   /// some comment
-  internal static let whatHappensHere = L10n.tr("Localizable", "what./*happens*/.here", fallback: #"hello world! /* still in string */"#)
+  internal static let whatHappensHere = L10n.tr("Localizable", "what./*happens*/.here", fallback: ###"hello world! /* still in string */"###)
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/plurals-unsupported.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/plurals-unsupported.swift
@@ -11,7 +11,7 @@ import Foundation
 internal enum L10n {
   /// Plural format key: "%#@elements@"
   internal static func unsupportedUsePlaceholdersInVariableRuleStringInt(_ p1: Int) -> String {
-    return L10n.tr("LocPluralUnsupported", "unsupported-use.placeholders-in-variable-rule.string-int", p1, fallback: #"Plural format key: "%#@elements@""#)
+    return L10n.tr("LocPluralUnsupported", "unsupported-use.placeholders-in-variable-rule.string-int", p1, fallback: ###"Plural format key: "%#@elements@""###)
   }
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/plurals.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/plurals.swift
@@ -11,15 +11,15 @@ import Foundation
 internal enum L10n {
   /// Plural format key: "%#@apples@"
   internal static func applesCount(_ p1: Int) -> String {
-    return L10n.tr("Localizable", "apples.count", p1, fallback: #"Plural format key: "%#@apples@""#)
+    return L10n.tr("Localizable", "apples.count", p1, fallback: ###"Plural format key: "%#@apples@""###)
   }
   /// Plural format key: "%#@Matches@"
   internal static func competitionEventNumberOfMatches(_ p1: Int) -> String {
-    return L10n.tr("Localizable", "competition.event.number-of-matches", p1, fallback: #"Plural format key: "%#@Matches@""#)
+    return L10n.tr("Localizable", "competition.event.number-of-matches", p1, fallback: ###"Plural format key: "%#@Matches@""###)
   }
   /// Plural format key: "%#@Subscriptions@"
   internal static func feedSubscriptionCount(_ p1: Int) -> String {
-    return L10n.tr("Localizable", "feed.subscription.count", p1, fallback: #"Plural format key: "%#@Subscriptions@""#)
+    return L10n.tr("Localizable", "feed.subscription.count", p1, fallback: ###"Plural format key: "%#@Subscriptions@""###)
   }
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/localizable-customBundle.h
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/localizable-customBundle.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString*)alertMessage;
 /// Title for an alert
 + (NSString*)alertTitle;
-/// value1
+/// value1	value
 + (NSString*)key1;
 /// These are %3$@'s %1$d %2$@.
 + (NSString*)objectOwnershipWithValues:(NSInteger)p1 :(id)p2 :(id)p3;

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/localizable-headerName.h
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/localizable-headerName.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString*)alertMessage;
 /// Title for an alert
 + (NSString*)alertTitle;
-/// value1
+/// value1	value
 + (NSString*)key1;
 /// These are %3$@'s %1$d %2$@.
 + (NSString*)objectOwnershipWithValues:(NSInteger)p1 :(id)p2 :(id)p3;

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/localizable.h
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/localizable.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString*)alertMessage;
 /// Title for an alert
 + (NSString*)alertTitle;
-/// value1
+/// value1	value
 + (NSString*)key1;
 /// These are %3$@'s %1$d %2$@.
 + (NSString*)objectOwnershipWithValues:(NSInteger)p1 :(id)p2 :(id)p3;

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/multiple.h
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/multiple.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString*)alertMessage;
 /// Title for an alert
 + (NSString*)alertTitle;
-/// value1
+/// value1	value
 + (NSString*)key1;
 /// These are %3$@'s %1$d %2$@.
 + (NSString*)objectOwnershipWithValues:(NSInteger)p1 :(id)p2 :(id)p3;

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/plurals-same-table.h
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/plurals-same-table.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString*)alertMessage;
 /// Title for an alert
 + (NSString*)alertTitle;
-/// value1
+/// value1	value
 + (NSString*)key1;
 /// These are %3$@'s %1$d %2$@.
 + (NSString*)objectOwnershipWithValues:(NSInteger)p1 :(id)p2 :(id)p3;

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/localizable-customBundle.m
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/localizable-customBundle.m
@@ -27,7 +27,7 @@ static NSString* tr(NSString *tableName, NSString *key, NSString *value, ...) {
     return tr(@"Localizable", @"alert__title", @"Title of the alert");
 }
 + (NSString*)key1 {
-    return tr(@"Localizable", @"key1", @"value1");
+    return tr(@"Localizable", @"key1", @"value1\tvalue");
 }
 + (NSString*)objectOwnershipWithValues:(NSInteger)p1 :(id)p2 :(id)p3
 {

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/localizable-headerName.m
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/localizable-headerName.m
@@ -33,7 +33,7 @@ static NSString* tr(NSString *tableName, NSString *key, NSString *value, ...) {
     return tr(@"Localizable", @"alert__title", @"Title of the alert");
 }
 + (NSString*)key1 {
-    return tr(@"Localizable", @"key1", @"value1");
+    return tr(@"Localizable", @"key1", @"value1\tvalue");
 }
 + (NSString*)objectOwnershipWithValues:(NSInteger)p1 :(id)p2 :(id)p3
 {

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/localizable-noComments.m
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/localizable-noComments.m
@@ -33,7 +33,7 @@ static NSString* tr(NSString *tableName, NSString *key, NSString *value, ...) {
     return tr(@"Localizable", @"alert__title", @"Title of the alert");
 }
 + (NSString*)key1 {
-    return tr(@"Localizable", @"key1", @"value1");
+    return tr(@"Localizable", @"key1", @"value1\tvalue");
 }
 + (NSString*)objectOwnershipWithValues:(NSInteger)p1 :(id)p2 :(id)p3
 {

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/localizable.m
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/localizable.m
@@ -33,7 +33,7 @@ static NSString* tr(NSString *tableName, NSString *key, NSString *value, ...) {
     return tr(@"Localizable", @"alert__title", @"Title of the alert");
 }
 + (NSString*)key1 {
-    return tr(@"Localizable", @"key1", @"value1");
+    return tr(@"Localizable", @"key1", @"value1\tvalue");
 }
 + (NSString*)objectOwnershipWithValues:(NSInteger)p1 :(id)p2 :(id)p3
 {

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/multiple.m
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/multiple.m
@@ -33,7 +33,7 @@ static NSString* tr(NSString *tableName, NSString *key, NSString *value, ...) {
     return tr(@"Localizable", @"alert__title", @"Title of the alert");
 }
 + (NSString*)key1 {
-    return tr(@"Localizable", @"key1", @"value1");
+    return tr(@"Localizable", @"key1", @"value1\tvalue");
 }
 + (NSString*)objectOwnershipWithValues:(NSInteger)p1 :(id)p2 :(id)p3
 {

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/plurals-same-table.m
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/plurals-same-table.m
@@ -33,7 +33,7 @@ static NSString* tr(NSString *tableName, NSString *key, NSString *value, ...) {
     return tr(@"Localizable", @"alert__title", @"Title of the alert");
 }
 + (NSString*)key1 {
-    return tr(@"Localizable", @"key1", @"value1");
+    return tr(@"Localizable", @"key1", @"value1\tvalue");
 }
 + (NSString*)objectOwnershipWithValues:(NSInteger)p1 :(id)p2 :(id)p3
 {

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-customBundle.swift
@@ -14,8 +14,8 @@ internal enum L10n {
   internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: "Some alert body there")
   /// Title for an alert
   internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: "Title of the alert")
-  /// value1
-  internal static let key1 = L10n.tr("Localizable", "key1", fallback: "value1")
+  /// value1	value
+  internal static let key1 = L10n.tr("Localizable", "key1", fallback: "value1\tvalue")
   /// These are %3$@'s %1$d %2$@.
   internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
     return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: "These are %3$@'s %1$d %2$@.")

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-customName.swift
@@ -14,8 +14,8 @@ internal enum XCTLoc {
   internal static let alertMessage = XCTLoc.tr("Localizable", "alert__message", fallback: "Some alert body there")
   /// Title for an alert
   internal static let alertTitle = XCTLoc.tr("Localizable", "alert__title", fallback: "Title of the alert")
-  /// value1
-  internal static let key1 = XCTLoc.tr("Localizable", "key1", fallback: "value1")
+  /// value1	value
+  internal static let key1 = XCTLoc.tr("Localizable", "key1", fallback: "value1\tvalue")
   /// These are %3$@'s %1$d %2$@.
   internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
     return XCTLoc.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: "These are %3$@'s %1$d %2$@.")

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-forceFileNameEnum.swift
@@ -15,8 +15,8 @@ internal enum L10n {
     internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: "Some alert body there")
     /// Title for an alert
     internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: "Title of the alert")
-    /// value1
-    internal static let key1 = L10n.tr("Localizable", "key1", fallback: "value1")
+    /// value1	value
+    internal static let key1 = L10n.tr("Localizable", "key1", fallback: "value1\tvalue")
     /// These are %3$@'s %1$d %2$@.
     internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
       return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: "These are %3$@'s %1$d %2$@.")

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-lookupFunction.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-lookupFunction.swift
@@ -14,8 +14,8 @@ internal enum L10n {
   internal static var alertMessage: String { return L10n.tr("Localizable", "alert__message", fallback: "Some alert body there") }
   /// Title for an alert
   internal static var alertTitle: String { return L10n.tr("Localizable", "alert__title", fallback: "Title of the alert") }
-  /// value1
-  internal static var key1: String { return L10n.tr("Localizable", "key1", fallback: "value1") }
+  /// value1	value
+  internal static var key1: String { return L10n.tr("Localizable", "key1", fallback: "value1\tvalue") }
   /// These are %3$@'s %1$d %2$@.
   internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
     return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: "These are %3$@'s %1$d %2$@.")

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-noComments.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-noComments.swift
@@ -12,7 +12,7 @@ import Foundation
 internal enum L10n {
   internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: "Some alert body there")
   internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: "Title of the alert")
-  internal static let key1 = L10n.tr("Localizable", "key1", fallback: "value1")
+  internal static let key1 = L10n.tr("Localizable", "key1", fallback: "value1\tvalue")
   internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
     return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: "These are %3$@'s %1$d %2$@.")
   }

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-publicAccess.swift
@@ -14,8 +14,8 @@ public enum L10n {
   public static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: "Some alert body there")
   /// Title for an alert
   public static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: "Title of the alert")
-  /// value1
-  public static let key1 = L10n.tr("Localizable", "key1", fallback: "value1")
+  /// value1	value
+  public static let key1 = L10n.tr("Localizable", "key1", fallback: "value1\tvalue")
   /// These are %3$@'s %1$d %2$@.
   public static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
     return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: "These are %3$@'s %1$d %2$@.")

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable.swift
@@ -14,8 +14,8 @@ internal enum L10n {
   internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: "Some alert body there")
   /// Title for an alert
   internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: "Title of the alert")
-  /// value1
-  internal static let key1 = L10n.tr("Localizable", "key1", fallback: "value1")
+  /// value1	value
+  internal static let key1 = L10n.tr("Localizable", "key1", fallback: "value1\tvalue")
   /// These are %3$@'s %1$d %2$@.
   internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
     return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: "These are %3$@'s %1$d %2$@.")

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/multiple.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/multiple.swift
@@ -15,8 +15,8 @@ internal enum L10n {
     internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: "Some alert body there")
     /// Title for an alert
     internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: "Title of the alert")
-    /// value1
-    internal static let key1 = L10n.tr("Localizable", "key1", fallback: "value1")
+    /// value1	value
+    internal static let key1 = L10n.tr("Localizable", "key1", fallback: "value1\tvalue")
     /// These are %3$@'s %1$d %2$@.
     internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
       return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: "These are %3$@'s %1$d %2$@.")

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/plurals-same-table.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/plurals-same-table.swift
@@ -14,8 +14,8 @@ internal enum L10n {
   internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: "Some alert body there")
   /// Title for an alert
   internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: "Title of the alert")
-  /// value1
-  internal static let key1 = L10n.tr("Localizable", "key1", fallback: "value1")
+  /// value1	value
+  internal static let key1 = L10n.tr("Localizable", "key1", fallback: "value1\tvalue")
   /// These are %3$@'s %1$d %2$@.
   internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
     return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: "These are %3$@'s %1$d %2$@.")

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-customBundle.swift
@@ -11,57 +11,57 @@ import Foundation
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
 internal enum L10n {
   /// Some alert body there
-  internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: #"Some alert body there"#)
+  internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: ###"Some alert body there"###)
   /// Title for an alert
-  internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: #"Title of the alert"#)
-  /// value1
-  internal static let key1 = L10n.tr("Localizable", "key1", fallback: #"value1"#)
+  internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: ###"Title of the alert"###)
+  /// value1	value
+  internal static let key1 = L10n.tr("Localizable", "key1", fallback: ###"value1\tvalue"###)
   /// These are %3$@'s %1$d %2$@.
   internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
-    return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: #"These are %3$@'s %1$d %2$@."#)
+    return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: ###"These are %3$@'s %1$d %2$@."###)
   }
   /// This is a %% character.
-  internal static let percent = L10n.tr("Localizable", "percent", fallback: #"This is a %% character."#)
+  internal static let percent = L10n.tr("Localizable", "percent", fallback: ###"This is a %% character."###)
   /// Hello, my name is "%@" and I'm %d
   internal static func `private`(_ p1: Any, _ p2: Int) -> String {
-    return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: #"Hello, my name is "%@" and I'm %d"#)
+    return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: ###"Hello, my name is "%@" and I'm %d"###)
   }
   /// Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'
   internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
-    return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: #"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"#)
+    return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: ###"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"###)
   }
   internal enum Apples {
     /// You have %d apples
     internal static func count(_ p1: Int) -> String {
-      return L10n.tr("Localizable", "apples.count", p1, fallback: #"You have %d apples"#)
+      return L10n.tr("Localizable", "apples.count", p1, fallback: ###"You have %d apples"###)
     }
   }
   internal enum Bananas {
     /// A comment with no space above it
     internal static func owner(_ p1: Int, _ p2: Any) -> String {
-      return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: #"Those %d bananas belong to %@."#)
+      return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: ###"Those %d bananas belong to %@."###)
     }
   }
   internal enum Key1 {
     /// Same as "key1" = "value1"; but in the context of user not logged in
-    internal static let anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: #"value2"#)
+    internal static let anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: ###"value2"###)
   }
   internal enum Many {
     internal enum Placeholders {
       /// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
       internal static func base(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-        return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+        return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
       }
       /// %@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
       internal static func zero(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-        return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+        return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
       }
     }
   }
   internal enum Settings {
     internal enum NavigationBar {
       /// Some Reserved Keyword there
-      internal static let `self` = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: #"Some Reserved Keyword there"#)
+      internal static let `self` = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: ###"Some Reserved Keyword there"###)
       internal enum Title {
         internal enum Deeper {
           internal enum Than {
@@ -73,7 +73,7 @@ internal enum L10n {
                       internal enum This {
                         internal enum Is {
                           /// DeepSettings
-                          internal static let deep = L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: #"DeepSettings"#)
+                          internal static let deep = L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: ###"DeepSettings"###)
                         }
                       }
                     }
@@ -85,21 +85,21 @@ internal enum L10n {
         }
         internal enum Even {
           /// Settings
-          internal static let deeper = L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: #"Settings"#)
+          internal static let deeper = L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: ###"Settings"###)
         }
       }
     }
     internal enum UserProfileSection {
       /// Here you can change some user profile settings.
-      internal static let footerText = L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: #"Here you can change some user profile settings."#)
+      internal static let footerText = L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: ###"Here you can change some user profile settings."###)
       /// User Profile Settings
-      internal static let headerTitle = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: #"User Profile Settings"#)
+      internal static let headerTitle = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: ###"User Profile Settings"###)
     }
   }
   internal enum What {
     internal enum Happens {
       /// some comment
-      internal static let here = L10n.tr("Localizable", "what./*happens*/.here", fallback: #"hello world! /* still in string */"#)
+      internal static let here = L10n.tr("Localizable", "what./*happens*/.here", fallback: ###"hello world! /* still in string */"###)
     }
   }
 }

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-customName.swift
@@ -11,57 +11,57 @@ import Foundation
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
 internal enum XCTLoc {
   /// Some alert body there
-  internal static let alertMessage = XCTLoc.tr("Localizable", "alert__message", fallback: #"Some alert body there"#)
+  internal static let alertMessage = XCTLoc.tr("Localizable", "alert__message", fallback: ###"Some alert body there"###)
   /// Title for an alert
-  internal static let alertTitle = XCTLoc.tr("Localizable", "alert__title", fallback: #"Title of the alert"#)
-  /// value1
-  internal static let key1 = XCTLoc.tr("Localizable", "key1", fallback: #"value1"#)
+  internal static let alertTitle = XCTLoc.tr("Localizable", "alert__title", fallback: ###"Title of the alert"###)
+  /// value1	value
+  internal static let key1 = XCTLoc.tr("Localizable", "key1", fallback: ###"value1\tvalue"###)
   /// These are %3$@'s %1$d %2$@.
   internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
-    return XCTLoc.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: #"These are %3$@'s %1$d %2$@."#)
+    return XCTLoc.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: ###"These are %3$@'s %1$d %2$@."###)
   }
   /// This is a %% character.
-  internal static let percent = XCTLoc.tr("Localizable", "percent", fallback: #"This is a %% character."#)
+  internal static let percent = XCTLoc.tr("Localizable", "percent", fallback: ###"This is a %% character."###)
   /// Hello, my name is "%@" and I'm %d
   internal static func `private`(_ p1: Any, _ p2: Int) -> String {
-    return XCTLoc.tr("Localizable", "private", String(describing: p1), p2, fallback: #"Hello, my name is "%@" and I'm %d"#)
+    return XCTLoc.tr("Localizable", "private", String(describing: p1), p2, fallback: ###"Hello, my name is "%@" and I'm %d"###)
   }
   /// Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'
   internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
-    return XCTLoc.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: #"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"#)
+    return XCTLoc.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: ###"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"###)
   }
   internal enum Apples {
     /// You have %d apples
     internal static func count(_ p1: Int) -> String {
-      return XCTLoc.tr("Localizable", "apples.count", p1, fallback: #"You have %d apples"#)
+      return XCTLoc.tr("Localizable", "apples.count", p1, fallback: ###"You have %d apples"###)
     }
   }
   internal enum Bananas {
     /// A comment with no space above it
     internal static func owner(_ p1: Int, _ p2: Any) -> String {
-      return XCTLoc.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: #"Those %d bananas belong to %@."#)
+      return XCTLoc.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: ###"Those %d bananas belong to %@."###)
     }
   }
   internal enum Key1 {
     /// Same as "key1" = "value1"; but in the context of user not logged in
-    internal static let anonymous = XCTLoc.tr("Localizable", "key1.anonymous", fallback: #"value2"#)
+    internal static let anonymous = XCTLoc.tr("Localizable", "key1.anonymous", fallback: ###"value2"###)
   }
   internal enum Many {
     internal enum Placeholders {
       /// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
       internal static func base(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-        return XCTLoc.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+        return XCTLoc.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
       }
       /// %@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
       internal static func zero(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-        return XCTLoc.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+        return XCTLoc.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
       }
     }
   }
   internal enum Settings {
     internal enum NavigationBar {
       /// Some Reserved Keyword there
-      internal static let `self` = XCTLoc.tr("Localizable", "settings.navigation-bar.self", fallback: #"Some Reserved Keyword there"#)
+      internal static let `self` = XCTLoc.tr("Localizable", "settings.navigation-bar.self", fallback: ###"Some Reserved Keyword there"###)
       internal enum Title {
         internal enum Deeper {
           internal enum Than {
@@ -73,7 +73,7 @@ internal enum XCTLoc {
                       internal enum This {
                         internal enum Is {
                           /// DeepSettings
-                          internal static let deep = XCTLoc.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: #"DeepSettings"#)
+                          internal static let deep = XCTLoc.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: ###"DeepSettings"###)
                         }
                       }
                     }
@@ -85,21 +85,21 @@ internal enum XCTLoc {
         }
         internal enum Even {
           /// Settings
-          internal static let deeper = XCTLoc.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: #"Settings"#)
+          internal static let deeper = XCTLoc.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: ###"Settings"###)
         }
       }
     }
     internal enum UserProfileSection {
       /// Here you can change some user profile settings.
-      internal static let footerText = XCTLoc.tr("Localizable", "settings.user__profile_section.footer_text", fallback: #"Here you can change some user profile settings."#)
+      internal static let footerText = XCTLoc.tr("Localizable", "settings.user__profile_section.footer_text", fallback: ###"Here you can change some user profile settings."###)
       /// User Profile Settings
-      internal static let headerTitle = XCTLoc.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: #"User Profile Settings"#)
+      internal static let headerTitle = XCTLoc.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: ###"User Profile Settings"###)
     }
   }
   internal enum What {
     internal enum Happens {
       /// some comment
-      internal static let here = XCTLoc.tr("Localizable", "what./*happens*/.here", fallback: #"hello world! /* still in string */"#)
+      internal static let here = XCTLoc.tr("Localizable", "what./*happens*/.here", fallback: ###"hello world! /* still in string */"###)
     }
   }
 }

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-forceFileNameEnum.swift
@@ -12,57 +12,57 @@ import Foundation
 internal enum L10n {
   internal enum Localizable {
     /// Some alert body there
-    internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: #"Some alert body there"#)
+    internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: ###"Some alert body there"###)
     /// Title for an alert
-    internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: #"Title of the alert"#)
-    /// value1
-    internal static let key1 = L10n.tr("Localizable", "key1", fallback: #"value1"#)
+    internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: ###"Title of the alert"###)
+    /// value1	value
+    internal static let key1 = L10n.tr("Localizable", "key1", fallback: ###"value1\tvalue"###)
     /// These are %3$@'s %1$d %2$@.
     internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
-      return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: #"These are %3$@'s %1$d %2$@."#)
+      return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: ###"These are %3$@'s %1$d %2$@."###)
     }
     /// This is a %% character.
-    internal static let percent = L10n.tr("Localizable", "percent", fallback: #"This is a %% character."#)
+    internal static let percent = L10n.tr("Localizable", "percent", fallback: ###"This is a %% character."###)
     /// Hello, my name is "%@" and I'm %d
     internal static func `private`(_ p1: Any, _ p2: Int) -> String {
-      return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: #"Hello, my name is "%@" and I'm %d"#)
+      return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: ###"Hello, my name is "%@" and I'm %d"###)
     }
     /// Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'
     internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
-      return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: #"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"#)
+      return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: ###"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"###)
     }
     internal enum Apples {
       /// You have %d apples
       internal static func count(_ p1: Int) -> String {
-        return L10n.tr("Localizable", "apples.count", p1, fallback: #"You have %d apples"#)
+        return L10n.tr("Localizable", "apples.count", p1, fallback: ###"You have %d apples"###)
       }
     }
     internal enum Bananas {
       /// A comment with no space above it
       internal static func owner(_ p1: Int, _ p2: Any) -> String {
-        return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: #"Those %d bananas belong to %@."#)
+        return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: ###"Those %d bananas belong to %@."###)
       }
     }
     internal enum Key1 {
       /// Same as "key1" = "value1"; but in the context of user not logged in
-      internal static let anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: #"value2"#)
+      internal static let anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: ###"value2"###)
     }
     internal enum Many {
       internal enum Placeholders {
         /// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
         internal static func base(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-          return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+          return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
         }
         /// %@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
         internal static func zero(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-          return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+          return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
         }
       }
     }
     internal enum Settings {
       internal enum NavigationBar {
         /// Some Reserved Keyword there
-        internal static let `self` = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: #"Some Reserved Keyword there"#)
+        internal static let `self` = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: ###"Some Reserved Keyword there"###)
         internal enum Title {
           internal enum Deeper {
             internal enum Than {
@@ -74,7 +74,7 @@ internal enum L10n {
                         internal enum This {
                           internal enum Is {
                             /// DeepSettings
-                            internal static let deep = L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: #"DeepSettings"#)
+                            internal static let deep = L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: ###"DeepSettings"###)
                           }
                         }
                       }
@@ -86,21 +86,21 @@ internal enum L10n {
           }
           internal enum Even {
             /// Settings
-            internal static let deeper = L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: #"Settings"#)
+            internal static let deeper = L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: ###"Settings"###)
           }
         }
       }
       internal enum UserProfileSection {
         /// Here you can change some user profile settings.
-        internal static let footerText = L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: #"Here you can change some user profile settings."#)
+        internal static let footerText = L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: ###"Here you can change some user profile settings."###)
         /// User Profile Settings
-        internal static let headerTitle = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: #"User Profile Settings"#)
+        internal static let headerTitle = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: ###"User Profile Settings"###)
       }
     }
     internal enum What {
       internal enum Happens {
         /// some comment
-        internal static let here = L10n.tr("Localizable", "what./*happens*/.here", fallback: #"hello world! /* still in string */"#)
+        internal static let here = L10n.tr("Localizable", "what./*happens*/.here", fallback: ###"hello world! /* still in string */"###)
       }
     }
   }

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-lookupFunction.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-lookupFunction.swift
@@ -11,57 +11,57 @@ import Foundation
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
 internal enum L10n {
   /// Some alert body there
-  internal static var alertMessage: String { return L10n.tr("Localizable", "alert__message", fallback: #"Some alert body there"#) }
+  internal static var alertMessage: String { return L10n.tr("Localizable", "alert__message", fallback: ###"Some alert body there"###) }
   /// Title for an alert
-  internal static var alertTitle: String { return L10n.tr("Localizable", "alert__title", fallback: #"Title of the alert"#) }
-  /// value1
-  internal static var key1: String { return L10n.tr("Localizable", "key1", fallback: #"value1"#) }
+  internal static var alertTitle: String { return L10n.tr("Localizable", "alert__title", fallback: ###"Title of the alert"###) }
+  /// value1	value
+  internal static var key1: String { return L10n.tr("Localizable", "key1", fallback: ###"value1\tvalue"###) }
   /// These are %3$@'s %1$d %2$@.
   internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
-    return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: #"These are %3$@'s %1$d %2$@."#)
+    return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: ###"These are %3$@'s %1$d %2$@."###)
   }
   /// This is a %% character.
-  internal static var percent: String { return L10n.tr("Localizable", "percent", fallback: #"This is a %% character."#) }
+  internal static var percent: String { return L10n.tr("Localizable", "percent", fallback: ###"This is a %% character."###) }
   /// Hello, my name is "%@" and I'm %d
   internal static func `private`(_ p1: Any, _ p2: Int) -> String {
-    return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: #"Hello, my name is "%@" and I'm %d"#)
+    return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: ###"Hello, my name is "%@" and I'm %d"###)
   }
   /// Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'
   internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
-    return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: #"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"#)
+    return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: ###"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"###)
   }
   internal enum Apples {
     /// You have %d apples
     internal static func count(_ p1: Int) -> String {
-      return L10n.tr("Localizable", "apples.count", p1, fallback: #"You have %d apples"#)
+      return L10n.tr("Localizable", "apples.count", p1, fallback: ###"You have %d apples"###)
     }
   }
   internal enum Bananas {
     /// A comment with no space above it
     internal static func owner(_ p1: Int, _ p2: Any) -> String {
-      return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: #"Those %d bananas belong to %@."#)
+      return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: ###"Those %d bananas belong to %@."###)
     }
   }
   internal enum Key1 {
     /// Same as "key1" = "value1"; but in the context of user not logged in
-    internal static var anonymous: String { return L10n.tr("Localizable", "key1.anonymous", fallback: #"value2"#) }
+    internal static var anonymous: String { return L10n.tr("Localizable", "key1.anonymous", fallback: ###"value2"###) }
   }
   internal enum Many {
     internal enum Placeholders {
       /// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
       internal static func base(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-        return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+        return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
       }
       /// %@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
       internal static func zero(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-        return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+        return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
       }
     }
   }
   internal enum Settings {
     internal enum NavigationBar {
       /// Some Reserved Keyword there
-      internal static var `self`: String { return L10n.tr("Localizable", "settings.navigation-bar.self", fallback: #"Some Reserved Keyword there"#) }
+      internal static var `self`: String { return L10n.tr("Localizable", "settings.navigation-bar.self", fallback: ###"Some Reserved Keyword there"###) }
       internal enum Title {
         internal enum Deeper {
           internal enum Than {
@@ -73,7 +73,7 @@ internal enum L10n {
                       internal enum This {
                         internal enum Is {
                           /// DeepSettings
-                          internal static var deep: String { return L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: #"DeepSettings"#) }
+                          internal static var deep: String { return L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: ###"DeepSettings"###) }
                         }
                       }
                     }
@@ -85,21 +85,21 @@ internal enum L10n {
         }
         internal enum Even {
           /// Settings
-          internal static var deeper: String { return L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: #"Settings"#) }
+          internal static var deeper: String { return L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: ###"Settings"###) }
         }
       }
     }
     internal enum UserProfileSection {
       /// Here you can change some user profile settings.
-      internal static var footerText: String { return L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: #"Here you can change some user profile settings."#) }
+      internal static var footerText: String { return L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: ###"Here you can change some user profile settings."###) }
       /// User Profile Settings
-      internal static var headerTitle: String { return L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: #"User Profile Settings"#) }
+      internal static var headerTitle: String { return L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: ###"User Profile Settings"###) }
     }
   }
   internal enum What {
     internal enum Happens {
       /// some comment
-      internal static var here: String { return L10n.tr("Localizable", "what./*happens*/.here", fallback: #"hello world! /* still in string */"#) }
+      internal static var here: String { return L10n.tr("Localizable", "what./*happens*/.here", fallback: ###"hello world! /* still in string */"###) }
     }
   }
 }

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-noComments.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-noComments.swift
@@ -10,45 +10,45 @@ import Foundation
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
 internal enum L10n {
-  internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: #"Some alert body there"#)
-  internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: #"Title of the alert"#)
-  internal static let key1 = L10n.tr("Localizable", "key1", fallback: #"value1"#)
+  internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: ###"Some alert body there"###)
+  internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: ###"Title of the alert"###)
+  internal static let key1 = L10n.tr("Localizable", "key1", fallback: ###"value1\tvalue"###)
   internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
-    return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: #"These are %3$@'s %1$d %2$@."#)
+    return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: ###"These are %3$@'s %1$d %2$@."###)
   }
-  internal static let percent = L10n.tr("Localizable", "percent", fallback: #"This is a %% character."#)
+  internal static let percent = L10n.tr("Localizable", "percent", fallback: ###"This is a %% character."###)
   internal static func `private`(_ p1: Any, _ p2: Int) -> String {
-    return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: #"Hello, my name is "%@" and I'm %d"#)
+    return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: ###"Hello, my name is "%@" and I'm %d"###)
   }
   internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
-    return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: #"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"#)
+    return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: ###"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"###)
   }
   internal enum Apples {
     internal static func count(_ p1: Int) -> String {
-      return L10n.tr("Localizable", "apples.count", p1, fallback: #"You have %d apples"#)
+      return L10n.tr("Localizable", "apples.count", p1, fallback: ###"You have %d apples"###)
     }
   }
   internal enum Bananas {
     internal static func owner(_ p1: Int, _ p2: Any) -> String {
-      return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: #"Those %d bananas belong to %@."#)
+      return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: ###"Those %d bananas belong to %@."###)
     }
   }
   internal enum Key1 {
-    internal static let anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: #"value2"#)
+    internal static let anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: ###"value2"###)
   }
   internal enum Many {
     internal enum Placeholders {
       internal static func base(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-        return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+        return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
       }
       internal static func zero(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-        return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+        return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
       }
     }
   }
   internal enum Settings {
     internal enum NavigationBar {
-      internal static let `self` = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: #"Some Reserved Keyword there"#)
+      internal static let `self` = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: ###"Some Reserved Keyword there"###)
       internal enum Title {
         internal enum Deeper {
           internal enum Than {
@@ -59,7 +59,7 @@ internal enum L10n {
                     internal enum Really {
                       internal enum This {
                         internal enum Is {
-                          internal static let deep = L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: #"DeepSettings"#)
+                          internal static let deep = L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: ###"DeepSettings"###)
                         }
                       }
                     }
@@ -70,18 +70,18 @@ internal enum L10n {
           }
         }
         internal enum Even {
-          internal static let deeper = L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: #"Settings"#)
+          internal static let deeper = L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: ###"Settings"###)
         }
       }
     }
     internal enum UserProfileSection {
-      internal static let footerText = L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: #"Here you can change some user profile settings."#)
-      internal static let headerTitle = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: #"User Profile Settings"#)
+      internal static let footerText = L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: ###"Here you can change some user profile settings."###)
+      internal static let headerTitle = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: ###"User Profile Settings"###)
     }
   }
   internal enum What {
     internal enum Happens {
-      internal static let here = L10n.tr("Localizable", "what./*happens*/.here", fallback: #"hello world! /* still in string */"#)
+      internal static let here = L10n.tr("Localizable", "what./*happens*/.here", fallback: ###"hello world! /* still in string */"###)
     }
   }
 }

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-publicAccess.swift
@@ -11,57 +11,57 @@ import Foundation
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
 public enum L10n {
   /// Some alert body there
-  public static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: #"Some alert body there"#)
+  public static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: ###"Some alert body there"###)
   /// Title for an alert
-  public static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: #"Title of the alert"#)
-  /// value1
-  public static let key1 = L10n.tr("Localizable", "key1", fallback: #"value1"#)
+  public static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: ###"Title of the alert"###)
+  /// value1	value
+  public static let key1 = L10n.tr("Localizable", "key1", fallback: ###"value1\tvalue"###)
   /// These are %3$@'s %1$d %2$@.
   public static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
-    return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: #"These are %3$@'s %1$d %2$@."#)
+    return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: ###"These are %3$@'s %1$d %2$@."###)
   }
   /// This is a %% character.
-  public static let percent = L10n.tr("Localizable", "percent", fallback: #"This is a %% character."#)
+  public static let percent = L10n.tr("Localizable", "percent", fallback: ###"This is a %% character."###)
   /// Hello, my name is "%@" and I'm %d
   public static func `private`(_ p1: Any, _ p2: Int) -> String {
-    return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: #"Hello, my name is "%@" and I'm %d"#)
+    return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: ###"Hello, my name is "%@" and I'm %d"###)
   }
   /// Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'
   public static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
-    return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: #"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"#)
+    return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: ###"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"###)
   }
   public enum Apples {
     /// You have %d apples
     public static func count(_ p1: Int) -> String {
-      return L10n.tr("Localizable", "apples.count", p1, fallback: #"You have %d apples"#)
+      return L10n.tr("Localizable", "apples.count", p1, fallback: ###"You have %d apples"###)
     }
   }
   public enum Bananas {
     /// A comment with no space above it
     public static func owner(_ p1: Int, _ p2: Any) -> String {
-      return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: #"Those %d bananas belong to %@."#)
+      return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: ###"Those %d bananas belong to %@."###)
     }
   }
   public enum Key1 {
     /// Same as "key1" = "value1"; but in the context of user not logged in
-    public static let anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: #"value2"#)
+    public static let anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: ###"value2"###)
   }
   public enum Many {
     public enum Placeholders {
       /// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
       public static func base(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-        return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+        return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
       }
       /// %@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
       public static func zero(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-        return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+        return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
       }
     }
   }
   public enum Settings {
     public enum NavigationBar {
       /// Some Reserved Keyword there
-      public static let `self` = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: #"Some Reserved Keyword there"#)
+      public static let `self` = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: ###"Some Reserved Keyword there"###)
       public enum Title {
         public enum Deeper {
           public enum Than {
@@ -73,7 +73,7 @@ public enum L10n {
                       public enum This {
                         public enum Is {
                           /// DeepSettings
-                          public static let deep = L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: #"DeepSettings"#)
+                          public static let deep = L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: ###"DeepSettings"###)
                         }
                       }
                     }
@@ -85,21 +85,21 @@ public enum L10n {
         }
         public enum Even {
           /// Settings
-          public static let deeper = L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: #"Settings"#)
+          public static let deeper = L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: ###"Settings"###)
         }
       }
     }
     public enum UserProfileSection {
       /// Here you can change some user profile settings.
-      public static let footerText = L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: #"Here you can change some user profile settings."#)
+      public static let footerText = L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: ###"Here you can change some user profile settings."###)
       /// User Profile Settings
-      public static let headerTitle = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: #"User Profile Settings"#)
+      public static let headerTitle = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: ###"User Profile Settings"###)
     }
   }
   public enum What {
     public enum Happens {
       /// some comment
-      public static let here = L10n.tr("Localizable", "what./*happens*/.here", fallback: #"hello world! /* still in string */"#)
+      public static let here = L10n.tr("Localizable", "what./*happens*/.here", fallback: ###"hello world! /* still in string */"###)
     }
   }
 }

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable.swift
@@ -11,57 +11,57 @@ import Foundation
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
 internal enum L10n {
   /// Some alert body there
-  internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: #"Some alert body there"#)
+  internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: ###"Some alert body there"###)
   /// Title for an alert
-  internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: #"Title of the alert"#)
-  /// value1
-  internal static let key1 = L10n.tr("Localizable", "key1", fallback: #"value1"#)
+  internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: ###"Title of the alert"###)
+  /// value1	value
+  internal static let key1 = L10n.tr("Localizable", "key1", fallback: ###"value1\tvalue"###)
   /// These are %3$@'s %1$d %2$@.
   internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
-    return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: #"These are %3$@'s %1$d %2$@."#)
+    return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: ###"These are %3$@'s %1$d %2$@."###)
   }
   /// This is a %% character.
-  internal static let percent = L10n.tr("Localizable", "percent", fallback: #"This is a %% character."#)
+  internal static let percent = L10n.tr("Localizable", "percent", fallback: ###"This is a %% character."###)
   /// Hello, my name is "%@" and I'm %d
   internal static func `private`(_ p1: Any, _ p2: Int) -> String {
-    return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: #"Hello, my name is "%@" and I'm %d"#)
+    return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: ###"Hello, my name is "%@" and I'm %d"###)
   }
   /// Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'
   internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
-    return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: #"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"#)
+    return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: ###"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"###)
   }
   internal enum Apples {
     /// You have %d apples
     internal static func count(_ p1: Int) -> String {
-      return L10n.tr("Localizable", "apples.count", p1, fallback: #"You have %d apples"#)
+      return L10n.tr("Localizable", "apples.count", p1, fallback: ###"You have %d apples"###)
     }
   }
   internal enum Bananas {
     /// A comment with no space above it
     internal static func owner(_ p1: Int, _ p2: Any) -> String {
-      return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: #"Those %d bananas belong to %@."#)
+      return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: ###"Those %d bananas belong to %@."###)
     }
   }
   internal enum Key1 {
     /// Same as "key1" = "value1"; but in the context of user not logged in
-    internal static let anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: #"value2"#)
+    internal static let anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: ###"value2"###)
   }
   internal enum Many {
     internal enum Placeholders {
       /// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
       internal static func base(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-        return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+        return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
       }
       /// %@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
       internal static func zero(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-        return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+        return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
       }
     }
   }
   internal enum Settings {
     internal enum NavigationBar {
       /// Some Reserved Keyword there
-      internal static let `self` = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: #"Some Reserved Keyword there"#)
+      internal static let `self` = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: ###"Some Reserved Keyword there"###)
       internal enum Title {
         internal enum Deeper {
           internal enum Than {
@@ -73,7 +73,7 @@ internal enum L10n {
                       internal enum This {
                         internal enum Is {
                           /// DeepSettings
-                          internal static let deep = L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: #"DeepSettings"#)
+                          internal static let deep = L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: ###"DeepSettings"###)
                         }
                       }
                     }
@@ -85,21 +85,21 @@ internal enum L10n {
         }
         internal enum Even {
           /// Settings
-          internal static let deeper = L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: #"Settings"#)
+          internal static let deeper = L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: ###"Settings"###)
         }
       }
     }
     internal enum UserProfileSection {
       /// Here you can change some user profile settings.
-      internal static let footerText = L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: #"Here you can change some user profile settings."#)
+      internal static let footerText = L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: ###"Here you can change some user profile settings."###)
       /// User Profile Settings
-      internal static let headerTitle = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: #"User Profile Settings"#)
+      internal static let headerTitle = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: ###"User Profile Settings"###)
     }
   }
   internal enum What {
     internal enum Happens {
       /// some comment
-      internal static let here = L10n.tr("Localizable", "what./*happens*/.here", fallback: #"hello world! /* still in string */"#)
+      internal static let here = L10n.tr("Localizable", "what./*happens*/.here", fallback: ###"hello world! /* still in string */"###)
     }
   }
 }

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/multiple.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/multiple.swift
@@ -12,57 +12,57 @@ import Foundation
 internal enum L10n {
   internal enum Localizable {
     /// Some alert body there
-    internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: #"Some alert body there"#)
+    internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: ###"Some alert body there"###)
     /// Title for an alert
-    internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: #"Title of the alert"#)
-    /// value1
-    internal static let key1 = L10n.tr("Localizable", "key1", fallback: #"value1"#)
+    internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: ###"Title of the alert"###)
+    /// value1	value
+    internal static let key1 = L10n.tr("Localizable", "key1", fallback: ###"value1\tvalue"###)
     /// These are %3$@'s %1$d %2$@.
     internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
-      return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: #"These are %3$@'s %1$d %2$@."#)
+      return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: ###"These are %3$@'s %1$d %2$@."###)
     }
     /// This is a %% character.
-    internal static let percent = L10n.tr("Localizable", "percent", fallback: #"This is a %% character."#)
+    internal static let percent = L10n.tr("Localizable", "percent", fallback: ###"This is a %% character."###)
     /// Hello, my name is "%@" and I'm %d
     internal static func `private`(_ p1: Any, _ p2: Int) -> String {
-      return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: #"Hello, my name is "%@" and I'm %d"#)
+      return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: ###"Hello, my name is "%@" and I'm %d"###)
     }
     /// Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'
     internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
-      return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: #"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"#)
+      return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: ###"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"###)
     }
     internal enum Apples {
       /// You have %d apples
       internal static func count(_ p1: Int) -> String {
-        return L10n.tr("Localizable", "apples.count", p1, fallback: #"You have %d apples"#)
+        return L10n.tr("Localizable", "apples.count", p1, fallback: ###"You have %d apples"###)
       }
     }
     internal enum Bananas {
       /// A comment with no space above it
       internal static func owner(_ p1: Int, _ p2: Any) -> String {
-        return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: #"Those %d bananas belong to %@."#)
+        return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: ###"Those %d bananas belong to %@."###)
       }
     }
     internal enum Key1 {
       /// Same as "key1" = "value1"; but in the context of user not logged in
-      internal static let anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: #"value2"#)
+      internal static let anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: ###"value2"###)
     }
     internal enum Many {
       internal enum Placeholders {
         /// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
         internal static func base(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-          return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+          return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
         }
         /// %@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
         internal static func zero(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-          return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+          return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
         }
       }
     }
     internal enum Settings {
       internal enum NavigationBar {
         /// Some Reserved Keyword there
-        internal static let `self` = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: #"Some Reserved Keyword there"#)
+        internal static let `self` = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: ###"Some Reserved Keyword there"###)
         internal enum Title {
           internal enum Deeper {
             internal enum Than {
@@ -74,7 +74,7 @@ internal enum L10n {
                         internal enum This {
                           internal enum Is {
                             /// DeepSettings
-                            internal static let deep = L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: #"DeepSettings"#)
+                            internal static let deep = L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: ###"DeepSettings"###)
                           }
                         }
                       }
@@ -86,51 +86,51 @@ internal enum L10n {
           }
           internal enum Even {
             /// Settings
-            internal static let deeper = L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: #"Settings"#)
+            internal static let deeper = L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: ###"Settings"###)
           }
         }
       }
       internal enum UserProfileSection {
         /// Here you can change some user profile settings.
-        internal static let footerText = L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: #"Here you can change some user profile settings."#)
+        internal static let footerText = L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: ###"Here you can change some user profile settings."###)
         /// User Profile Settings
-        internal static let headerTitle = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: #"User Profile Settings"#)
+        internal static let headerTitle = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: ###"User Profile Settings"###)
       }
     }
     internal enum What {
       internal enum Happens {
         /// some comment
-        internal static let here = L10n.tr("Localizable", "what./*happens*/.here", fallback: #"hello world! /* still in string */"#)
+        internal static let here = L10n.tr("Localizable", "what./*happens*/.here", fallback: ###"hello world! /* still in string */"###)
       }
     }
   }
   internal enum LocMultiline {
     /// multi
     /// line
-    internal static let multiline = L10n.tr("LocMultiline", "MULTILINE", fallback: #"multi\nline"#)
+    internal static let multiline = L10n.tr("LocMultiline", "MULTILINE", fallback: ###"multi\nline"###)
     /// test
-    internal static let multiLineKey = L10n.tr("LocMultiline", "multiLine\nKey", fallback: #"test"#)
+    internal static let multiLineKey = L10n.tr("LocMultiline", "multiLine\nKey", fallback: ###"test"###)
     /// A multiline
     ///    comment
-    internal static let multilineComment = L10n.tr("LocMultiline", "multiline-comment", fallback: #"This string should have a multiline comment"#)
+    internal static let multilineComment = L10n.tr("LocMultiline", "multiline-comment", fallback: ###"This string should have a multiline comment"###)
     /// another
     /// multi
     ///     line
-    internal static let multiline2 = L10n.tr("LocMultiline", "MULTILINE2", fallback: #"another\nmulti\n    line"#)
+    internal static let multiline2 = L10n.tr("LocMultiline", "MULTILINE2", fallback: ###"another\nmulti\n    line"###)
     /// single line
-    internal static let singleline = L10n.tr("LocMultiline", "SINGLELINE", fallback: #"single line"#)
+    internal static let singleline = L10n.tr("LocMultiline", "SINGLELINE", fallback: ###"single line"###)
     /// another single line
-    internal static let singleline2 = L10n.tr("LocMultiline", "SINGLELINE2", fallback: #"another single line"#)
+    internal static let singleline2 = L10n.tr("LocMultiline", "SINGLELINE2", fallback: ###"another single line"###)
     internal enum Ending {
       /// Ceci n'est pas une pipe.
-      internal static let with = L10n.tr("LocMultiline", "ending.with.", fallback: #"Ceci n'est pas une pipe."#)
+      internal static let with = L10n.tr("LocMultiline", "ending.with.", fallback: ###"Ceci n'est pas une pipe."###)
     }
     internal enum Some {
       internal enum Dots {
         internal enum And {
           internal enum Empty {
             /// Veni, vidi, vici
-            internal static let components = L10n.tr("LocMultiline", "..some..dots.and..empty..components..", fallback: #"Veni, vidi, vici"#)
+            internal static let components = L10n.tr("LocMultiline", "..some..dots.and..empty..components..", fallback: ###"Veni, vidi, vici"###)
           }
         }
       }

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-advanced.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-advanced.swift
@@ -15,11 +15,11 @@ internal enum L10n {
       internal enum Plurals {
         /// Plural format key: "%@ - %#@d2@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@"
         internal static func base(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Any, _ p9: Int, _ p10: Float) -> String {
-          return L10n.tr("LocPluralAdvanced", "many.placeholders.plurals.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), String(describing: p8), p9, p10, fallback: #"Plural format key: "%@ - %#@d2@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@""#)
+          return L10n.tr("LocPluralAdvanced", "many.placeholders.plurals.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), String(describing: p8), p9, p10, fallback: ###"Plural format key: "%@ - %#@d2@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@""###)
         }
         /// Plural format key: "%@ - %#@d2@ - %0$#@zero@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@"
         internal static func zero(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Any, _ p9: Int, _ p10: Float) -> String {
-          return L10n.tr("LocPluralAdvanced", "many.placeholders.plurals.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), String(describing: p8), p9, p10, fallback: #"Plural format key: "%@ - %#@d2@ - %0$#@zero@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@""#)
+          return L10n.tr("LocPluralAdvanced", "many.placeholders.plurals.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), String(describing: p8), p9, p10, fallback: ###"Plural format key: "%@ - %#@d2@ - %0$#@zero@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@""###)
         }
       }
     }
@@ -28,19 +28,19 @@ internal enum L10n {
     internal enum PlaceholdersAndVariables {
       /// Plural format key: "%1$@ %3$#@has_rating@"
       internal static func positionalstringPositional3int(_ p1: Any, _ p2: Int) -> String {
-        return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.positionalstring-positional3int", String(describing: p1), p2, fallback: #"Plural format key: "%1$@ %3$#@has_rating@""#)
+        return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.positionalstring-positional3int", String(describing: p1), p2, fallback: ###"Plural format key: "%1$@ %3$#@has_rating@""###)
       }
       /// Plural format key: "%@ %#@has_rating@"
       internal static func stringInt(_ p1: Any, _ p2: Int) -> String {
-        return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-int", String(describing: p1), p2, fallback: #"Plural format key: "%@ %#@has_rating@""#)
+        return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-int", String(describing: p1), p2, fallback: ###"Plural format key: "%@ %#@has_rating@""###)
       }
       /// Plural format key: "%@ %2$#@has_rating@"
       internal static func stringPositional2int(_ p1: Any, _ p2: Int) -> String {
-        return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-positional2int", String(describing: p1), p2, fallback: #"Plural format key: "%@ %2$#@has_rating@""#)
+        return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-positional2int", String(describing: p1), p2, fallback: ###"Plural format key: "%@ %2$#@has_rating@""###)
       }
       /// Plural format key: "%@ %3$#@has_rating@"
       internal static func stringPositional3int(_ p1: Any, _ p2: Int) -> String {
-        return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-positional3int", String(describing: p1), p2, fallback: #"Plural format key: "%@ %3$#@has_rating@""#)
+        return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-positional3int", String(describing: p1), p2, fallback: ###"Plural format key: "%@ %3$#@has_rating@""###)
       }
     }
   }
@@ -48,13 +48,13 @@ internal enum L10n {
     internal enum PlaceholdersAndVariables {
       /// Plural format key: "Your %3$@ list contains %1$#@first@ %2$@."
       internal static func intStringString(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
-        return L10n.tr("LocPluralAdvanced", "multiple.placeholders-and-variables.int-string-string", p1, String(describing: p2), String(describing: p3), fallback: #"Plural format key: "Your %3$@ list contains %1$#@first@ %2$@.""#)
+        return L10n.tr("LocPluralAdvanced", "multiple.placeholders-and-variables.int-string-string", p1, String(describing: p2), String(describing: p3), fallback: ###"Plural format key: "Your %3$@ list contains %1$#@first@ %2$@.""###)
       }
     }
     internal enum Variables {
       /// Plural format key: "%#@files@ (%#@bytes@, %#@minutes@)"
       internal static func threeVariablesInFormatkey(_ p1: Int, _ p2: Int, _ p3: Int) -> String {
-        return L10n.tr("LocPluralAdvanced", "multiple.variables.three-variables-in-formatkey", p1, p2, p3, fallback: #"Plural format key: "%#@files@ (%#@bytes@, %#@minutes@)""#)
+        return L10n.tr("LocPluralAdvanced", "multiple.variables.three-variables-in-formatkey", p1, p2, p3, fallback: ###"Plural format key: "%#@files@ (%#@bytes@, %#@minutes@)""###)
       }
     }
   }

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-same-table.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-same-table.swift
@@ -11,42 +11,42 @@ import Foundation
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
 internal enum L10n {
   /// Some alert body there
-  internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: #"Some alert body there"#)
+  internal static let alertMessage = L10n.tr("Localizable", "alert__message", fallback: ###"Some alert body there"###)
   /// Title for an alert
-  internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: #"Title of the alert"#)
-  /// value1
-  internal static let key1 = L10n.tr("Localizable", "key1", fallback: #"value1"#)
+  internal static let alertTitle = L10n.tr("Localizable", "alert__title", fallback: ###"Title of the alert"###)
+  /// value1	value
+  internal static let key1 = L10n.tr("Localizable", "key1", fallback: ###"value1\tvalue"###)
   /// These are %3$@'s %1$d %2$@.
   internal static func objectOwnership(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
-    return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: #"These are %3$@'s %1$d %2$@."#)
+    return L10n.tr("Localizable", "ObjectOwnership", p1, String(describing: p2), String(describing: p3), fallback: ###"These are %3$@'s %1$d %2$@."###)
   }
   /// This is a %% character.
-  internal static let percent = L10n.tr("Localizable", "percent", fallback: #"This is a %% character."#)
+  internal static let percent = L10n.tr("Localizable", "percent", fallback: ###"This is a %% character."###)
   /// Hello, my name is "%@" and I'm %d
   internal static func `private`(_ p1: Any, _ p2: Int) -> String {
-    return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: #"Hello, my name is "%@" and I'm %d"#)
+    return L10n.tr("Localizable", "private", String(describing: p1), p2, fallback: ###"Hello, my name is "%@" and I'm %d"###)
   }
   /// Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'
   internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
-    return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: #"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"#)
+    return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: ###"Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'"###)
   }
   internal enum Apples {
     /// Plural format key: "%#@apples@"
     internal static func count(_ p1: Int) -> String {
-      return L10n.tr("Localizable", "apples.count", p1, fallback: #"Plural format key: "%#@apples@""#)
+      return L10n.tr("Localizable", "apples.count", p1, fallback: ###"Plural format key: "%#@apples@""###)
     }
   }
   internal enum Bananas {
     /// A comment with no space above it
     internal static func owner(_ p1: Int, _ p2: Any) -> String {
-      return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: #"Those %d bananas belong to %@."#)
+      return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: ###"Those %d bananas belong to %@."###)
     }
   }
   internal enum Competition {
     internal enum Event {
       /// Plural format key: "%#@Matches@"
       internal static func numberOfMatches(_ p1: Int) -> String {
-        return L10n.tr("Localizable", "competition.event.number-of-matches", p1, fallback: #"Plural format key: "%#@Matches@""#)
+        return L10n.tr("Localizable", "competition.event.number-of-matches", p1, fallback: ###"Plural format key: "%#@Matches@""###)
       }
     }
   }
@@ -54,30 +54,30 @@ internal enum L10n {
     internal enum Subscription {
       /// Plural format key: "%#@Subscriptions@"
       internal static func count(_ p1: Int) -> String {
-        return L10n.tr("Localizable", "feed.subscription.count", p1, fallback: #"Plural format key: "%#@Subscriptions@""#)
+        return L10n.tr("Localizable", "feed.subscription.count", p1, fallback: ###"Plural format key: "%#@Subscriptions@""###)
       }
     }
   }
   internal enum Key1 {
     /// Same as "key1" = "value1"; but in the context of user not logged in
-    internal static let anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: #"value2"#)
+    internal static let anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: ###"value2"###)
   }
   internal enum Many {
     internal enum Placeholders {
       /// %@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
       internal static func base(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-        return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+        return L10n.tr("Localizable", "many.placeholders.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
       }
       /// %@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d
       internal static func zero(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Float, _ p9: Any, _ p10: Int, _ p11: Float) -> String {
-        return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: #"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"#)
+        return L10n.tr("Localizable", "many.placeholders.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), p8, String(describing: p9), p10, p11, fallback: ###"%@ %d %0$@ %f %5$d %04$f %6$d %007$@ %8$3.2f %11$1.2f %9$@ %10$d"###)
       }
     }
   }
   internal enum Settings {
     internal enum NavigationBar {
       /// Some Reserved Keyword there
-      internal static let `self` = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: #"Some Reserved Keyword there"#)
+      internal static let `self` = L10n.tr("Localizable", "settings.navigation-bar.self", fallback: ###"Some Reserved Keyword there"###)
       internal enum Title {
         internal enum Deeper {
           internal enum Than {
@@ -89,7 +89,7 @@ internal enum L10n {
                       internal enum This {
                         internal enum Is {
                           /// DeepSettings
-                          internal static let deep = L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: #"DeepSettings"#)
+                          internal static let deep = L10n.tr("Localizable", "settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", fallback: ###"DeepSettings"###)
                         }
                       }
                     }
@@ -101,21 +101,21 @@ internal enum L10n {
         }
         internal enum Even {
           /// Settings
-          internal static let deeper = L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: #"Settings"#)
+          internal static let deeper = L10n.tr("Localizable", "settings.navigation-bar.title.even.deeper", fallback: ###"Settings"###)
         }
       }
     }
     internal enum UserProfileSection {
       /// Here you can change some user profile settings.
-      internal static let footerText = L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: #"Here you can change some user profile settings."#)
+      internal static let footerText = L10n.tr("Localizable", "settings.user__profile_section.footer_text", fallback: ###"Here you can change some user profile settings."###)
       /// User Profile Settings
-      internal static let headerTitle = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: #"User Profile Settings"#)
+      internal static let headerTitle = L10n.tr("Localizable", "settings.user__profile_section.HEADER_TITLE", fallback: ###"User Profile Settings"###)
     }
   }
   internal enum What {
     internal enum Happens {
       /// some comment
-      internal static let here = L10n.tr("Localizable", "what./*happens*/.here", fallback: #"hello world! /* still in string */"#)
+      internal static let here = L10n.tr("Localizable", "what./*happens*/.here", fallback: ###"hello world! /* still in string */"###)
     }
   }
 }

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-unsupported.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-unsupported.swift
@@ -14,7 +14,7 @@ internal enum L10n {
     internal enum PlaceholdersInVariableRule {
       /// Plural format key: "%#@elements@"
       internal static func stringInt(_ p1: Int) -> String {
-        return L10n.tr("LocPluralUnsupported", "unsupported-use.placeholders-in-variable-rule.string-int", p1, fallback: #"Plural format key: "%#@elements@""#)
+        return L10n.tr("LocPluralUnsupported", "unsupported-use.placeholders-in-variable-rule.string-int", p1, fallback: ###"Plural format key: "%#@elements@""###)
       }
     }
   }

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals.swift
@@ -13,14 +13,14 @@ internal enum L10n {
   internal enum Apples {
     /// Plural format key: "%#@apples@"
     internal static func count(_ p1: Int) -> String {
-      return L10n.tr("Localizable", "apples.count", p1, fallback: #"Plural format key: "%#@apples@""#)
+      return L10n.tr("Localizable", "apples.count", p1, fallback: ###"Plural format key: "%#@apples@""###)
     }
   }
   internal enum Competition {
     internal enum Event {
       /// Plural format key: "%#@Matches@"
       internal static func numberOfMatches(_ p1: Int) -> String {
-        return L10n.tr("Localizable", "competition.event.number-of-matches", p1, fallback: #"Plural format key: "%#@Matches@""#)
+        return L10n.tr("Localizable", "competition.event.number-of-matches", p1, fallback: ###"Plural format key: "%#@Matches@""###)
       }
     }
   }
@@ -28,7 +28,7 @@ internal enum L10n {
     internal enum Subscription {
       /// Plural format key: "%#@Subscriptions@"
       internal static func count(_ p1: Int) -> String {
-        return L10n.tr("Localizable", "feed.subscription.count", p1, fallback: #"Plural format key: "%#@Subscriptions@""#)
+        return L10n.tr("Localizable", "feed.subscription.count", p1, fallback: ###"Plural format key: "%#@Subscriptions@""###)
       }
     }
   }

--- a/Sources/TestUtils/Fixtures/Resources/Strings/Localizable.strings
+++ b/Sources/TestUtils/Fixtures/Resources/Strings/Localizable.strings
@@ -5,7 +5,7 @@
 "percent" = "This is a %% character.";
 "private" = "Hello, my name is \"%@\" and I'm %d";
 
-"key1" = "value1";
+"key1" = "value1\tvalue";
 /* Same as "key1" = "value1"; but in the context of user not logged in */
 "key1.anonymous" = "value2";
 

--- a/Sources/TestUtils/Fixtures/StencilContexts/Strings/custom-separator.yaml
+++ b/Sources/TestUtils/Fixtures/StencilContexts/Strings/custom-separator.yaml
@@ -33,7 +33,7 @@ tables:
       - "String"
     - key: "key1"
       name: "key1"
-      translation: "value1"
+      translation: "value1\tvalue"
     - comment: "Same as \"key1\" = \"value1\"; but in the context of user not logged
         in"
       key: "key1.anonymous"

--- a/Sources/TestUtils/Fixtures/StencilContexts/Strings/localizable.yaml
+++ b/Sources/TestUtils/Fixtures/StencilContexts/Strings/localizable.yaml
@@ -121,7 +121,7 @@ tables:
       translation: "Title of the alert"
     - key: "key1"
       name: "key1"
-      translation: "value1"
+      translation: "value1\tvalue"
     - key: "ObjectOwnership"
       name: "ObjectOwnership"
       translation: "These are %3$@'s %1$d %2$@."

--- a/Sources/TestUtils/Fixtures/StencilContexts/Strings/multiple.yaml
+++ b/Sources/TestUtils/Fixtures/StencilContexts/Strings/multiple.yaml
@@ -121,7 +121,7 @@ tables:
       translation: "Title of the alert"
     - key: "key1"
       name: "key1"
-      translation: "value1"
+      translation: "value1\tvalue"
     - key: "ObjectOwnership"
       name: "ObjectOwnership"
       translation: "These are %3$@'s %1$d %2$@."

--- a/Sources/TestUtils/Fixtures/StencilContexts/Strings/plurals-same-table.yaml
+++ b/Sources/TestUtils/Fixtures/StencilContexts/Strings/plurals-same-table.yaml
@@ -139,7 +139,7 @@ tables:
       translation: "Title of the alert"
     - key: "key1"
       name: "key1"
-      translation: "value1"
+      translation: "value1\tvalue"
     - key: "ObjectOwnership"
       name: "ObjectOwnership"
       translation: "These are %3$@'s %1$d %2$@."


### PR DESCRIPTION
- If a string contains the sequence `"#`, it'll break our use of raw strings
- If a translation contains a tab `\t`, Xcode will complain that the source code contains invalid characters