### PR TITLE
Fix warnings in templates caused by SwiftLint 0.51.0

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,9 +1,8 @@
-swiftlint_version: 0.48.0
+swiftlint_version: 0.51.0
 
 opt_in_rules:
  - accessibility_label_for_image
  - anonymous_argument_in_multiline_closure
- - anyobject_protocol
  - array_init
  - attributes
  - balanced_xctest_lifecycle
@@ -98,6 +97,10 @@ excluded:
   - Sources/TestUtils/Fixtures
 
 # Rules customization
+attributes:
+  always_on_line_above:
+    ["@Flag", "@OptionGroup"]
+
 conditional_returns_on_newline:
   if_only: true
 
@@ -117,6 +120,9 @@ file_header:
 
 indentation_width:
   indentation_width: 2
+
+large_tuple:
+  warning: 3
 
 line_length:
   warning: 120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ _None_
   [Liquidsoul](https://github.com/liquidsoul)
   [#1022](https://github.com/SwiftGen/SwiftGen/issues/1022)
   [#1107](https://github.com/SwiftGen/SwiftGen/pull/1107)
+* Templates: added `// swiftlint:enable all` to the bottom of templates to fix [warning](https://github.com/realm/SwiftLint/pull/4731) introduced by SwiftLint [0.51.0](https://github.com/realm/SwiftLint/releases/tag/0.51.0).  
+ [Zev Eisenberg](https://github.com/ZevEisenberg)
+ [#1054](https://github.com/SwiftGen/pull/1054)
 
 ### Internal Changes
 

--- a/Sources/SwiftGenCLI/templates/colors/literals-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/colors/literals-swift4.stencil
@@ -45,3 +45,4 @@
 {% else %}
 // No color found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/colors/literals-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/colors/literals-swift5.stencil
@@ -45,3 +45,4 @@
 {% else %}
 // No color found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/colors/swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/colors/swift4.stencil
@@ -80,3 +80,4 @@ private struct RGBAComponents {
 {% else %}
 // No color found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/colors/swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/colors/swift5.stencil
@@ -80,3 +80,4 @@ private struct RGBAComponents {
 {% else %}
 // No color found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/coredata/swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/coredata/swift4.stencil
@@ -229,3 +229,4 @@ extension {{ entityClassName }} {
 {% endfor %}
 {% endfor %}
 // swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/coredata/swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/coredata/swift5.stencil
@@ -229,3 +229,4 @@ extension {{ entityClassName }} {
 {% endfor %}
 {% endfor %}
 // swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/files/flat-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/files/flat-swift4.stencil
@@ -101,3 +101,4 @@ private final class BundleToken {
 {% else %}
 // No files found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/files/flat-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/files/flat-swift5.stencil
@@ -101,3 +101,4 @@ private final class BundleToken {
 {% else %}
 // No files found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/files/structured-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/files/structured-swift4.stencil
@@ -105,3 +105,4 @@ private final class BundleToken {
 {% else %}
 // No files found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/files/structured-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/files/structured-swift5.stencil
@@ -105,3 +105,4 @@ private final class BundleToken {
 {% else %}
 // No files found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/fonts/swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/fonts/swift4.stencil
@@ -108,3 +108,4 @@ private final class BundleToken {
 {% else %}
 // No fonts found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/fonts/swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/fonts/swift5.stencil
@@ -160,3 +160,4 @@ private final class BundleToken {
 {% else %}
 // No fonts found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/ib/scenes-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/ib/scenes-swift4.stencil
@@ -157,3 +157,4 @@ private final class BundleToken {
 {% else %}
 // No storyboard found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/ib/scenes-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/ib/scenes-swift5.stencil
@@ -157,3 +157,4 @@ private final class BundleToken {
 {% else %}
 // No storyboard found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/ib/segues-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/ib/segues-swift4.stencil
@@ -58,3 +58,4 @@ import {{module}}
 {% else %}
 // No storyboard found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/ib/segues-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/ib/segues-swift5.stencil
@@ -58,3 +58,4 @@ import {{module}}
 {% else %}
 // No storyboard found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/json/inline-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/json/inline-swift4.stencil
@@ -80,3 +80,4 @@ import Foundation
 {% else %}
 // No files found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/json/inline-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/json/inline-swift5.stencil
@@ -80,3 +80,4 @@ import Foundation
 {% else %}
 // No files found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/json/runtime-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/json/runtime-swift4.stencil
@@ -109,3 +109,4 @@ private final class BundleToken {
 {% else %}
 // No files found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/json/runtime-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/json/runtime-swift5.stencil
@@ -109,3 +109,4 @@ private final class BundleToken {
 {% else %}
 // No files found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/plist/inline-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/plist/inline-swift4.stencil
@@ -80,3 +80,4 @@ import Foundation
 {% else %}
 // No files found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/plist/inline-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/plist/inline-swift5.stencil
@@ -80,3 +80,4 @@ import Foundation
 {% else %}
 // No files found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/plist/runtime-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/plist/runtime-swift4.stencil
@@ -114,3 +114,4 @@ private final class BundleToken {
 {% else %}
 // No files found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/plist/runtime-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/plist/runtime-swift5.stencil
@@ -114,3 +114,4 @@ private final class BundleToken {
 {% else %}
 // No files found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/strings/flat-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/flat-swift4.stencil
@@ -97,3 +97,4 @@ private final class BundleToken {
 {% else %}
 // No string found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/strings/flat-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/flat-swift5.stencil
@@ -97,3 +97,4 @@ private final class BundleToken {
 {% else %}
 // No string found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/strings/structured-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/structured-swift4.stencil
@@ -101,3 +101,4 @@ private final class BundleToken {
 {% else %}
 // No string found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/strings/structured-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/structured-swift5.stencil
@@ -101,3 +101,4 @@ private final class BundleToken {
 {% else %}
 // No string found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/xcassets/swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/xcassets/swift4.stencil
@@ -353,3 +353,4 @@ private final class BundleToken {
 {% else %}
 // No assets found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/xcassets/swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/xcassets/swift5.stencil
@@ -435,3 +435,4 @@ private final class BundleToken {
 {% else %}
 // No assets found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/yaml/inline-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/yaml/inline-swift4.stencil
@@ -90,3 +90,4 @@ import Foundation
 {% else %}
 // No files found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/yaml/inline-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/yaml/inline-swift5.stencil
@@ -90,3 +90,4 @@ import Foundation
 {% else %}
 // No files found
 {% endif %}
+// swiftlint:enable all

--- a/Sources/SwiftGenKit/Parsers/AnyCodable.swift
+++ b/Sources/SwiftGenKit/Parsers/AnyCodable.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-// swiftlint:disable cyclomatic_complexity function_body_length
+// swiftlint:disable cyclomatic_complexity
 public struct AnyCodable: Codable {
   public let value: Any?
 
@@ -114,7 +114,7 @@ public struct AnyCodable: Codable {
     }
   }
 }
-// swiftlint:enable cyclomatic_complexity function_body_length
+// swiftlint:enable cyclomatic_complexity
 
 extension KeyedDecodingContainer {
   public func decode(_ type: [String: Any].Type, forKey key: K) throws -> [String: Any] {

--- a/Sources/SwiftGenKit/Parsers/Colors/ColorsParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Colors/ColorsParser.swift
@@ -74,7 +74,7 @@ public enum Colors {
     }
 
     public static var defaultFilter: String {
-      let extensions = Parser.subParsers.flatMap { $0.extensions }.sorted()
+      let extensions = Self.subParsers.flatMap { $0.extensions }.sorted()
       return filterRegex(forExtensions: extensions)
     }
 

--- a/Sources/SwiftGenKit/Parsers/Filter.swift
+++ b/Sources/SwiftGenKit/Parsers/Filter.swift
@@ -27,17 +27,17 @@ public struct Filter {
     }
 
     /// Equivalent of Path.DirectoryEnumerationOptions.skipsSubdirectoryDescendants
-    public static let skipsSubdirectoryDescendants = Options(rawValue: 1 << 0)
+    public static let skipsSubdirectoryDescendants = Self(rawValue: 1 << 0)
     /// Equivalent of Path.DirectoryEnumerationOptions.skipsPackageDescendants
-    public static let skipsPackageDescendants = Options(rawValue: 1 << 1)
+    public static let skipsPackageDescendants = Self(rawValue: 1 << 1)
     /// Equivalent of Path.DirectoryEnumerationOptions.skipsHiddenFiles
-    public static let skipsHiddenFiles = Options(rawValue: 1 << 2)
+    public static let skipsHiddenFiles = Self(rawValue: 1 << 2)
     /// Ignore directories
-    public static let skipsDirectories = Options(rawValue: 1 << 3)
+    public static let skipsDirectories = Self(rawValue: 1 << 3)
     /// Ignore files
-    public static let skipsFiles = Options(rawValue: 1 << 4)
+    public static let skipsFiles = Self(rawValue: 1 << 4)
 
-    public static let `default`: Options = [.skipsDirectories, .skipsHiddenFiles, .skipsPackageDescendants]
+    public static let `default`: Self = [.skipsDirectories, .skipsHiddenFiles, .skipsPackageDescendants]
 
     fileprivate var directoryEnumerationOptions: Path.DirectoryEnumerationOptions {
       Path.DirectoryEnumerationOptions(

--- a/Sources/SwiftGenKit/Parsers/Strings/StringsDictEntry.swift
+++ b/Sources/SwiftGenKit/Parsers/Strings/StringsDictEntry.swift
@@ -14,11 +14,13 @@ enum StringsDict {
 }
 
 extension StringsDict {
+  // swiftlint:disable line_length
   /// Plural entries are used to define language plural rules.
   ///
   /// Reference: https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/StringsdictFileFormat/StringsdictFileFormat.html
-  // swiftlint:disable:previous line_length
   struct PluralEntry: Codable {
+    // swiftlint:enable line_length
+
     /// A format string that contains variables.
     /// Each variable is preceded by the %#@ characters and followed by the @ character.
     let formatKey: String
@@ -90,8 +92,8 @@ extension StringsDict: Decodable {
     }
 
     // fixed keys
-    static let formatKey = CodingKeys(key: "NSStringLocalizedFormatKey")
-    static let variableWidthRules = CodingKeys(key: "NSStringVariableWidthRuleType")
+    static let formatKey = Self(key: "NSStringLocalizedFormatKey")
+    static let variableWidthRules = Self(key: "NSStringVariableWidthRuleType")
   }
 
   init(from coder: Decoder) throws {

--- a/Sources/SwiftGenKit/Parsers/Strings/StringsParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Strings/StringsParser.swift
@@ -77,7 +77,7 @@ public enum Strings {
 
     public static let allOptions: ParserOptionList = [Option.separator]
     public static var defaultFilter: String {
-      let extensions = Parser.subParsers.flatMap { $0.extensions }.sorted()
+      let extensions = Self.subParsers.flatMap { $0.extensions }.sorted()
       return filterRegex(forExtensions: extensions)
     }
 

--- a/Sources/TestUtils/Fixtures/Generated/Colors/literals-swift4/defaults-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Colors/literals-swift4/defaults-customName.swift
@@ -27,3 +27,4 @@ internal extension UIColor {
   static let themeCyan = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
 }
 // swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Colors/literals-swift4/defaults-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Colors/literals-swift4/defaults-forceFileNameEnum.swift
@@ -30,3 +30,4 @@ internal extension ColorName {
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Colors/literals-swift4/defaults-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Colors/literals-swift4/defaults-publicAccess.swift
@@ -28,3 +28,4 @@ public extension ColorName {
   static let themeCyan = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
 }
 // swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Colors/literals-swift4/defaults.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Colors/literals-swift4/defaults.swift
@@ -28,3 +28,4 @@ internal extension ColorName {
   static let themeCyan = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
 }
 // swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Colors/literals-swift4/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Colors/literals-swift4/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No color found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Colors/literals-swift4/multiple.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Colors/literals-swift4/multiple.swift
@@ -46,3 +46,4 @@ internal extension ColorName {
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Colors/literals-swift5/defaults-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Colors/literals-swift5/defaults-customName.swift
@@ -27,3 +27,4 @@ internal extension UIColor {
   static let themeCyan = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
 }
 // swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Colors/literals-swift5/defaults-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Colors/literals-swift5/defaults-forceFileNameEnum.swift
@@ -30,3 +30,4 @@ internal extension ColorName {
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Colors/literals-swift5/defaults-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Colors/literals-swift5/defaults-publicAccess.swift
@@ -28,3 +28,4 @@ public extension ColorName {
   static let themeCyan = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
 }
 // swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Colors/literals-swift5/defaults.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Colors/literals-swift5/defaults.swift
@@ -28,3 +28,4 @@ internal extension ColorName {
   static let themeCyan = #colorLiteral(red: 1.0, green: 0.4, blue: 0.8, alpha: 1.0)
 }
 // swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Colors/literals-swift5/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Colors/literals-swift5/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No color found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Colors/literals-swift5/multiple.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Colors/literals-swift5/multiple.swift
@@ -46,3 +46,4 @@ internal extension ColorName {
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Colors/swift4/defaults-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Colors/swift4/defaults-customName.swift
@@ -71,3 +71,4 @@ internal extension XCTColor {
     self.init(rgbaValue: color.rgbaValue)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Colors/swift4/defaults-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Colors/swift4/defaults-forceFileNameEnum.swift
@@ -73,3 +73,4 @@ internal extension Color {
     self.init(rgbaValue: color.rgbaValue)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Colors/swift4/defaults-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Colors/swift4/defaults-publicAccess.swift
@@ -71,3 +71,4 @@ public extension Color {
     self.init(rgbaValue: color.rgbaValue)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Colors/swift4/defaults.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Colors/swift4/defaults.swift
@@ -71,3 +71,4 @@ internal extension Color {
     self.init(rgbaValue: color.rgbaValue)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Colors/swift4/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Colors/swift4/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No color found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Colors/swift4/multiple.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Colors/swift4/multiple.swift
@@ -96,3 +96,4 @@ internal extension Color {
     self.init(rgbaValue: color.rgbaValue)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Colors/swift5/defaults-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Colors/swift5/defaults-customName.swift
@@ -71,3 +71,4 @@ internal extension XCTColor {
     self.init(rgbaValue: color.rgbaValue)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Colors/swift5/defaults-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Colors/swift5/defaults-forceFileNameEnum.swift
@@ -73,3 +73,4 @@ internal extension Color {
     self.init(rgbaValue: color.rgbaValue)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Colors/swift5/defaults-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Colors/swift5/defaults-publicAccess.swift
@@ -71,3 +71,4 @@ public extension Color {
     self.init(rgbaValue: color.rgbaValue)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Colors/swift5/defaults.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Colors/swift5/defaults.swift
@@ -71,3 +71,4 @@ internal extension Color {
     self.init(rgbaValue: color.rgbaValue)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Colors/swift5/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Colors/swift5/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No color found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Colors/swift5/multiple.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Colors/swift5/multiple.swift
@@ -96,3 +96,4 @@ internal extension Color {
     self.init(rgbaValue: color.rgbaValue)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/CoreData/swift4/defaults-extraImports.swift
+++ b/Sources/TestUtils/Fixtures/Generated/CoreData/swift4/defaults-extraImports.swift
@@ -455,3 +455,4 @@ extension SecondaryEntity {
 }
 
 // swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/CoreData/swift4/defaults-generateObjcName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/CoreData/swift4/defaults-generateObjcName.swift
@@ -458,3 +458,4 @@ extension SecondaryEntity {
 }
 
 // swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/CoreData/swift4/defaults-importCoreLocation.swift
+++ b/Sources/TestUtils/Fixtures/Generated/CoreData/swift4/defaults-importCoreLocation.swift
@@ -454,3 +454,4 @@ extension SecondaryEntity {
 }
 
 // swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/CoreData/swift4/defaults-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/CoreData/swift4/defaults-publicAccess.swift
@@ -453,3 +453,4 @@ extension SecondaryEntity {
 }
 
 // swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/CoreData/swift4/defaults.swift
+++ b/Sources/TestUtils/Fixtures/Generated/CoreData/swift4/defaults.swift
@@ -453,3 +453,4 @@ extension SecondaryEntity {
 }
 
 // swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/CoreData/swift4/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/CoreData/swift4/empty.swift
@@ -10,3 +10,4 @@ import Foundation
 // swiftlint:disable identifier_name line_length type_body_length
 
 // swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/CoreData/swift5/defaults-extraImports.swift
+++ b/Sources/TestUtils/Fixtures/Generated/CoreData/swift5/defaults-extraImports.swift
@@ -455,3 +455,4 @@ extension SecondaryEntity {
 }
 
 // swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/CoreData/swift5/defaults-generateObjcName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/CoreData/swift5/defaults-generateObjcName.swift
@@ -458,3 +458,4 @@ extension SecondaryEntity {
 }
 
 // swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/CoreData/swift5/defaults-importCoreLocation.swift
+++ b/Sources/TestUtils/Fixtures/Generated/CoreData/swift5/defaults-importCoreLocation.swift
@@ -454,3 +454,4 @@ extension SecondaryEntity {
 }
 
 // swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/CoreData/swift5/defaults-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/CoreData/swift5/defaults-publicAccess.swift
@@ -453,3 +453,4 @@ extension SecondaryEntity {
 }
 
 // swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/CoreData/swift5/defaults.swift
+++ b/Sources/TestUtils/Fixtures/Generated/CoreData/swift5/defaults.swift
@@ -453,3 +453,4 @@ extension SecondaryEntity {
 }
 
 // swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/CoreData/swift5/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/CoreData/swift5/empty.swift
@@ -10,3 +10,4 @@ import Foundation
 // swiftlint:disable identifier_name line_length type_body_length
 
 // swiftlint:enable identifier_name line_length type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Files/flat-swift4/defaults-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Files/flat-swift4/defaults-customBundle.swift
@@ -59,3 +59,4 @@ internal struct File {
     return url(locale: locale).path
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Files/flat-swift4/defaults-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Files/flat-swift4/defaults-customName.swift
@@ -71,3 +71,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type explicit_type_interface
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Files/flat-swift4/defaults-dontUseExtension.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Files/flat-swift4/defaults-dontUseExtension.swift
@@ -71,3 +71,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type explicit_type_interface
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Files/flat-swift4/defaults-preservePath.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Files/flat-swift4/defaults-preservePath.swift
@@ -71,3 +71,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type explicit_type_interface
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Files/flat-swift4/defaults-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Files/flat-swift4/defaults-publicAccess.swift
@@ -71,3 +71,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type explicit_type_interface
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Files/flat-swift4/defaults.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Files/flat-swift4/defaults.swift
@@ -71,3 +71,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type explicit_type_interface
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Files/flat-swift4/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Files/flat-swift4/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No files found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Files/flat-swift5/defaults-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Files/flat-swift5/defaults-customBundle.swift
@@ -59,3 +59,4 @@ internal struct File {
     return url(locale: locale).path
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Files/flat-swift5/defaults-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Files/flat-swift5/defaults-customName.swift
@@ -71,3 +71,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type explicit_type_interface
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Files/flat-swift5/defaults-dontUseExtension.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Files/flat-swift5/defaults-dontUseExtension.swift
@@ -71,3 +71,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type explicit_type_interface
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Files/flat-swift5/defaults-preservePath.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Files/flat-swift5/defaults-preservePath.swift
@@ -71,3 +71,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type explicit_type_interface
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Files/flat-swift5/defaults-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Files/flat-swift5/defaults-publicAccess.swift
@@ -71,3 +71,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type explicit_type_interface
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Files/flat-swift5/defaults.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Files/flat-swift5/defaults.swift
@@ -71,3 +71,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type explicit_type_interface
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Files/flat-swift5/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Files/flat-swift5/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No files found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Files/structured-swift4/defaults-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Files/structured-swift4/defaults-customBundle.swift
@@ -71,3 +71,4 @@ internal struct File {
     return url(locale: locale).path
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Files/structured-swift4/defaults-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Files/structured-swift4/defaults-customName.swift
@@ -83,3 +83,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type explicit_type_interface
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Files/structured-swift4/defaults-dontUseExtension.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Files/structured-swift4/defaults-dontUseExtension.swift
@@ -83,3 +83,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type explicit_type_interface
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Files/structured-swift4/defaults-preservePath.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Files/structured-swift4/defaults-preservePath.swift
@@ -83,3 +83,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type explicit_type_interface
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Files/structured-swift4/defaults-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Files/structured-swift4/defaults-publicAccess.swift
@@ -83,3 +83,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type explicit_type_interface
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Files/structured-swift4/defaults.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Files/structured-swift4/defaults.swift
@@ -83,3 +83,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type explicit_type_interface
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Files/structured-swift4/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Files/structured-swift4/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No files found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Files/structured-swift5/defaults-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Files/structured-swift5/defaults-customBundle.swift
@@ -71,3 +71,4 @@ internal struct File {
     return url(locale: locale).path
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Files/structured-swift5/defaults-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Files/structured-swift5/defaults-customName.swift
@@ -83,3 +83,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type explicit_type_interface
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Files/structured-swift5/defaults-dontUseExtension.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Files/structured-swift5/defaults-dontUseExtension.swift
@@ -83,3 +83,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type explicit_type_interface
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Files/structured-swift5/defaults-preservePath.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Files/structured-swift5/defaults-preservePath.swift
@@ -83,3 +83,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type explicit_type_interface
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Files/structured-swift5/defaults-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Files/structured-swift5/defaults-publicAccess.swift
@@ -83,3 +83,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type explicit_type_interface
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Files/structured-swift5/defaults.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Files/structured-swift5/defaults.swift
@@ -83,3 +83,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type explicit_type_interface
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Files/structured-swift5/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Files/structured-swift5/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No files found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift4/defaults-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift4/defaults-customBundle.swift
@@ -105,3 +105,4 @@ internal extension FontConvertible.Font {
     self.init(name: font.name, size: size)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift4/defaults-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift4/defaults-customName.swift
@@ -117,3 +117,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift4/defaults-lookupFunction.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift4/defaults-lookupFunction.swift
@@ -105,3 +105,4 @@ internal extension FontConvertible.Font {
     self.init(name: font.name, size: size)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift4/defaults-preservePath.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift4/defaults-preservePath.swift
@@ -117,3 +117,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift4/defaults-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift4/defaults-publicAccess.swift
@@ -117,3 +117,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift4/defaults.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift4/defaults.swift
@@ -117,3 +117,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift4/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift4/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No fonts found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults-customBundle.swift
@@ -157,3 +157,4 @@ internal extension SwiftUI.Font {
   }
 }
 #endif
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults-customName.swift
@@ -169,3 +169,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults-lookupFunction.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults-lookupFunction.swift
@@ -157,3 +157,4 @@ internal extension SwiftUI.Font {
   }
 }
 #endif
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults-preservePath.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults-preservePath.swift
@@ -169,3 +169,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults-publicAccess.swift
@@ -169,3 +169,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/defaults.swift
@@ -169,3 +169,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Fonts/swift5/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No fonts found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all-customBundle.swift
@@ -140,3 +140,4 @@ internal struct InitialSceneType<T: UIViewController> {
     return controller
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all-customName.swift
@@ -152,3 +152,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all-ignoreTargetModule-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all-ignoreTargetModule-withExtraModule.swift
@@ -151,3 +151,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all-ignoreTargetModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all-ignoreTargetModule.swift
@@ -152,3 +152,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all-lookupFunction.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all-lookupFunction.swift
@@ -140,3 +140,4 @@ internal struct InitialSceneType<T: UIViewController> {
     return controller
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all-noDefinedModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all-noDefinedModule.swift
@@ -153,3 +153,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all-publicAccess.swift
@@ -152,3 +152,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all-withExtraModule.swift
@@ -151,3 +151,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/all.swift
@@ -152,3 +152,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift4/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No storyboard found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all-customBundle.swift
@@ -138,3 +138,4 @@ internal struct InitialSceneType<T: UIViewController> {
     return controller
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all-customName.swift
@@ -150,3 +150,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all-ignoreTargetModule-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all-ignoreTargetModule-withExtraModule.swift
@@ -149,3 +149,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all-ignoreTargetModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all-ignoreTargetModule.swift
@@ -150,3 +150,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all-lookupFunction.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all-lookupFunction.swift
@@ -138,3 +138,4 @@ internal struct InitialSceneType<T: UIViewController> {
     return controller
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all-noDefinedModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all-noDefinedModule.swift
@@ -151,3 +151,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all-publicAccess.swift
@@ -150,3 +150,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all-withExtraModule.swift
@@ -149,3 +149,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/all.swift
@@ -150,3 +150,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/scenes-swift5/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No storyboard found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/all-customName.swift
@@ -52,3 +52,4 @@ internal extension SegueType where RawValue == String {
     self.init(rawValue: identifier)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/all-ignoreTargetModule-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/all-ignoreTargetModule-withExtraModule.swift
@@ -51,3 +51,4 @@ internal extension SegueType where RawValue == String {
     self.init(rawValue: identifier)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/all-ignoreTargetModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/all-ignoreTargetModule.swift
@@ -52,3 +52,4 @@ internal extension SegueType where RawValue == String {
     self.init(rawValue: identifier)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/all-noDefinedModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/all-noDefinedModule.swift
@@ -53,3 +53,4 @@ internal extension SegueType where RawValue == String {
     self.init(rawValue: identifier)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/all-publicAccess.swift
@@ -52,3 +52,4 @@ public extension SegueType where RawValue == String {
     self.init(rawValue: identifier)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/all-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/all-withExtraModule.swift
@@ -51,3 +51,4 @@ internal extension SegueType where RawValue == String {
     self.init(rawValue: identifier)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/all.swift
@@ -52,3 +52,4 @@ internal extension SegueType where RawValue == String {
     self.init(rawValue: identifier)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift4/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No storyboard found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/all-customName.swift
@@ -52,3 +52,4 @@ internal extension SegueType where RawValue == String {
     self.init(rawValue: identifier)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/all-ignoreTargetModule-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/all-ignoreTargetModule-withExtraModule.swift
@@ -51,3 +51,4 @@ internal extension SegueType where RawValue == String {
     self.init(rawValue: identifier)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/all-ignoreTargetModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/all-ignoreTargetModule.swift
@@ -52,3 +52,4 @@ internal extension SegueType where RawValue == String {
     self.init(rawValue: identifier)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/all-noDefinedModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/all-noDefinedModule.swift
@@ -53,3 +53,4 @@ internal extension SegueType where RawValue == String {
     self.init(rawValue: identifier)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/all-publicAccess.swift
@@ -52,3 +52,4 @@ public extension SegueType where RawValue == String {
     self.init(rawValue: identifier)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/all-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/all-withExtraModule.swift
@@ -51,3 +51,4 @@ internal extension SegueType where RawValue == String {
     self.init(rawValue: identifier)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/all.swift
@@ -52,3 +52,4 @@ internal extension SegueType where RawValue == String {
     self.init(rawValue: identifier)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-iOS/segues-swift5/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No storyboard found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift4/all-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift4/all-customBundle.swift
@@ -127,3 +127,4 @@ internal struct InitialSceneType<T> {
     return controller
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift4/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift4/all-customName.swift
@@ -139,3 +139,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift4/all-ignoreTargetModule-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift4/all-ignoreTargetModule-withExtraModule.swift
@@ -138,3 +138,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift4/all-ignoreTargetModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift4/all-ignoreTargetModule.swift
@@ -139,3 +139,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift4/all-lookupFunction.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift4/all-lookupFunction.swift
@@ -127,3 +127,4 @@ internal struct InitialSceneType<T> {
     return controller
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift4/all-noDefinedModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift4/all-noDefinedModule.swift
@@ -140,3 +140,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift4/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift4/all-publicAccess.swift
@@ -139,3 +139,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift4/all-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift4/all-withExtraModule.swift
@@ -138,3 +138,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift4/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift4/all.swift
@@ -139,3 +139,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift4/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift4/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No storyboard found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift5/all-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift5/all-customBundle.swift
@@ -127,3 +127,4 @@ internal struct InitialSceneType<T> {
     return controller
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift5/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift5/all-customName.swift
@@ -139,3 +139,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift5/all-ignoreTargetModule-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift5/all-ignoreTargetModule-withExtraModule.swift
@@ -138,3 +138,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift5/all-ignoreTargetModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift5/all-ignoreTargetModule.swift
@@ -139,3 +139,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift5/all-lookupFunction.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift5/all-lookupFunction.swift
@@ -127,3 +127,4 @@ internal struct InitialSceneType<T> {
     return controller
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift5/all-noDefinedModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift5/all-noDefinedModule.swift
@@ -140,3 +140,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift5/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift5/all-publicAccess.swift
@@ -139,3 +139,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift5/all-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift5/all-withExtraModule.swift
@@ -138,3 +138,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift5/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift5/all.swift
@@ -139,3 +139,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift5/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/scenes-swift5/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No storyboard found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-customName.swift
@@ -49,3 +49,4 @@ internal extension SegueType where RawValue == String {
     self.init(rawValue: identifier)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-ignoreTargetModule-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-ignoreTargetModule-withExtraModule.swift
@@ -48,3 +48,4 @@ internal extension SegueType where RawValue == String {
     self.init(rawValue: identifier)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-ignoreTargetModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-ignoreTargetModule.swift
@@ -49,3 +49,4 @@ internal extension SegueType where RawValue == String {
     self.init(rawValue: identifier)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-noDefinedModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-noDefinedModule.swift
@@ -50,3 +50,4 @@ internal extension SegueType where RawValue == String {
     self.init(rawValue: identifier)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-publicAccess.swift
@@ -49,3 +49,4 @@ public extension SegueType where RawValue == String {
     self.init(rawValue: identifier)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all-withExtraModule.swift
@@ -48,3 +48,4 @@ internal extension SegueType where RawValue == String {
     self.init(rawValue: identifier)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/all.swift
@@ -49,3 +49,4 @@ internal extension SegueType where RawValue == String {
     self.init(rawValue: identifier)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift4/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No storyboard found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-customName.swift
@@ -49,3 +49,4 @@ internal extension SegueType where RawValue == String {
     self.init(rawValue: identifier)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-ignoreTargetModule-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-ignoreTargetModule-withExtraModule.swift
@@ -48,3 +48,4 @@ internal extension SegueType where RawValue == String {
     self.init(rawValue: identifier)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-ignoreTargetModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-ignoreTargetModule.swift
@@ -49,3 +49,4 @@ internal extension SegueType where RawValue == String {
     self.init(rawValue: identifier)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-noDefinedModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-noDefinedModule.swift
@@ -50,3 +50,4 @@ internal extension SegueType where RawValue == String {
     self.init(rawValue: identifier)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-publicAccess.swift
@@ -49,3 +49,4 @@ public extension SegueType where RawValue == String {
     self.init(rawValue: identifier)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-withExtraModule.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all-withExtraModule.swift
@@ -48,3 +48,4 @@ internal extension SegueType where RawValue == String {
     self.init(rawValue: identifier)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/all.swift
@@ -49,3 +49,4 @@ internal extension SegueType where RawValue == String {
     self.init(rawValue: identifier)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/IB-macOS/segues-swift5/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No storyboard found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/JSON/inline-swift4/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/JSON/inline-swift4/all-customName.swift
@@ -30,3 +30,4 @@ internal enum CustomJSON {
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/JSON/inline-swift4/all-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/JSON/inline-swift4/all-forceFileNameEnum.swift
@@ -30,3 +30,4 @@ internal enum JSONFiles {
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/JSON/inline-swift4/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/JSON/inline-swift4/all-publicAccess.swift
@@ -30,3 +30,4 @@ public enum JSONFiles {
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/JSON/inline-swift4/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/JSON/inline-swift4/all.swift
@@ -30,3 +30,4 @@ internal enum JSONFiles {
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/JSON/inline-swift4/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/JSON/inline-swift4/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No files found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/JSON/inline-swift5/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/JSON/inline-swift5/all-customName.swift
@@ -30,3 +30,4 @@ internal enum CustomJSON {
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/JSON/inline-swift5/all-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/JSON/inline-swift5/all-forceFileNameEnum.swift
@@ -30,3 +30,4 @@ internal enum JSONFiles {
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/JSON/inline-swift5/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/JSON/inline-swift5/all-publicAccess.swift
@@ -30,3 +30,4 @@ public enum JSONFiles {
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/JSON/inline-swift5/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/JSON/inline-swift5/all.swift
@@ -30,3 +30,4 @@ internal enum JSONFiles {
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/JSON/inline-swift5/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/JSON/inline-swift5/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No files found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift4/all-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift4/all-customBundle.swift
@@ -57,3 +57,4 @@ private struct JSONDocument {
     return result
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift4/all-customname.swift
+++ b/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift4/all-customname.swift
@@ -69,3 +69,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift4/all-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift4/all-forceFileNameEnum.swift
@@ -69,3 +69,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift4/all-lookupFunction.swift
+++ b/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift4/all-lookupFunction.swift
@@ -57,3 +57,4 @@ private struct JSONDocument {
     return result
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift4/all-preservePath.swift
+++ b/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift4/all-preservePath.swift
@@ -69,3 +69,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift4/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift4/all-publicAccess.swift
@@ -69,3 +69,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift4/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift4/all.swift
@@ -69,3 +69,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift4/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift4/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No files found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift5/all-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift5/all-customBundle.swift
@@ -57,3 +57,4 @@ private struct JSONDocument {
     return result
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift5/all-customname.swift
+++ b/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift5/all-customname.swift
@@ -69,3 +69,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift5/all-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift5/all-forceFileNameEnum.swift
@@ -69,3 +69,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift5/all-lookupFunction.swift
+++ b/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift5/all-lookupFunction.swift
@@ -57,3 +57,4 @@ private struct JSONDocument {
     return result
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift5/all-preservePath.swift
+++ b/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift5/all-preservePath.swift
@@ -69,3 +69,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift5/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift5/all-publicAccess.swift
@@ -69,3 +69,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift5/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift5/all.swift
@@ -69,3 +69,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift5/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/JSON/runtime-swift5/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No files found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift4/all-customname.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift4/all-customname.swift
@@ -57,3 +57,4 @@ internal enum CustomPlist {
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift4/all-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift4/all-forceFileNameEnum.swift
@@ -57,3 +57,4 @@ internal enum PlistFiles {
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift4/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift4/all-publicAccess.swift
@@ -57,3 +57,4 @@ public enum PlistFiles {
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift4/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift4/all.swift
@@ -57,3 +57,4 @@ internal enum PlistFiles {
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift4/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift4/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No files found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift5/all-customname.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift5/all-customname.swift
@@ -57,3 +57,4 @@ internal enum CustomPlist {
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift5/all-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift5/all-forceFileNameEnum.swift
@@ -57,3 +57,4 @@ internal enum PlistFiles {
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift5/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift5/all-publicAccess.swift
@@ -57,3 +57,4 @@ public enum PlistFiles {
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift5/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift5/all.swift
@@ -57,3 +57,4 @@ internal enum PlistFiles {
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift5/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/inline-swift5/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No files found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/all-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/all-customBundle.swift
@@ -88,3 +88,4 @@ private struct PlistDocument {
     return result
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/all-customName.swift
@@ -100,3 +100,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/all-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/all-forceFileNameEnum.swift
@@ -100,3 +100,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/all-lookupFunction.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/all-lookupFunction.swift
@@ -88,3 +88,4 @@ private struct PlistDocument {
     return result
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/all-preservePath.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/all-preservePath.swift
@@ -100,3 +100,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/all-publicAccess.swift
@@ -100,3 +100,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/all.swift
@@ -100,3 +100,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift4/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No files found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/all-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/all-customBundle.swift
@@ -88,3 +88,4 @@ private struct PlistDocument {
     return result
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/all-customName.swift
@@ -100,3 +100,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/all-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/all-forceFileNameEnum.swift
@@ -100,3 +100,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/all-lookupFunction.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/all-lookupFunction.swift
@@ -88,3 +88,4 @@ private struct PlistDocument {
     return result
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/all-preservePath.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/all-preservePath.swift
@@ -100,3 +100,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/all-publicAccess.swift
@@ -100,3 +100,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/all.swift
@@ -100,3 +100,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Plist/runtime-swift5/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No files found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No string found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/localizable-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/localizable-customBundle.swift
@@ -70,3 +70,4 @@ extension L10n {
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/localizable-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/localizable-customName.swift
@@ -82,3 +82,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/localizable-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/localizable-forceFileNameEnum.swift
@@ -84,3 +84,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/localizable-lookupFunction.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/localizable-lookupFunction.swift
@@ -70,3 +70,4 @@ extension L10n {
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/localizable-noComments.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/localizable-noComments.swift
@@ -64,3 +64,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/localizable-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/localizable-publicAccess.swift
@@ -82,3 +82,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/localizable.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/localizable.swift
@@ -82,3 +82,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/multiple.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/multiple.swift
@@ -106,3 +106,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/plurals-advanced.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/plurals-advanced.swift
@@ -64,3 +64,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/plurals-same-table.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/plurals-same-table.swift
@@ -90,3 +90,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/plurals-unsupported.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/plurals-unsupported.swift
@@ -36,3 +36,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/plurals.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/plurals.swift
@@ -44,3 +44,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No string found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/localizable-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/localizable-customBundle.swift
@@ -70,3 +70,4 @@ extension L10n {
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/localizable-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/localizable-customName.swift
@@ -82,3 +82,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/localizable-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/localizable-forceFileNameEnum.swift
@@ -84,3 +84,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/localizable-lookupFunction.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/localizable-lookupFunction.swift
@@ -70,3 +70,4 @@ extension L10n {
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/localizable-noComments.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/localizable-noComments.swift
@@ -64,3 +64,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/localizable-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/localizable-publicAccess.swift
@@ -82,3 +82,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/localizable.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/localizable.swift
@@ -82,3 +82,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/multiple.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/multiple.swift
@@ -106,3 +106,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/plurals-advanced.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/plurals-advanced.swift
@@ -64,3 +64,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/plurals-same-table.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/plurals-same-table.swift
@@ -90,3 +90,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/plurals-unsupported.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/plurals-unsupported.swift
@@ -36,3 +36,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/plurals.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/plurals.swift
@@ -44,3 +44,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No string found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-customBundle.swift
@@ -114,3 +114,4 @@ extension L10n {
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-customName.swift
@@ -126,3 +126,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-forceFileNameEnum.swift
@@ -128,3 +128,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-lookupFunction.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-lookupFunction.swift
@@ -114,3 +114,4 @@ extension L10n {
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-noComments.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-noComments.swift
@@ -108,3 +108,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable-publicAccess.swift
@@ -126,3 +126,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/localizable.swift
@@ -126,3 +126,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/multiple.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/multiple.swift
@@ -160,3 +160,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/plurals-advanced.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/plurals-advanced.swift
@@ -82,3 +82,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/plurals-same-table.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/plurals-same-table.swift
@@ -142,3 +142,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/plurals-unsupported.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/plurals-unsupported.swift
@@ -42,3 +42,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/plurals.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/plurals.swift
@@ -56,3 +56,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No string found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-customBundle.swift
@@ -114,3 +114,4 @@ extension L10n {
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-customName.swift
@@ -126,3 +126,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-forceFileNameEnum.swift
@@ -128,3 +128,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-lookupFunction.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-lookupFunction.swift
@@ -114,3 +114,4 @@ extension L10n {
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-noComments.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-noComments.swift
@@ -108,3 +108,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable-publicAccess.swift
@@ -126,3 +126,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/localizable.swift
@@ -126,3 +126,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/multiple.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/multiple.swift
@@ -160,3 +160,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-advanced.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-advanced.swift
@@ -82,3 +82,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-same-table.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-same-table.swift
@@ -142,3 +142,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-unsupported.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-unsupported.swift
@@ -42,3 +42,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals.swift
@@ -56,3 +56,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift4/all-allValues.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift4/all-allValues.swift
@@ -319,3 +319,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift4/all-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift4/all-customBundle.swift
@@ -254,3 +254,4 @@ internal struct SymbolAsset {
   }
   #endif
 }
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift4/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift4/all-customName.swift
@@ -266,3 +266,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift4/all-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift4/all-forceFileNameEnum.swift
@@ -266,3 +266,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift4/all-forceNamespaces.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift4/all-forceNamespaces.swift
@@ -268,3 +268,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift4/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift4/all-publicAccess.swift
@@ -266,3 +266,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift4/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift4/all.swift
@@ -266,3 +266,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift4/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift4/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No assets found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift4/food.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift4/food.swift
@@ -102,3 +102,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-allValues.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-allValues.swift
@@ -401,3 +401,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-customBundle.swift
@@ -336,3 +336,4 @@ internal extension SwiftUI.Image {
   }
 }
 #endif
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-customName.swift
@@ -348,3 +348,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-forceFileNameEnum.swift
@@ -348,3 +348,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-forceNamespaces.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-forceNamespaces.swift
@@ -350,3 +350,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-publicAccess.swift
@@ -348,3 +348,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all.swift
@@ -348,3 +348,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No assets found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/food.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/food.swift
@@ -132,3 +132,4 @@ private final class BundleToken {
   }()
 }
 // swiftlint:enable convenience_type
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/YAML/inline-swift4/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/YAML/inline-swift4/all-customName.swift
@@ -42,3 +42,4 @@ internal enum CustomYAML {
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/YAML/inline-swift4/all-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/YAML/inline-swift4/all-forceFileNameEnum.swift
@@ -42,3 +42,4 @@ internal enum YAMLFiles {
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/YAML/inline-swift4/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/YAML/inline-swift4/all-publicAccess.swift
@@ -42,3 +42,4 @@ public enum YAMLFiles {
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/YAML/inline-swift4/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/YAML/inline-swift4/all.swift
@@ -42,3 +42,4 @@ internal enum YAMLFiles {
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/YAML/inline-swift4/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/YAML/inline-swift4/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No files found
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/YAML/inline-swift5/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/YAML/inline-swift5/all-customName.swift
@@ -42,3 +42,4 @@ internal enum CustomYAML {
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/YAML/inline-swift5/all-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/YAML/inline-swift5/all-forceFileNameEnum.swift
@@ -42,3 +42,4 @@ internal enum YAMLFiles {
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/YAML/inline-swift5/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/YAML/inline-swift5/all-publicAccess.swift
@@ -42,3 +42,4 @@ public enum YAMLFiles {
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/YAML/inline-swift5/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/YAML/inline-swift5/all.swift
@@ -42,3 +42,4 @@ internal enum YAMLFiles {
   }
 }
 // swiftlint:enable identifier_name line_length number_separator type_body_length
+// swiftlint:enable all

--- a/Sources/TestUtils/Fixtures/Generated/YAML/inline-swift5/empty.swift
+++ b/Sources/TestUtils/Fixtures/Generated/YAML/inline-swift5/empty.swift
@@ -2,3 +2,4 @@
 // Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
 
 // No files found
+// swiftlint:enable all

--- a/Tests/TemplatesTests/JsonTests.swift
+++ b/Tests/TemplatesTests/JsonTests.swift
@@ -56,6 +56,7 @@ final class JsonTests: XCTestCase {
   }
 
   // generate variations to test customname generation
+  // swiftlint:disable:next closure_body_length
   private let runtimeVariations: VariationGenerator = { name, context in
     guard name == "all" else { return [(context: context, suffix: "")] }
 

--- a/Tests/TemplatesTests/PlistTests.swift
+++ b/Tests/TemplatesTests/PlistTests.swift
@@ -56,6 +56,7 @@ final class PlistTests: XCTestCase {
   }
 
   // generate variations to test customname generation
+  // swiftlint:disable:next closure_body_length
   private let runtimeVariations: VariationGenerator = { name, context in
     guard name == "all" else { return [(context: context, suffix: "")] }
 

--- a/Tests/TemplatesTests/StringsTests.swift
+++ b/Tests/TemplatesTests/StringsTests.swift
@@ -22,6 +22,7 @@ final class StringsTests: XCTestCase {
   }
 
   // generate variations to test customname generation
+  // swiftlint:disable:next closure_body_length
   private let variations: VariationGenerator = { name, context in
     guard name == "localizable" else { return [(context: context, suffix: "")] }
 

--- a/rakelib/lint.rake
+++ b/rakelib/lint.rake
@@ -5,7 +5,7 @@
 
 namespace :lint do
   SWIFTLINT = 'rakelib/lint.sh'
-  SWIFTLINT_VERSION = '0.48.0'
+  SWIFTLINT_VERSION = '0.51.0'
 
   task :install do |task| 
     next if check_version

--- a/rakelib/lint.sh
+++ b/rakelib/lint.sh
@@ -42,11 +42,12 @@ trap finish EXIT
 
 # actually run swiftlint
 if [ "$key" = "templates_generated" ]; then
-  # copy the generated output to a temp dir and strip the "swiftlint:disable:all"
+  # copy the generated output to a temp dir and strip the "swiftlint:disable all" and "swiftlint:enable all".
+  # Replace them with " --" so the whole line reads as "// --".
   for f in `find "${PROJECT_DIR}/${selected_path}" -name '*.swift'`; do
     temp_file="${scratch}${f#"$PROJECT_DIR"}"
     mkdir -p $(dirname "$temp_file")
-    sed "s/swiftlint:disable all/ --/" "$f" > "$temp_file"
+    sed "s/swiftlint:\(enable\|disable\) all/ --/" "$f" > "$temp_file"
   done
 
   "$SWIFTLINT" lint --strict --config "$CONFIG" $REPORTER "$scratch" | sed s@"$scratch"@"${PROJECT_DIR}"@


### PR DESCRIPTION
* [x] I've started my branch from the `develop` branch (gitflow)
  * [x] And I've selected `develop` as the "base" branch for this Pull Request I'm about to create
* [x] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself  
      _(or added `#trivial` to the PR title if I think it doesn't warrant a mention in the CHANGELOG)_
  * [x] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
  * [x] Add a period and 2 spaces at the end of your short entry description
  * [x] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

Added `// swiftlint:enable all` to the bottom of all the Swift templates. Updated relevant internal tests to account for this change. Also updated the version of SwiftLint that SwiftGen uses to make sure it's compatible with the latest and greatest.

## Links

- [SwiftLint 0.51.0 release](https://github.com/realm/SwiftLint/releases/tag/0.51.0)
- Issue is caused by new [`blanket_disable_command`](https://github.com/realm/SwiftLint/pull/4731) SwiftLint rule.