### PR TITLE
Make Asset and ImageAsset conform to Sendable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ _None_
 
 ### New Features
 
-_None_
+* Add Sendable conformance to the generated Assets.
+  [SergeyPetrachkov](https://github.com/SergeyPetrachkov)
+  [#1119](https://github.com/SwiftGen/SwiftGen/pull/1119)
 
 ### Bug Fixes
 

--- a/Sources/SwiftGenCLI/templates/xcassets/swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/xcassets/swift5.stencil
@@ -129,7 +129,7 @@
   {% endfor %}
 {% endmacro %}
 // swiftlint:disable identifier_name line_length nesting type_body_length type_name
-{{accessModifier}} enum {{enumName}} {
+{{accessModifier}} enum {{enumName}}: Sendable {
   {% if catalogs.count > 1 or param.forceFileNameEnum %}
   {% for catalog in catalogs %}
   {{accessModifier}} enum {{catalog.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
@@ -275,7 +275,7 @@
 {% endif %}
 {% if hasImage %}
 
-{{accessModifier}} struct {{imageType}} {
+{{accessModifier}} struct {{imageType}}: Sendable {
   {{accessModifier}} fileprivate(set) var name: String
 
   #if os(macOS)

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-allValues.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-allValues.swift
@@ -24,7 +24,7 @@ internal typealias AssetImageTypeAlias = ImageAsset.Image
 // MARK: - Asset Catalogs
 
 // swiftlint:disable identifier_name line_length nesting type_body_length type_name
-internal enum Asset {
+internal enum Asset: Sendable {
   internal enum Files {
     internal static let data = DataAsset(name: "Data")
     internal enum Json {
@@ -249,7 +249,7 @@ internal extension NSDataAsset {
   }
 }
 
-internal struct ImageAsset {
+internal struct ImageAsset: Sendable {
   internal fileprivate(set) var name: String
 
   #if os(macOS)

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-customBundle.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-customBundle.swift
@@ -24,7 +24,7 @@ internal typealias AssetImageTypeAlias = ImageAsset.Image
 // MARK: - Asset Catalogs
 
 // swiftlint:disable identifier_name line_length nesting type_body_length type_name
-internal enum Asset {
+internal enum Asset: Sendable {
   internal enum Files {
     internal static let data = DataAsset(name: "Data")
     internal enum Json {
@@ -196,7 +196,7 @@ internal extension NSDataAsset {
   }
 }
 
-internal struct ImageAsset {
+internal struct ImageAsset: Sendable {
   internal fileprivate(set) var name: String
 
   #if os(macOS)

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-customName.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-customName.swift
@@ -24,7 +24,7 @@ internal typealias XCTImage = XCTImageAsset.Image
 // MARK: - Asset Catalogs
 
 // swiftlint:disable identifier_name line_length nesting type_body_length type_name
-internal enum XCTAssets {
+internal enum XCTAssets: Sendable {
   internal enum Files {
     internal static let data = XCTDataAsset(name: "Data")
     internal enum Json {
@@ -196,7 +196,7 @@ internal extension NSDataAsset {
   }
 }
 
-internal struct XCTImageAsset {
+internal struct XCTImageAsset: Sendable {
   internal fileprivate(set) var name: String
 
   #if os(macOS)

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-forceFileNameEnum.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-forceFileNameEnum.swift
@@ -24,7 +24,7 @@ internal typealias AssetImageTypeAlias = ImageAsset.Image
 // MARK: - Asset Catalogs
 
 // swiftlint:disable identifier_name line_length nesting type_body_length type_name
-internal enum Asset {
+internal enum Asset: Sendable {
   internal enum Files {
     internal static let data = DataAsset(name: "Data")
     internal enum Json {
@@ -196,7 +196,7 @@ internal extension NSDataAsset {
   }
 }
 
-internal struct ImageAsset {
+internal struct ImageAsset: Sendable {
   internal fileprivate(set) var name: String
 
   #if os(macOS)

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-forceNamespaces.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-forceNamespaces.swift
@@ -24,7 +24,7 @@ internal typealias AssetImageTypeAlias = ImageAsset.Image
 // MARK: - Asset Catalogs
 
 // swiftlint:disable identifier_name line_length nesting type_body_length type_name
-internal enum Asset {
+internal enum Asset: Sendable {
   internal enum Files {
     internal static let data = DataAsset(name: "Data")
     internal enum Json {
@@ -198,7 +198,7 @@ internal extension NSDataAsset {
   }
 }
 
-internal struct ImageAsset {
+internal struct ImageAsset: Sendable {
   internal fileprivate(set) var name: String
 
   #if os(macOS)

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-publicAccess.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all-publicAccess.swift
@@ -24,7 +24,7 @@ public typealias AssetImageTypeAlias = ImageAsset.Image
 // MARK: - Asset Catalogs
 
 // swiftlint:disable identifier_name line_length nesting type_body_length type_name
-public enum Asset {
+public enum Asset: Sendable {
   public enum Files {
     public static let data = DataAsset(name: "Data")
     public enum Json {
@@ -196,7 +196,7 @@ public extension NSDataAsset {
   }
 }
 
-public struct ImageAsset {
+public struct ImageAsset: Sendable {
   public fileprivate(set) var name: String
 
   #if os(macOS)

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/all.swift
@@ -24,7 +24,7 @@ internal typealias AssetImageTypeAlias = ImageAsset.Image
 // MARK: - Asset Catalogs
 
 // swiftlint:disable identifier_name line_length nesting type_body_length type_name
-internal enum Asset {
+internal enum Asset: Sendable {
   internal enum Files {
     internal static let data = DataAsset(name: "Data")
     internal enum Json {
@@ -196,7 +196,7 @@ internal extension NSDataAsset {
   }
 }
 
-internal struct ImageAsset {
+internal struct ImageAsset: Sendable {
   internal fileprivate(set) var name: String
 
   #if os(macOS)

--- a/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/food.swift
+++ b/Sources/TestUtils/Fixtures/Generated/XCAssets/swift5/food.swift
@@ -21,7 +21,7 @@ internal typealias AssetImageTypeAlias = ImageAsset.Image
 // MARK: - Asset Catalogs
 
 // swiftlint:disable identifier_name line_length nesting type_body_length type_name
-internal enum Asset {
+internal enum Asset: Sendable {
   internal enum Exotic {
     internal static let banana = ImageAsset(name: "Exotic/Banana")
     internal static let mango = ImageAsset(name: "Exotic/Mango")
@@ -40,7 +40,7 @@ internal enum Asset {
 
 // MARK: - Implementation Details
 
-internal struct ImageAsset {
+internal struct ImageAsset: Sendable {
   internal fileprivate(set) var name: String
 
   #if os(macOS)


### PR DESCRIPTION
## What's done:

* added Sendable conformance to ImageAsset and Asset types so the generated code is Swift6- and strict-concurrency-checks- ready. Since all types that are used in the equation are `Sendable`, and since `Sendable` is available iOS 8+, macOS 10.10+, watchOS 2.0+ (in other words from the very old versions), it should be safe to just add Sendable conformance to the swift5 stencil without introducing breaking changes. This will allow people to use the generated codes without any unwanted warnings from the compiler.

* [x] I've started my branch from the `develop` branch (gitflow)
  * [x] And I've selected `develop` as the "base" branch for this Pull Request I'm about to create
* [x] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself  
      _(or added `#trivial` to the PR title if I think it doesn't warrant a mention in the CHANGELOG)_
  * [x] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
  * [x] Add a period and 2 spaces at the end of your short entry description
  * [x] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

