### PR TITLE
Workaround for using SwiftGenPlugin in Xcode Cloud

### DIFF
--- a/Sources/SwiftGen/Commands/Config/Config GenerateXCFileLists.swift
+++ b/Sources/SwiftGen/Commands/Config/Config GenerateXCFileLists.swift
@@ -48,12 +48,12 @@ extension Commands.Config {
 
       if let inputPath = inputs {
         let content = try configuration.inputXCFileList()
-        try inputPath.write(content)
+        try inputPath.writeFix(content)
       }
 
       if let outputPath = outputs {
         let content = try configuration.outputXCFileList()
-        try outputPath.write(content)
+        try outputPath.writeFix(content)
       }
     }
   }

--- a/Sources/SwiftGen/Commands/Config/Config Init.swift
+++ b/Sources/SwiftGen/Commands/Config/Config Init.swift
@@ -26,7 +26,7 @@ extension Commands.Config {
 
     func run() throws {
       let content = Config.example(versionForDocLink: Version.swiftgen, commentAllLines: true)
-      try config.file.write(content)
+      try config.file.writeFix(content)
       logMessage(.info, "Example configuration file created: \(config.file)")
       if open {
         NSWorkspace.shared.open(config.file.url)

--- a/Sources/SwiftGenCLI/OutputDestination.swift
+++ b/Sources/SwiftGenCLI/OutputDestination.swift
@@ -34,8 +34,18 @@ extension OutputDestination {
         logMessage(.info, "Not writing the file as content is unchanged")
         return
       }
-      try path.write(content)
+      try path.writeFix(content)
       logMessage(.info, "File written: \(path)")
     }
   }
+}
+
+import Foundation
+
+extension Path {
+    /// Work around for a bug in SPM that prevents SwiftGen from driving files to DerivedData folder located on external drive.
+    /// https://github.com/apple/swift-package-manager/issues/6948#issuecomment-1747196926
+    public func writeFix(_ string: String, encoding: String.Encoding = String.Encoding.utf8) throws {
+      try string.write(toFile: normalize().string, atomically: false, encoding: encoding)
+    }
 }


### PR DESCRIPTION
The atomic version of api has a bug as of Swift 5.9.2 where writing to DerivedData folder located on external drives fails. This is also how Xcode Cloud is setup, hence writing generated files with SwiftGen fails there too.

See more details https://github.com/apple/swift-package-manager/issues/6948#issuecomment-1747196926

The proper fix is already implemented https://github.com/apple/swift-package-manager/pull/6910 but not released yet (as of Swift 5.9.2)

Fixes https://github.com/SwiftGen/SwiftGenPlugin/issues/18

I've tested this by making a private binary release of this change and testing with a fork of SwiftGenPlugin, see more here https://github.com/SwiftGen/SwiftGenPlugin/issues/18#issuecomment-1894018747