### PR TITLE
Made L10n.tr not use bare strings as formats.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ### Breaking Changes
 
-_None_
+* Strings: due to the bugfix for bare strings, for structured-swift5, `%%` in bare strings will be rendered as-such, instead of single `%`.  
+  [Grigory Entin](https://github.com/grigorye)
+  [#1038](https://github.com/SwiftGen/SwiftGen/pull/1038)
 
 ### New Features
 

--- a/Sources/SwiftGenCLI/templates/strings/structured-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/structured-swift5.stencil
@@ -83,6 +83,13 @@ extension {{enumName}} {
     {% endif %}
     return String(format: format, locale: Locale.current, arguments: args)
   }
+  private static func tr(_ table: String, _ key: String, fallback value: String) -> String {
+    {% if param.lookupFunction %}
+    return {{ param.lookupFunction }}(key, table, value)
+    {% else %}
+    return {{param.bundle|default:"BundleToken.bundle"}}.localizedString(forKey: key, value: value, table: table)
+    {% endif %}
+  }
 }
 {% if not param.bundle and not param.lookupFunction %}
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-customBundle.swift
@@ -113,4 +113,7 @@ extension L10n {
     let format = ResourcesBundle.bundle.localizedString(forKey: key, value: value, table: table)
     return String(format: format, locale: Locale.current, arguments: args)
   }
+  private static func tr(_ table: String, _ key: String, fallback value: String) -> String {
+    return ResourcesBundle.bundle.localizedString(forKey: key, value: value, table: table)
+  }
 }

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-customName.swift
@@ -113,6 +113,9 @@ extension XCTLoc {
     let format = BundleToken.bundle.localizedString(forKey: key, value: value, table: table)
     return String(format: format, locale: Locale.current, arguments: args)
   }
+  private static func tr(_ table: String, _ key: String, fallback value: String) -> String {
+    return BundleToken.bundle.localizedString(forKey: key, value: value, table: table)
+  }
 }
 
 // swiftlint:disable convenience_type

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-forceFileNameEnum.swift
@@ -115,6 +115,9 @@ extension L10n {
     let format = BundleToken.bundle.localizedString(forKey: key, value: value, table: table)
     return String(format: format, locale: Locale.current, arguments: args)
   }
+  private static func tr(_ table: String, _ key: String, fallback value: String) -> String {
+    return BundleToken.bundle.localizedString(forKey: key, value: value, table: table)
+  }
 }
 
 // swiftlint:disable convenience_type

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-lookupFunction.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-lookupFunction.swift
@@ -113,4 +113,7 @@ extension L10n {
     let format = XCTLocFunc(forKey:table:fallback:)(key, table, value)
     return String(format: format, locale: Locale.current, arguments: args)
   }
+  private static func tr(_ table: String, _ key: String, fallback value: String) -> String {
+    return XCTLocFunc(forKey:table:fallback:)(key, table, value)
+  }
 }

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-noComments.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-noComments.swift
@@ -95,6 +95,9 @@ extension L10n {
     let format = BundleToken.bundle.localizedString(forKey: key, value: value, table: table)
     return String(format: format, locale: Locale.current, arguments: args)
   }
+  private static func tr(_ table: String, _ key: String, fallback value: String) -> String {
+    return BundleToken.bundle.localizedString(forKey: key, value: value, table: table)
+  }
 }
 
 // swiftlint:disable convenience_type

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-publicAccess.swift
@@ -113,6 +113,9 @@ extension L10n {
     let format = BundleToken.bundle.localizedString(forKey: key, value: value, table: table)
     return String(format: format, locale: Locale.current, arguments: args)
   }
+  private static func tr(_ table: String, _ key: String, fallback value: String) -> String {
+    return BundleToken.bundle.localizedString(forKey: key, value: value, table: table)
+  }
 }
 
 // swiftlint:disable convenience_type

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable.swift
@@ -113,6 +113,9 @@ extension L10n {
     let format = BundleToken.bundle.localizedString(forKey: key, value: value, table: table)
     return String(format: format, locale: Locale.current, arguments: args)
   }
+  private static func tr(_ table: String, _ key: String, fallback value: String) -> String {
+    return BundleToken.bundle.localizedString(forKey: key, value: value, table: table)
+  }
 }
 
 // swiftlint:disable convenience_type

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/multiple.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/multiple.swift
@@ -147,6 +147,9 @@ extension L10n {
     let format = BundleToken.bundle.localizedString(forKey: key, value: value, table: table)
     return String(format: format, locale: Locale.current, arguments: args)
   }
+  private static func tr(_ table: String, _ key: String, fallback value: String) -> String {
+    return BundleToken.bundle.localizedString(forKey: key, value: value, table: table)
+  }
 }
 
 // swiftlint:disable convenience_type

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-advanced.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-advanced.swift
@@ -69,6 +69,9 @@ extension L10n {
     let format = BundleToken.bundle.localizedString(forKey: key, value: value, table: table)
     return String(format: format, locale: Locale.current, arguments: args)
   }
+  private static func tr(_ table: String, _ key: String, fallback value: String) -> String {
+    return BundleToken.bundle.localizedString(forKey: key, value: value, table: table)
+  }
 }
 
 // swiftlint:disable convenience_type

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-same-table.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-same-table.swift
@@ -129,6 +129,9 @@ extension L10n {
     let format = BundleToken.bundle.localizedString(forKey: key, value: value, table: table)
     return String(format: format, locale: Locale.current, arguments: args)
   }
+  private static func tr(_ table: String, _ key: String, fallback value: String) -> String {
+    return BundleToken.bundle.localizedString(forKey: key, value: value, table: table)
+  }
 }
 
 // swiftlint:disable convenience_type

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-unsupported.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-unsupported.swift
@@ -29,6 +29,9 @@ extension L10n {
     let format = BundleToken.bundle.localizedString(forKey: key, value: value, table: table)
     return String(format: format, locale: Locale.current, arguments: args)
   }
+  private static func tr(_ table: String, _ key: String, fallback value: String) -> String {
+    return BundleToken.bundle.localizedString(forKey: key, value: value, table: table)
+  }
 }
 
 // swiftlint:disable convenience_type

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals.swift
@@ -43,6 +43,9 @@ extension L10n {
     let format = BundleToken.bundle.localizedString(forKey: key, value: value, table: table)
     return String(format: format, locale: Locale.current, arguments: args)
   }
+  private static func tr(_ table: String, _ key: String, fallback value: String) -> String {
+    return BundleToken.bundle.localizedString(forKey: key, value: value, table: table)
+  }
 }
 
 // swiftlint:disable convenience_type


### PR DESCRIPTION
* [x] I've started my branch from the `develop` branch (gitflow)
  * [x] And I've selected `develop` as the "base" branch for this Pull Request I'm about to create
* [x] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself  
      _(or added `#trivial` to the PR title if I think it doesn't warrant a mention in the CHANGELOG)_
  * [x] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
  * [x] Add a period and 2 spaces at the end of your short entry description
  * [x] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

This addresses #1039, by introducing a specialized variant of `tr` for argument-less calls used with wrappers generated for bare strings. Beware that this is a breaking change for the cases where `%%` had to be used before in bare strings.