### PR TITLE
Strings: fix objc-m template (varargs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ _None_
   [David Jennes](https://github.com/djbe)
   [#987](https://github.com/SwiftGen/SwiftGen/issues/987)
   [#989](https://github.com/SwiftGen/SwiftGen/pull/989)
+* Strings: fix the Objective-C template.  
+  [David Jennes](https://github.com/djbe)
+  [#990](https://github.com/SwiftGen/SwiftGen/issues/990)
+  [#991](https://github.com/SwiftGen/SwiftGen/pull/991)
 
 ## 6.6.1
 

--- a/Sources/SwiftGenCLI/templates/strings/objc-m.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/objc-m.stencil
@@ -20,7 +20,7 @@ static NSString* tr(NSString *tableName, NSString *key, NSString *value, ...) {
     NSLocale *locale = [NSLocale currentLocale];
 
     va_list args;
-    va_start(args, key);
+    va_start(args, value);
     NSString *result = [[NSString alloc] initWithFormat:format locale:locale arguments:args];
     va_end(args);
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/localizable-customBundle.m
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/localizable-customBundle.m
@@ -11,7 +11,7 @@ static NSString* tr(NSString *tableName, NSString *key, NSString *value, ...) {
     NSLocale *locale = [NSLocale currentLocale];
 
     va_list args;
-    va_start(args, key);
+    va_start(args, value);
     NSString *result = [[NSString alloc] initWithFormat:format locale:locale arguments:args];
     va_end(args);
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/localizable-headerName.m
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/localizable-headerName.m
@@ -17,7 +17,7 @@ static NSString* tr(NSString *tableName, NSString *key, NSString *value, ...) {
     NSLocale *locale = [NSLocale currentLocale];
 
     va_list args;
-    va_start(args, key);
+    va_start(args, value);
     NSString *result = [[NSString alloc] initWithFormat:format locale:locale arguments:args];
     va_end(args);
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/localizable-noComments.m
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/localizable-noComments.m
@@ -17,7 +17,7 @@ static NSString* tr(NSString *tableName, NSString *key, NSString *value, ...) {
     NSLocale *locale = [NSLocale currentLocale];
 
     va_list args;
-    va_start(args, key);
+    va_start(args, value);
     NSString *result = [[NSString alloc] initWithFormat:format locale:locale arguments:args];
     va_end(args);
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/localizable.m
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/localizable.m
@@ -17,7 +17,7 @@ static NSString* tr(NSString *tableName, NSString *key, NSString *value, ...) {
     NSLocale *locale = [NSLocale currentLocale];
 
     va_list args;
-    va_start(args, key);
+    va_start(args, value);
     NSString *result = [[NSString alloc] initWithFormat:format locale:locale arguments:args];
     va_end(args);
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/multiple.m
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/multiple.m
@@ -17,7 +17,7 @@ static NSString* tr(NSString *tableName, NSString *key, NSString *value, ...) {
     NSLocale *locale = [NSLocale currentLocale];
 
     va_list args;
-    va_start(args, key);
+    va_start(args, value);
     NSString *result = [[NSString alloc] initWithFormat:format locale:locale arguments:args];
     va_end(args);
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/plurals-advanced.m
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/plurals-advanced.m
@@ -17,7 +17,7 @@ static NSString* tr(NSString *tableName, NSString *key, NSString *value, ...) {
     NSLocale *locale = [NSLocale currentLocale];
 
     va_list args;
-    va_start(args, key);
+    va_start(args, value);
     NSString *result = [[NSString alloc] initWithFormat:format locale:locale arguments:args];
     va_end(args);
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/plurals-same-table.m
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/plurals-same-table.m
@@ -17,7 +17,7 @@ static NSString* tr(NSString *tableName, NSString *key, NSString *value, ...) {
     NSLocale *locale = [NSLocale currentLocale];
 
     va_list args;
-    va_start(args, key);
+    va_start(args, value);
     NSString *result = [[NSString alloc] initWithFormat:format locale:locale arguments:args];
     va_end(args);
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/plurals-unsupported.m
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/plurals-unsupported.m
@@ -17,7 +17,7 @@ static NSString* tr(NSString *tableName, NSString *key, NSString *value, ...) {
     NSLocale *locale = [NSLocale currentLocale];
 
     va_list args;
-    va_start(args, key);
+    va_start(args, value);
     NSString *result = [[NSString alloc] initWithFormat:format locale:locale arguments:args];
     va_end(args);
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/plurals.m
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/plurals.m
@@ -17,7 +17,7 @@ static NSString* tr(NSString *tableName, NSString *key, NSString *value, ...) {
     NSLocale *locale = [NSLocale currentLocale];
 
     va_list args;
-    va_start(args, key);
+    va_start(args, value);
     NSString *result = [[NSString alloc] initWithFormat:format locale:locale arguments:args];
     va_end(args);
 


### PR DESCRIPTION
We broke varargs in the obj-c template in the 6.6 release, when we added the fallback value to translations.