### PR TITLE
Fonts: check file signature before emitting warning in sandboxed env (plugin)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,11 @@ _None_
 
 ### Bug Fixes
 
-_None_
+* Fonts: check font file signature before emitting a warning (plugin sandboxing)
+  [Richard Bergoin](https://github.com/kenji21)
+  [#952](https://github.com/SwiftGen/SwiftGen/issues/952)
+  [#1079](https://github.com/SwiftGen/SwiftGen/issues/1079)
+  [#1080](https://github.com/SwiftGen/SwiftGen/pull/1080)
 
 ### Internal Changes
 
@@ -60,7 +64,7 @@ _None_
 
 ### Changes in core dependencies of SwiftGen
 
-* [StencilSwiftKit 2.10.1](https://github.com/SwiftGen/StencilSwiftKit/blob/2.10.1/CHANGELOG.md)
+* [StencilSwiftKit 2.10.1](https://github.com/SwiftGen/StencilSwiftKit/blob/2.10.1/CHANGELOG.md).  
 
 ### Bug Fixes
 

--- a/Sources/SwiftGenKit/Parsers/Fonts/FontsParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Fonts/FontsParser.swift
@@ -35,18 +35,44 @@ public enum Fonts {
 
 // MARK: - Helpers
 
+private extension Data {
+    var isTrueTypeFont: Bool {
+        let trueTypeFontHeaderBytes: [UInt8] = [0x00, 0x01, 0x00, 0x00, 0x00] // https://en.wikipedia.org/wiki/List_of_file_signatures
+        var values = [UInt8](repeating: 0, count: trueTypeFontHeaderBytes.count)
+        self.copyBytes(to: &values, count: trueTypeFontHeaderBytes.count)
+        return values == trueTypeFontHeaderBytes
+    }
+
+    var isOpenTypeFont: Bool {
+        let openTypeFontHeaderBytes: [UInt8] = [0x4F, 0x54, 0x54, 0x4F] // https://en.wikipedia.org/wiki/List_of_file_signatures
+        var values = [UInt8](repeating: 0, count: openTypeFontHeaderBytes.count)
+        self.copyBytes(to: &values, count: openTypeFontHeaderBytes.count)
+        return values == openTypeFontHeaderBytes
+    }
+}
+
 private extension Fonts.Parser {
   /// Try to quickly check if the given file is an actual font file.
   ///
   /// - Note: This can seemingly fail in sandboxed environments.
   func checkIsFont(path: Path) -> Bool {
-    guard let values = try? path.url.resourceValues(forKeys: [.typeIdentifierKey]),
-      let uti = values.typeIdentifier else {
-      warningHandler?("Unable to determine the Universal Type Identifier for file \(path)", #file, #line)
+    do {
+      let values = try path.url.resourceValues(forKeys: [.typeIdentifierKey])
+      guard let uti = values.typeIdentifier else {
+        return true
+      }
+      return UTTypeConformsTo(uti as CFString, kUTTypeFont)
+    } catch {
+      if let handle = try? FileHandle(forReadingFrom: path.url) {
+        defer { handle.closeFile() }
+        let fileHeaderData = handle.readData(ofLength: 5)
+        if fileHeaderData.isTrueTypeFont || fileHeaderData.isOpenTypeFont {
+          return true
+        }
+      }
+      warningHandler?("Unable to determine the Universal Type Identifier for file \(path) : \(error)", #file, #line)
       return true
     }
-
-    return UTTypeConformsTo(uti as CFString, kUTTypeFont)
   }
 
   func addFont(_ font: Fonts.Font) {


### PR DESCRIPTION
Fix for https://github.com/SwiftGen/SwiftGen/issues/1079 and https://github.com/SwiftGen/SwiftGen/issues/952

To prevent warning being displayed in Xcode when using the plugin, I've added a check for the signature of font files (the first bytes) before emitting the warning

<img width="475" alt="Screenshot 5" src="https://github.com/SwiftGen/SwiftGen/assets/1105089/1b24d8b0-a202-422b-93f9-8c088564dde6">

