### PR TITLE
Fix paths in release.rake homebrew part #trivial

### DIFF
--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -177,7 +177,7 @@ namespace :release do
     Utils.print_header 'Updating Homebrew Formula'
 
     tag = Utils.podspec_version(POD_NAME)
-    archive_url = "https://github.com/SwiftGen/SwiftGen/archive/#{tag}.tar.gz"
+    archive_url = "https://github.com/SwiftGen/SwiftGen/archive/refs/tags/#{tag}.tar.gz"
     digest = Digest::SHA256.hexdigest URI.open(archive_url).read
 
     formulas_dir = Bundler.with_original_env { `brew --repository homebrew/core`.chomp }
@@ -186,7 +186,7 @@ namespace :release do
       sh 'git pull'
       sh "git checkout -b swiftgen-#{tag} origin/master"
 
-      formula_file = "#{formulas_dir}/Formula/swiftgen.rb"
+      formula_file = "#{formulas_dir}/Formula/s/swiftgen.rb"
       formula = File.read(formula_file)
 
       new_formula = formula

--- a/rakelib/release.rake
+++ b/rakelib/release.rake
@@ -128,9 +128,9 @@ namespace :release do
     # Write the `info.json` artifact bundle manifest
     info_template = File.read("rakelib/artifactbundle.info.json.template")
     info_file_content = info_template.gsub(/(VERSION)/, version)
-    
+
     File.open("#{bundle_dir}/info.json", "w") do |f|
-      f.write(info_file_content)   
+      f.write(info_file_content)
     end
 
     # Zip the bundle
@@ -149,7 +149,7 @@ namespace :release do
       "swiftgen-#{version}.artifactbundle.zip"
     ]
     repo_name = File.basename(`git remote get-url origin`.chomp, '.git').freeze
-    
+
     # Create (or update) release
     puts "Pushing release notes for tag #{version}"
     begin
@@ -175,7 +175,7 @@ namespace :release do
   desc 'Release a new version on Homebrew and prepare a PR'
   task :homebrew do
     Utils.print_header 'Updating Homebrew Formula'
-    
+
     tag = Utils.podspec_version(POD_NAME)
     archive_url = "https://github.com/SwiftGen/SwiftGen/archive/#{tag}.tar.gz"
     digest = Digest::SHA256.hexdigest URI.open(archive_url).read


### PR DESCRIPTION
* [x] I've started my branch from the `develop` branch (gitflow)
  * [x] And I've selected `develop` as the "base" branch for this Pull Request I'm about to create
* [x] I've added `#trivial` to the PR title if I think it doesn't warrant a mention in the CHANGELOG)
---

I've stumbled on this when I released the 6.6.3.
