### PR TITLE
fix: rake output:compile for XCAssets templates by removing lazy vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ _None_
   [#1030](https://github.com/SwiftGen/SwiftGen/issues/1030)
   [#1104](https://github.com/SwiftGen/SwiftGen/issues/1104)
   [#1105](https://github.com/SwiftGen/SwiftGen/pull/1105)
+* XCAssets: Fix rake output:compile for XCAsserts templates by removing lazy vars.  
+  [Liquidsoul](https://github.com/liquidsoul)
+  [#1022](https://github.com/SwiftGen/SwiftGen/issues/1022)
+  [#1107](https://github.com/SwiftGen/SwiftGen/pull/1107)
 
 ### Internal Changes
 

--- a/Sources/SwiftGenCLI/templates/xcassets/swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/xcassets/swift5.stencil
@@ -193,12 +193,12 @@
   #endif
 
   @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
-  {{accessModifier}} private(set) lazy var color: Color = {
+  {{accessModifier}} var color: Color {
     guard let color = Color(asset: self) else {
       fatalError("Unable to load color asset named \(name).")
     }
     return color
-  }()
+  }
 
   #if os(iOS) || os(tvOS)
   @available(iOS 11.0, tvOS 11.0, *)
@@ -213,9 +213,9 @@
 
   #if canImport(SwiftUI)
   @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
-  {{accessModifier}} private(set) lazy var swiftUIColor: SwiftUI.Color = {
+  {{accessModifier}} var swiftUIColor: SwiftUI.Color {
     SwiftUI.Color(asset: self)
-  }()
+  }
   #endif
 
   fileprivate init(name: String) {

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-allValues.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-allValues.swift
@@ -171,12 +171,12 @@ internal final class ColorAsset {
   #endif
 
   @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
-  internal private(set) lazy var color: Color = {
+  internal var color: Color {
     guard let color = Color(asset: self) else {
       fatalError("Unable to load color asset named \(name).")
     }
     return color
-  }()
+  }
 
   #if os(iOS) || os(tvOS)
   @available(iOS 11.0, tvOS 11.0, *)
@@ -191,9 +191,9 @@ internal final class ColorAsset {
 
   #if canImport(SwiftUI)
   @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
-  internal private(set) lazy var swiftUIColor: SwiftUI.Color = {
+  internal var swiftUIColor: SwiftUI.Color {
     SwiftUI.Color(asset: self)
-  }()
+  }
   #endif
 
   fileprivate init(name: String) {

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-customBundle.swift
@@ -118,12 +118,12 @@ internal final class ColorAsset {
   #endif
 
   @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
-  internal private(set) lazy var color: Color = {
+  internal var color: Color {
     guard let color = Color(asset: self) else {
       fatalError("Unable to load color asset named \(name).")
     }
     return color
-  }()
+  }
 
   #if os(iOS) || os(tvOS)
   @available(iOS 11.0, tvOS 11.0, *)
@@ -138,9 +138,9 @@ internal final class ColorAsset {
 
   #if canImport(SwiftUI)
   @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
-  internal private(set) lazy var swiftUIColor: SwiftUI.Color = {
+  internal var swiftUIColor: SwiftUI.Color {
     SwiftUI.Color(asset: self)
-  }()
+  }
   #endif
 
   fileprivate init(name: String) {

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-customName.swift
@@ -118,12 +118,12 @@ internal final class XCTColorAsset {
   #endif
 
   @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
-  internal private(set) lazy var color: Color = {
+  internal var color: Color {
     guard let color = Color(asset: self) else {
       fatalError("Unable to load color asset named \(name).")
     }
     return color
-  }()
+  }
 
   #if os(iOS) || os(tvOS)
   @available(iOS 11.0, tvOS 11.0, *)
@@ -138,9 +138,9 @@ internal final class XCTColorAsset {
 
   #if canImport(SwiftUI)
   @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
-  internal private(set) lazy var swiftUIColor: SwiftUI.Color = {
+  internal var swiftUIColor: SwiftUI.Color {
     SwiftUI.Color(asset: self)
-  }()
+  }
   #endif
 
   fileprivate init(name: String) {

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-forceFileNameEnum.swift
@@ -118,12 +118,12 @@ internal final class ColorAsset {
   #endif
 
   @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
-  internal private(set) lazy var color: Color = {
+  internal var color: Color {
     guard let color = Color(asset: self) else {
       fatalError("Unable to load color asset named \(name).")
     }
     return color
-  }()
+  }
 
   #if os(iOS) || os(tvOS)
   @available(iOS 11.0, tvOS 11.0, *)
@@ -138,9 +138,9 @@ internal final class ColorAsset {
 
   #if canImport(SwiftUI)
   @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
-  internal private(set) lazy var swiftUIColor: SwiftUI.Color = {
+  internal var swiftUIColor: SwiftUI.Color {
     SwiftUI.Color(asset: self)
-  }()
+  }
   #endif
 
   fileprivate init(name: String) {

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-forceNamespaces.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-forceNamespaces.swift
@@ -120,12 +120,12 @@ internal final class ColorAsset {
   #endif
 
   @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
-  internal private(set) lazy var color: Color = {
+  internal var color: Color {
     guard let color = Color(asset: self) else {
       fatalError("Unable to load color asset named \(name).")
     }
     return color
-  }()
+  }
 
   #if os(iOS) || os(tvOS)
   @available(iOS 11.0, tvOS 11.0, *)
@@ -140,9 +140,9 @@ internal final class ColorAsset {
 
   #if canImport(SwiftUI)
   @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
-  internal private(set) lazy var swiftUIColor: SwiftUI.Color = {
+  internal var swiftUIColor: SwiftUI.Color {
     SwiftUI.Color(asset: self)
-  }()
+  }
   #endif
 
   fileprivate init(name: String) {

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-publicAccess.swift
@@ -118,12 +118,12 @@ public final class ColorAsset {
   #endif
 
   @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
-  public private(set) lazy var color: Color = {
+  public var color: Color {
     guard let color = Color(asset: self) else {
       fatalError("Unable to load color asset named \(name).")
     }
     return color
-  }()
+  }
 
   #if os(iOS) || os(tvOS)
   @available(iOS 11.0, tvOS 11.0, *)
@@ -138,9 +138,9 @@ public final class ColorAsset {
 
   #if canImport(SwiftUI)
   @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
-  public private(set) lazy var swiftUIColor: SwiftUI.Color = {
+  public var swiftUIColor: SwiftUI.Color {
     SwiftUI.Color(asset: self)
-  }()
+  }
   #endif
 
   fileprivate init(name: String) {

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all.swift
@@ -118,12 +118,12 @@ internal final class ColorAsset {
   #endif
 
   @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
-  internal private(set) lazy var color: Color = {
+  internal var color: Color {
     guard let color = Color(asset: self) else {
       fatalError("Unable to load color asset named \(name).")
     }
     return color
-  }()
+  }
 
   #if os(iOS) || os(tvOS)
   @available(iOS 11.0, tvOS 11.0, *)
@@ -138,9 +138,9 @@ internal final class ColorAsset {
 
   #if canImport(SwiftUI)
   @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
-  internal private(set) lazy var swiftUIColor: SwiftUI.Color = {
+  internal var swiftUIColor: SwiftUI.Color {
     SwiftUI.Color(asset: self)
-  }()
+  }
   #endif
 
   fileprivate init(name: String) {


### PR DESCRIPTION
* [x] I've started my branch from the `develop` branch (gitflow)
  * [x] And I've selected `develop` as the "base" branch for this Pull Request I'm about to create
* [x] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself  
      _(or added `#trivial` to the PR title if I think it doesn't warrant a mention in the CHANGELOG)_
  * [x] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
  * [x] Add a period and 2 spaces at the end of your short entry description
  * [x] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

The Swift compiler does not allow the use of @available on stored variables anymore. This means that the `lazy var` used in the templates cannot be made available only for certain OSes.
I have fixed the issue by removing the `lazy var` altogether. Compared to the previous implementation, this introduces an overhead on every access to a color. I could not find a way to keep the lazy var without droping old OSes.

Fixes #1022 