### PR TITLE
Bumped Yams to 5.0.1 #trivial

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -18,14 +18,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - 
-        name: Cache SPM
-        uses: actions/cache@v3
-        with:
-          path: .build
-          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
-          restore-keys: |
-            ${{ runner.os }}-spm-
+      # Note: there's no SPM cache step here, to ensure "clean" compilation works
       -
         name: Verify installation
         run: bundle exec rake cli:install[./standalone,./standalone/frameworks,./standalone/stencils]

--- a/Package.resolved
+++ b/Package.resolved
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SwiftGen/StencilSwiftKit.git",
       "state" : {
-        "revision" : "631c85b83b89e9b229b2a7d5affe3b24f4a9701e",
-        "version" : "2.10.0"
+        "revision" : "20e2de5322c83df005939d9d9300fab130b49f97",
+        "version" : "2.10.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams.git",
       "state" : {
-        "revision" : "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
-        "version" : "4.0.6"
+        "revision" : "01835dc202670b5bb90d07f3eae41867e9ed29f6",
+        "version" : "5.0.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -12,13 +12,13 @@ let package = Package(
     .library(name: "SwiftGenKit", targets: ["SwiftGenKit"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.0.0"),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.1.3"),
     .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.1"),
     .package(url: "https://github.com/kylef/PathKit.git", from: "1.0.1"),
     .package(url: "https://github.com/krzysztofzablocki/Difference.git", branch: "master"),
-    .package(url: "https://github.com/stencilproject/Stencil.git", from: "0.15.0"),
+    .package(url: "https://github.com/stencilproject/Stencil.git", from: "0.15.1"),
     .package(url: "https://github.com/shibapm/Komondor.git", exact: "1.1.3"),
-    .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", from: "2.10.0"),
+    .package(url: "https://github.com/SwiftGen/StencilSwiftKit.git", from: "2.10.1"),
     .package(url: "https://github.com/tid-kijyun/Kanna.git", from: "5.2.7")
   ],
   targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -39,6 +39,7 @@ let package = Package(
     .target(name: "SwiftGenKit", dependencies: [
       "Kanna",
       "PathKit",
+      "Stencil",
       "Yams"
     ]),
     .testTarget(name: "SwiftGenKitTests", dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.0.0"),
-    .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.6"),
+    .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.1"),
     .package(url: "https://github.com/kylef/PathKit.git", from: "1.0.1"),
     .package(url: "https://github.com/krzysztofzablocki/Difference.git", branch: "master"),
     .package(url: "https://github.com/stencilproject/Stencil.git", from: "0.15.0"),


### PR DESCRIPTION
Just wondering if we could bump Yams to `5.0.1`? If not, could we update the range to `"4.0.6"..<"6.0.0"`?

The only change in Yams 5.x is that they raised the minimum Swift version.