### PR TITLE
Added support for `--quiet` and `--verbose` flags to `swiftgen run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ _None_
 
 ### New Features
 
-_None_
+* CLI: Added support for `--quiet` and `--verbose` flags to `swiftgen run`.  
+  [John Szumski](https://github.com/jszumski)
+  [#1007](https://github.com/SwiftGen/SwiftGen/issues/1007)
+  [#1008](https://github.com/SwiftGen/SwiftGen/pull/1008)
 
 ### Bug Fixes
 

--- a/Sources/SwiftGen/Commands/Run.swift
+++ b/Sources/SwiftGen/Commands/Run.swift
@@ -64,7 +64,12 @@ extension Commands.Run {
     @Argument(help: .init(Parser.info.pathDescription, valueName: "path"))
     var paths: [Path]
 
+    @Flag
+    var logLevel: CommandLogLevel = .default
+
     mutating func run() throws {
+      commandLogLevel = logLevel
+
       let parserOptions = try Parameters.parse(items: options)
       let parser = try Parser(options: parserOptions) { msg, _, _ in
         logMessage(.warning, msg)


### PR DESCRIPTION
Fixes https://github.com/SwiftGen/SwiftGen/issues/1007 by extending https://github.com/SwiftGen/SwiftGen/pull/846 to support using `--quiet` and `--verbose` with the `run` command.  If both flags are provided, quiet will override verbose.