### PR TITLE
Show translations instead of plural key for entries from stringdict files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ _None_
 
 ### Bug Fixes
 
+* Strings: Translation entry for String Dictionaries now returns translation value instead of formatKey.   
+  [Paul Taykalo](https://github.com/PaulTaykalo)
+
 * Build: Fixed the `rake cli:install` command and with it the Homebrew formula.  
   [Liquidsoul](https://github.com/liquidsoul)
   [#1030](https://github.com/SwiftGen/SwiftGen/issues/1030)

--- a/Sources/SwiftGenKit/Parsers/Strings/FileTypeParser/StringsDictFileParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Strings/FileTypeParser/StringsDictFileParser.swift
@@ -33,9 +33,12 @@ extension Strings {
 
         return try plurals.map { keyValuePair -> Entry in
           let (key, pluralEntry) = keyValuePair
+          // We are taking "Other" rule, since its the only one that always should be there
+          let translation = (pluralEntry.variables.first?.rule.other) ?? ""
           return Entry(
             key: key,
-            translation: "Plural format key: \"\(pluralEntry.formatKey)\"",
+            formatKey: pluralEntry.formatKey,
+            translation: translation,
             types: try PlaceholderType.placeholderTypes(
               fromFormat: pluralEntry.formatKeyWithVariableValueTypes
             ),

--- a/Sources/SwiftGenKit/Parsers/Strings/StringsEntry.swift
+++ b/Sources/SwiftGenKit/Parsers/Strings/StringsEntry.swift
@@ -12,19 +12,21 @@ extension Strings {
     var comment: String?
     let key: String
     let translation: String
+    let formatKey: String?
     let types: [PlaceholderType]
     let keyStructure: [String]
 
-    init(key: String, translation: String, types: [PlaceholderType], keyStructureSeparator: String) {
+    init(key: String, formatKey: String? = nil, translation: String, types: [PlaceholderType], keyStructureSeparator: String) {
       self.key = key
       self.translation = translation
+      self.formatKey = formatKey
       self.types = types
       self.keyStructure = Self.split(key: key, separator: keyStructureSeparator)
     }
 
-    init(key: String, translation: String, keyStructureSeparator: String) throws {
+    init(key: String, formatKey: String? = nil, translation: String, keyStructureSeparator: String) throws {
       let types = try PlaceholderType.placeholderTypes(fromFormat: translation)
-      self.init(key: key, translation: translation, types: types, keyStructureSeparator: keyStructureSeparator)
+      self.init(key: key, formatKey: formatKey, translation: translation, types: types, keyStructureSeparator: keyStructureSeparator)
     }
 
     // MARK: - Structured keys

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/plurals-advanced.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/plurals-advanced.swift
@@ -9,37 +9,37 @@ import Foundation
 
 // swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 internal enum L10n {
-  /// Plural format key: "%@ - %#@d2@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@"
+  /// %d twos
   internal static func manyPlaceholdersPluralsBase(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Any, _ p9: Int, _ p10: Float) -> String {
-    return L10n.tr("LocPluralAdvanced", "many.placeholders.plurals.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), String(describing: p8), p9, p10, fallback: "Plural format key: \"%@ - %#@d2@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@\"")
+    return L10n.tr("LocPluralAdvanced", "many.placeholders.plurals.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), String(describing: p8), p9, p10, fallback: "%d twos")
   }
-  /// Plural format key: "%@ - %#@d2@ - %0$#@zero@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@"
+  /// %d twos
   internal static func manyPlaceholdersPluralsZero(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Any, _ p9: Int, _ p10: Float) -> String {
-    return L10n.tr("LocPluralAdvanced", "many.placeholders.plurals.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), String(describing: p8), p9, p10, fallback: "Plural format key: \"%@ - %#@d2@ - %0$#@zero@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@\"")
+    return L10n.tr("LocPluralAdvanced", "many.placeholders.plurals.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), String(describing: p8), p9, p10, fallback: "%d twos")
   }
-  /// Plural format key: "%1$@ %3$#@has_rating@"
+  /// has %d ratings
   internal static func mixedPlaceholdersAndVariablesPositionalstringPositional3int(_ p1: Any, _ p2: Int) -> String {
-    return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.positionalstring-positional3int", String(describing: p1), p2, fallback: "Plural format key: \"%1$@ %3$#@has_rating@\"")
+    return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.positionalstring-positional3int", String(describing: p1), p2, fallback: "has %d ratings")
   }
-  /// Plural format key: "%@ %#@has_rating@"
+  /// has %d ratings
   internal static func mixedPlaceholdersAndVariablesStringInt(_ p1: Any, _ p2: Int) -> String {
-    return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-int", String(describing: p1), p2, fallback: "Plural format key: \"%@ %#@has_rating@\"")
+    return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-int", String(describing: p1), p2, fallback: "has %d ratings")
   }
-  /// Plural format key: "%@ %2$#@has_rating@"
+  /// has %d ratings
   internal static func mixedPlaceholdersAndVariablesStringPositional2int(_ p1: Any, _ p2: Int) -> String {
-    return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-positional2int", String(describing: p1), p2, fallback: "Plural format key: \"%@ %2$#@has_rating@\"")
+    return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-positional2int", String(describing: p1), p2, fallback: "has %d ratings")
   }
-  /// Plural format key: "%@ %3$#@has_rating@"
+  /// has %d ratings
   internal static func mixedPlaceholdersAndVariablesStringPositional3int(_ p1: Any, _ p2: Int) -> String {
-    return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-positional3int", String(describing: p1), p2, fallback: "Plural format key: \"%@ %3$#@has_rating@\"")
+    return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-positional3int", String(describing: p1), p2, fallback: "has %d ratings")
   }
-  /// Plural format key: "Your %3$@ list contains %1$#@first@ %2$@."
+  /// %1$d items. You should buy them
   internal static func multiplePlaceholdersAndVariablesIntStringString(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
-    return L10n.tr("LocPluralAdvanced", "multiple.placeholders-and-variables.int-string-string", p1, String(describing: p2), String(describing: p3), fallback: "Plural format key: \"Your %3$@ list contains %1$#@first@ %2$@.\"")
+    return L10n.tr("LocPluralAdvanced", "multiple.placeholders-and-variables.int-string-string", p1, String(describing: p2), String(describing: p3), fallback: "%1$d items. You should buy them")
   }
-  /// Plural format key: "%#@files@ (%#@bytes@, %#@minutes@)"
+  /// %d files remaining
   internal static func multipleVariablesThreeVariablesInFormatkey(_ p1: Int, _ p2: Int, _ p3: Int) -> String {
-    return L10n.tr("LocPluralAdvanced", "multiple.variables.three-variables-in-formatkey", p1, p2, p3, fallback: "Plural format key: \"%#@files@ (%#@bytes@, %#@minutes@)\"")
+    return L10n.tr("LocPluralAdvanced", "multiple.variables.three-variables-in-formatkey", p1, p2, p3, fallback: "%d files remaining")
   }
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/plurals-same-table.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/plurals-same-table.swift
@@ -29,21 +29,21 @@ internal enum L10n {
   internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
     return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: "Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'")
   }
-  /// Plural format key: "%#@apples@"
+  /// You have %d apples. Wow that is a lot!
   internal static func applesCount(_ p1: Int) -> String {
-    return L10n.tr("Localizable", "apples.count", p1, fallback: "Plural format key: \"%#@apples@\"")
+    return L10n.tr("Localizable", "apples.count", p1, fallback: "You have %d apples. Wow that is a lot!")
   }
   /// A comment with no space above it
   internal static func bananasOwner(_ p1: Int, _ p2: Any) -> String {
     return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: "Those %d bananas belong to %@.")
   }
-  /// Plural format key: "%#@Matches@"
+  /// %ld matches
   internal static func competitionEventNumberOfMatches(_ p1: Int) -> String {
-    return L10n.tr("Localizable", "competition.event.number-of-matches", p1, fallback: "Plural format key: \"%#@Matches@\"")
+    return L10n.tr("Localizable", "competition.event.number-of-matches", p1, fallback: "%ld matches")
   }
-  /// Plural format key: "%#@Subscriptions@"
+  /// %ld subscriptions
   internal static func feedSubscriptionCount(_ p1: Int) -> String {
-    return L10n.tr("Localizable", "feed.subscription.count", p1, fallback: "Plural format key: \"%#@Subscriptions@\"")
+    return L10n.tr("Localizable", "feed.subscription.count", p1, fallback: "%ld subscriptions")
   }
   /// Same as "key1" = "value1"; but in the context of user not logged in
   internal static let key1Anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: "value2")

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/plurals-unsupported.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/plurals-unsupported.swift
@@ -9,9 +9,9 @@ import Foundation
 
 // swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 internal enum L10n {
-  /// Plural format key: "%#@elements@"
+  /// %@ has %d ratings
   internal static func unsupportedUsePlaceholdersInVariableRuleStringInt(_ p1: Int) -> String {
-    return L10n.tr("LocPluralUnsupported", "unsupported-use.placeholders-in-variable-rule.string-int", p1, fallback: "Plural format key: \"%#@elements@\"")
+    return L10n.tr("LocPluralUnsupported", "unsupported-use.placeholders-in-variable-rule.string-int", p1, fallback: "%@ has %d ratings")
   }
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/plurals.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/plurals.swift
@@ -9,17 +9,17 @@ import Foundation
 
 // swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 internal enum L10n {
-  /// Plural format key: "%#@apples@"
+  /// You have %d apples. Wow that is a lot!
   internal static func applesCount(_ p1: Int) -> String {
-    return L10n.tr("Localizable", "apples.count", p1, fallback: "Plural format key: \"%#@apples@\"")
+    return L10n.tr("Localizable", "apples.count", p1, fallback: "You have %d apples. Wow that is a lot!")
   }
-  /// Plural format key: "%#@Matches@"
+  /// %ld matches
   internal static func competitionEventNumberOfMatches(_ p1: Int) -> String {
-    return L10n.tr("Localizable", "competition.event.number-of-matches", p1, fallback: "Plural format key: \"%#@Matches@\"")
+    return L10n.tr("Localizable", "competition.event.number-of-matches", p1, fallback: "%ld matches")
   }
-  /// Plural format key: "%#@Subscriptions@"
+  /// %ld subscriptions
   internal static func feedSubscriptionCount(_ p1: Int) -> String {
-    return L10n.tr("Localizable", "feed.subscription.count", p1, fallback: "Plural format key: \"%#@Subscriptions@\"")
+    return L10n.tr("Localizable", "feed.subscription.count", p1, fallback: "%ld subscriptions")
   }
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/plurals-advanced.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/plurals-advanced.swift
@@ -9,37 +9,37 @@ import Foundation
 
 // swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 internal enum L10n {
-  /// Plural format key: "%@ - %#@d2@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@"
+  /// %d twos
   internal static func manyPlaceholdersPluralsBase(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Any, _ p9: Int, _ p10: Float) -> String {
-    return L10n.tr("LocPluralAdvanced", "many.placeholders.plurals.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), String(describing: p8), p9, p10, fallback: "Plural format key: \"%@ - %#@d2@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@\"")
+    return L10n.tr("LocPluralAdvanced", "many.placeholders.plurals.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), String(describing: p8), p9, p10, fallback: "%d twos")
   }
-  /// Plural format key: "%@ - %#@d2@ - %0$#@zero@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@"
+  /// %d twos
   internal static func manyPlaceholdersPluralsZero(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Any, _ p9: Int, _ p10: Float) -> String {
-    return L10n.tr("LocPluralAdvanced", "many.placeholders.plurals.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), String(describing: p8), p9, p10, fallback: "Plural format key: \"%@ - %#@d2@ - %0$#@zero@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@\"")
+    return L10n.tr("LocPluralAdvanced", "many.placeholders.plurals.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), String(describing: p8), p9, p10, fallback: "%d twos")
   }
-  /// Plural format key: "%1$@ %3$#@has_rating@"
+  /// has %d ratings
   internal static func mixedPlaceholdersAndVariablesPositionalstringPositional3int(_ p1: Any, _ p2: Int) -> String {
-    return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.positionalstring-positional3int", String(describing: p1), p2, fallback: "Plural format key: \"%1$@ %3$#@has_rating@\"")
+    return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.positionalstring-positional3int", String(describing: p1), p2, fallback: "has %d ratings")
   }
-  /// Plural format key: "%@ %#@has_rating@"
+  /// has %d ratings
   internal static func mixedPlaceholdersAndVariablesStringInt(_ p1: Any, _ p2: Int) -> String {
-    return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-int", String(describing: p1), p2, fallback: "Plural format key: \"%@ %#@has_rating@\"")
+    return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-int", String(describing: p1), p2, fallback: "has %d ratings")
   }
-  /// Plural format key: "%@ %2$#@has_rating@"
+  /// has %d ratings
   internal static func mixedPlaceholdersAndVariablesStringPositional2int(_ p1: Any, _ p2: Int) -> String {
-    return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-positional2int", String(describing: p1), p2, fallback: "Plural format key: \"%@ %2$#@has_rating@\"")
+    return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-positional2int", String(describing: p1), p2, fallback: "has %d ratings")
   }
-  /// Plural format key: "%@ %3$#@has_rating@"
+  /// has %d ratings
   internal static func mixedPlaceholdersAndVariablesStringPositional3int(_ p1: Any, _ p2: Int) -> String {
-    return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-positional3int", String(describing: p1), p2, fallback: "Plural format key: \"%@ %3$#@has_rating@\"")
+    return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-positional3int", String(describing: p1), p2, fallback: "has %d ratings")
   }
-  /// Plural format key: "Your %3$@ list contains %1$#@first@ %2$@."
+  /// %1$d items. You should buy them
   internal static func multiplePlaceholdersAndVariablesIntStringString(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
-    return L10n.tr("LocPluralAdvanced", "multiple.placeholders-and-variables.int-string-string", p1, String(describing: p2), String(describing: p3), fallback: "Plural format key: \"Your %3$@ list contains %1$#@first@ %2$@.\"")
+    return L10n.tr("LocPluralAdvanced", "multiple.placeholders-and-variables.int-string-string", p1, String(describing: p2), String(describing: p3), fallback: "%1$d items. You should buy them")
   }
-  /// Plural format key: "%#@files@ (%#@bytes@, %#@minutes@)"
+  /// %d files remaining
   internal static func multipleVariablesThreeVariablesInFormatkey(_ p1: Int, _ p2: Int, _ p3: Int) -> String {
-    return L10n.tr("LocPluralAdvanced", "multiple.variables.three-variables-in-formatkey", p1, p2, p3, fallback: "Plural format key: \"%#@files@ (%#@bytes@, %#@minutes@)\"")
+    return L10n.tr("LocPluralAdvanced", "multiple.variables.three-variables-in-formatkey", p1, p2, p3, fallback: "%d files remaining")
   }
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/plurals-same-table.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/plurals-same-table.swift
@@ -29,21 +29,21 @@ internal enum L10n {
   internal static func types(_ p1: Any, _ p2: CChar, _ p3: Int, _ p4: Float, _ p5: UnsafePointer<CChar>, _ p6: UnsafeRawPointer) -> String {
     return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: "Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'")
   }
-  /// Plural format key: "%#@apples@"
+  /// You have %d apples. Wow that is a lot!
   internal static func applesCount(_ p1: Int) -> String {
-    return L10n.tr("Localizable", "apples.count", p1, fallback: "Plural format key: \"%#@apples@\"")
+    return L10n.tr("Localizable", "apples.count", p1, fallback: "You have %d apples. Wow that is a lot!")
   }
   /// A comment with no space above it
   internal static func bananasOwner(_ p1: Int, _ p2: Any) -> String {
     return L10n.tr("Localizable", "bananas.owner", p1, String(describing: p2), fallback: "Those %d bananas belong to %@.")
   }
-  /// Plural format key: "%#@Matches@"
+  /// %ld matches
   internal static func competitionEventNumberOfMatches(_ p1: Int) -> String {
-    return L10n.tr("Localizable", "competition.event.number-of-matches", p1, fallback: "Plural format key: \"%#@Matches@\"")
+    return L10n.tr("Localizable", "competition.event.number-of-matches", p1, fallback: "%ld matches")
   }
-  /// Plural format key: "%#@Subscriptions@"
+  /// %ld subscriptions
   internal static func feedSubscriptionCount(_ p1: Int) -> String {
-    return L10n.tr("Localizable", "feed.subscription.count", p1, fallback: "Plural format key: \"%#@Subscriptions@\"")
+    return L10n.tr("Localizable", "feed.subscription.count", p1, fallback: "%ld subscriptions")
   }
   /// Same as "key1" = "value1"; but in the context of user not logged in
   internal static let key1Anonymous = L10n.tr("Localizable", "key1.anonymous", fallback: "value2")

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/plurals-unsupported.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/plurals-unsupported.swift
@@ -9,9 +9,9 @@ import Foundation
 
 // swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 internal enum L10n {
-  /// Plural format key: "%#@elements@"
+  /// %@ has %d ratings
   internal static func unsupportedUsePlaceholdersInVariableRuleStringInt(_ p1: Int) -> String {
-    return L10n.tr("LocPluralUnsupported", "unsupported-use.placeholders-in-variable-rule.string-int", p1, fallback: "Plural format key: \"%#@elements@\"")
+    return L10n.tr("LocPluralUnsupported", "unsupported-use.placeholders-in-variable-rule.string-int", p1, fallback: "%@ has %d ratings")
   }
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/plurals.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/plurals.swift
@@ -9,17 +9,17 @@ import Foundation
 
 // swiftlint:disable function_parameter_count identifier_name line_length type_body_length
 internal enum L10n {
-  /// Plural format key: "%#@apples@"
+  /// You have %d apples. Wow that is a lot!
   internal static func applesCount(_ p1: Int) -> String {
-    return L10n.tr("Localizable", "apples.count", p1, fallback: "Plural format key: \"%#@apples@\"")
+    return L10n.tr("Localizable", "apples.count", p1, fallback: "You have %d apples. Wow that is a lot!")
   }
-  /// Plural format key: "%#@Matches@"
+  /// %ld matches
   internal static func competitionEventNumberOfMatches(_ p1: Int) -> String {
-    return L10n.tr("Localizable", "competition.event.number-of-matches", p1, fallback: "Plural format key: \"%#@Matches@\"")
+    return L10n.tr("Localizable", "competition.event.number-of-matches", p1, fallback: "%ld matches")
   }
-  /// Plural format key: "%#@Subscriptions@"
+  /// %ld subscriptions
   internal static func feedSubscriptionCount(_ p1: Int) -> String {
-    return L10n.tr("Localizable", "feed.subscription.count", p1, fallback: "Plural format key: \"%#@Subscriptions@\"")
+    return L10n.tr("Localizable", "feed.subscription.count", p1, fallback: "%ld subscriptions")
   }
 }
 // swiftlint:enable function_parameter_count identifier_name line_length type_body_length

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/plurals-advanced.h
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/plurals-advanced.h
@@ -5,21 +5,21 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface LocPluralAdvanced : NSObject
-/// Plural format key: "%@ - %#@d2@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@"
+/// %d twos
 + (NSString*)manyPlaceholdersPluralsBaseWithValues:(id)p1 :(NSInteger)p2 :(float)p3 :(float)p4 :(NSInteger)p5 :(NSInteger)p6 :(id)p7 :(id)p8 :(NSInteger)p9 :(float)p10;
-/// Plural format key: "%@ - %#@d2@ - %0$#@zero@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@"
+/// %d twos
 + (NSString*)manyPlaceholdersPluralsZeroWithValues:(id)p1 :(NSInteger)p2 :(float)p3 :(float)p4 :(NSInteger)p5 :(NSInteger)p6 :(id)p7 :(id)p8 :(NSInteger)p9 :(float)p10;
-/// Plural format key: "%1$@ %3$#@has_rating@"
+/// has %d ratings
 + (NSString*)mixedPlaceholdersAndVariablesPositionalstringPositional3intWithValues:(id)p1 :(NSInteger)p2;
-/// Plural format key: "%@ %#@has_rating@"
+/// has %d ratings
 + (NSString*)mixedPlaceholdersAndVariablesStringIntWithValues:(id)p1 :(NSInteger)p2;
-/// Plural format key: "%@ %2$#@has_rating@"
+/// has %d ratings
 + (NSString*)mixedPlaceholdersAndVariablesStringPositional2intWithValues:(id)p1 :(NSInteger)p2;
-/// Plural format key: "%@ %3$#@has_rating@"
+/// has %d ratings
 + (NSString*)mixedPlaceholdersAndVariablesStringPositional3intWithValues:(id)p1 :(NSInteger)p2;
-/// Plural format key: "Your %3$@ list contains %1$#@first@ %2$@."
+/// %1$d items. You should buy them
 + (NSString*)multiplePlaceholdersAndVariablesIntStringStringWithValues:(NSInteger)p1 :(id)p2 :(id)p3;
-/// Plural format key: "%#@files@ (%#@bytes@, %#@minutes@)"
+/// %d files remaining
 + (NSString*)multipleVariablesThreeVariablesInFormatkeyWithValues:(NSInteger)p1 :(NSInteger)p2 :(NSInteger)p3;
 @end
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/plurals-same-table.h
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/plurals-same-table.h
@@ -19,13 +19,13 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString*)privateWithValues:(id)p1 :(NSInteger)p2;
 /// Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'
 + (NSString*)typesWithValues:(id)p1 :(char)p2 :(NSInteger)p3 :(float)p4 :(char*)p5 :(void*)p6;
-/// Plural format key: "%#@apples@"
+/// You have %d apples. Wow that is a lot!
 + (NSString*)applesCountWithValue:(NSInteger)p1;
 /// A comment with no space above it
 + (NSString*)bananasOwnerWithValues:(NSInteger)p1 :(id)p2;
-/// Plural format key: "%#@Matches@"
+/// %ld matches
 + (NSString*)competitionEventNumberOfMatchesWithValue:(NSInteger)p1;
-/// Plural format key: "%#@Subscriptions@"
+/// %ld subscriptions
 + (NSString*)feedSubscriptionCountWithValue:(NSInteger)p1;
 /// Same as "key1" = "value1"; but in the context of user not logged in
 + (NSString*)key1Anonymous;

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/plurals-unsupported.h
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/plurals-unsupported.h
@@ -5,7 +5,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface LocPluralUnsupported : NSObject
-/// Plural format key: "%#@elements@"
+/// %@ has %d ratings
 + (NSString*)unsupportedUsePlaceholdersInVariableRuleStringIntWithValue:(NSInteger)p1;
 @end
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/plurals.h
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/plurals.h
@@ -5,11 +5,11 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface Localizable : NSObject
-/// Plural format key: "%#@apples@"
+/// You have %d apples. Wow that is a lot!
 + (NSString*)applesCountWithValue:(NSInteger)p1;
-/// Plural format key: "%#@Matches@"
+/// %ld matches
 + (NSString*)competitionEventNumberOfMatchesWithValue:(NSInteger)p1;
-/// Plural format key: "%#@Subscriptions@"
+/// %ld subscriptions
 + (NSString*)feedSubscriptionCountWithValue:(NSInteger)p1;
 @end
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/plurals-advanced.m
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/plurals-advanced.m
@@ -28,35 +28,35 @@ static NSString* tr(NSString *tableName, NSString *key, NSString *value, ...) {
 @implementation LocPluralAdvanced : NSObject
 + (NSString*)manyPlaceholdersPluralsBaseWithValues:(id)p1 :(NSInteger)p2 :(float)p3 :(float)p4 :(NSInteger)p5 :(NSInteger)p6 :(id)p7 :(id)p8 :(NSInteger)p9 :(float)p10
 {
-    return tr(@"LocPluralAdvanced", @"many.placeholders.plurals.base", @"Plural format key: \"%@ - %#@d2@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@\"", p1, p2, p3, p4, p5, p6, p7, p8, p9, p10);
+    return tr(@"LocPluralAdvanced", @"many.placeholders.plurals.base", @"%d twos", p1, p2, p3, p4, p5, p6, p7, p8, p9, p10);
 }
 + (NSString*)manyPlaceholdersPluralsZeroWithValues:(id)p1 :(NSInteger)p2 :(float)p3 :(float)p4 :(NSInteger)p5 :(NSInteger)p6 :(id)p7 :(id)p8 :(NSInteger)p9 :(float)p10
 {
-    return tr(@"LocPluralAdvanced", @"many.placeholders.plurals.zero", @"Plural format key: \"%@ - %#@d2@ - %0$#@zero@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@\"", p1, p2, p3, p4, p5, p6, p7, p8, p9, p10);
+    return tr(@"LocPluralAdvanced", @"many.placeholders.plurals.zero", @"%d twos", p1, p2, p3, p4, p5, p6, p7, p8, p9, p10);
 }
 + (NSString*)mixedPlaceholdersAndVariablesPositionalstringPositional3intWithValues:(id)p1 :(NSInteger)p2
 {
-    return tr(@"LocPluralAdvanced", @"mixed.placeholders-and-variables.positionalstring-positional3int", @"Plural format key: \"%1$@ %3$#@has_rating@\"", p1, p2);
+    return tr(@"LocPluralAdvanced", @"mixed.placeholders-and-variables.positionalstring-positional3int", @"has %d ratings", p1, p2);
 }
 + (NSString*)mixedPlaceholdersAndVariablesStringIntWithValues:(id)p1 :(NSInteger)p2
 {
-    return tr(@"LocPluralAdvanced", @"mixed.placeholders-and-variables.string-int", @"Plural format key: \"%@ %#@has_rating@\"", p1, p2);
+    return tr(@"LocPluralAdvanced", @"mixed.placeholders-and-variables.string-int", @"has %d ratings", p1, p2);
 }
 + (NSString*)mixedPlaceholdersAndVariablesStringPositional2intWithValues:(id)p1 :(NSInteger)p2
 {
-    return tr(@"LocPluralAdvanced", @"mixed.placeholders-and-variables.string-positional2int", @"Plural format key: \"%@ %2$#@has_rating@\"", p1, p2);
+    return tr(@"LocPluralAdvanced", @"mixed.placeholders-and-variables.string-positional2int", @"has %d ratings", p1, p2);
 }
 + (NSString*)mixedPlaceholdersAndVariablesStringPositional3intWithValues:(id)p1 :(NSInteger)p2
 {
-    return tr(@"LocPluralAdvanced", @"mixed.placeholders-and-variables.string-positional3int", @"Plural format key: \"%@ %3$#@has_rating@\"", p1, p2);
+    return tr(@"LocPluralAdvanced", @"mixed.placeholders-and-variables.string-positional3int", @"has %d ratings", p1, p2);
 }
 + (NSString*)multiplePlaceholdersAndVariablesIntStringStringWithValues:(NSInteger)p1 :(id)p2 :(id)p3
 {
-    return tr(@"LocPluralAdvanced", @"multiple.placeholders-and-variables.int-string-string", @"Plural format key: \"Your %3$@ list contains %1$#@first@ %2$@.\"", p1, p2, p3);
+    return tr(@"LocPluralAdvanced", @"multiple.placeholders-and-variables.int-string-string", @"%1$d items. You should buy them", p1, p2, p3);
 }
 + (NSString*)multipleVariablesThreeVariablesInFormatkeyWithValues:(NSInteger)p1 :(NSInteger)p2 :(NSInteger)p3
 {
-    return tr(@"LocPluralAdvanced", @"multiple.variables.three-variables-in-formatkey", @"Plural format key: \"%#@files@ (%#@bytes@, %#@minutes@)\"", p1, p2, p3);
+    return tr(@"LocPluralAdvanced", @"multiple.variables.three-variables-in-formatkey", @"%d files remaining", p1, p2, p3);
 }
 @end
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/plurals-same-table.m
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/plurals-same-table.m
@@ -52,7 +52,7 @@ static NSString* tr(NSString *tableName, NSString *key, NSString *value, ...) {
 }
 + (NSString*)applesCountWithValue:(NSInteger)p1
 {
-    return tr(@"Localizable", @"apples.count", @"Plural format key: \"%#@apples@\"", p1);
+    return tr(@"Localizable", @"apples.count", @"You have %d apples. Wow that is a lot!", p1);
 }
 + (NSString*)bananasOwnerWithValues:(NSInteger)p1 :(id)p2
 {
@@ -60,11 +60,11 @@ static NSString* tr(NSString *tableName, NSString *key, NSString *value, ...) {
 }
 + (NSString*)competitionEventNumberOfMatchesWithValue:(NSInteger)p1
 {
-    return tr(@"Localizable", @"competition.event.number-of-matches", @"Plural format key: \"%#@Matches@\"", p1);
+    return tr(@"Localizable", @"competition.event.number-of-matches", @"%ld matches", p1);
 }
 + (NSString*)feedSubscriptionCountWithValue:(NSInteger)p1
 {
-    return tr(@"Localizable", @"feed.subscription.count", @"Plural format key: \"%#@Subscriptions@\"", p1);
+    return tr(@"Localizable", @"feed.subscription.count", @"%ld subscriptions", p1);
 }
 + (NSString*)key1Anonymous {
     return tr(@"Localizable", @"key1.anonymous", @"value2");

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/plurals-unsupported.m
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/plurals-unsupported.m
@@ -28,7 +28,7 @@ static NSString* tr(NSString *tableName, NSString *key, NSString *value, ...) {
 @implementation LocPluralUnsupported : NSObject
 + (NSString*)unsupportedUsePlaceholdersInVariableRuleStringIntWithValue:(NSInteger)p1
 {
-    return tr(@"LocPluralUnsupported", @"unsupported-use.placeholders-in-variable-rule.string-int", @"Plural format key: \"%#@elements@\"", p1);
+    return tr(@"LocPluralUnsupported", @"unsupported-use.placeholders-in-variable-rule.string-int", @"%@ has %d ratings", p1);
 }
 @end
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/plurals.m
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/plurals.m
@@ -28,15 +28,15 @@ static NSString* tr(NSString *tableName, NSString *key, NSString *value, ...) {
 @implementation Localizable : NSObject
 + (NSString*)applesCountWithValue:(NSInteger)p1
 {
-    return tr(@"Localizable", @"apples.count", @"Plural format key: \"%#@apples@\"", p1);
+    return tr(@"Localizable", @"apples.count", @"You have %d apples. Wow that is a lot!", p1);
 }
 + (NSString*)competitionEventNumberOfMatchesWithValue:(NSInteger)p1
 {
-    return tr(@"Localizable", @"competition.event.number-of-matches", @"Plural format key: \"%#@Matches@\"", p1);
+    return tr(@"Localizable", @"competition.event.number-of-matches", @"%ld matches", p1);
 }
 + (NSString*)feedSubscriptionCountWithValue:(NSInteger)p1
 {
-    return tr(@"Localizable", @"feed.subscription.count", @"Plural format key: \"%#@Subscriptions@\"", p1);
+    return tr(@"Localizable", @"feed.subscription.count", @"%ld subscriptions", p1);
 }
 @end
 

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/plurals-advanced.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/plurals-advanced.swift
@@ -13,48 +13,48 @@ internal enum L10n {
   internal enum Many {
     internal enum Placeholders {
       internal enum Plurals {
-        /// Plural format key: "%@ - %#@d2@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@"
+        /// %d twos
         internal static func base(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Any, _ p9: Int, _ p10: Float) -> String {
-          return L10n.tr("LocPluralAdvanced", "many.placeholders.plurals.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), String(describing: p8), p9, p10, fallback: "Plural format key: \"%@ - %#@d2@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@\"")
+          return L10n.tr("LocPluralAdvanced", "many.placeholders.plurals.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), String(describing: p8), p9, p10, fallback: "%d twos")
         }
-        /// Plural format key: "%@ - %#@d2@ - %0$#@zero@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@"
+        /// %d twos
         internal static func zero(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Any, _ p9: Int, _ p10: Float) -> String {
-          return L10n.tr("LocPluralAdvanced", "many.placeholders.plurals.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), String(describing: p8), p9, p10, fallback: "Plural format key: \"%@ - %#@d2@ - %0$#@zero@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@\"")
+          return L10n.tr("LocPluralAdvanced", "many.placeholders.plurals.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), String(describing: p8), p9, p10, fallback: "%d twos")
         }
       }
     }
   }
   internal enum Mixed {
     internal enum PlaceholdersAndVariables {
-      /// Plural format key: "%1$@ %3$#@has_rating@"
+      /// has %d ratings
       internal static func positionalstringPositional3int(_ p1: Any, _ p2: Int) -> String {
-        return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.positionalstring-positional3int", String(describing: p1), p2, fallback: "Plural format key: \"%1$@ %3$#@has_rating@\"")
+        return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.positionalstring-positional3int", String(describing: p1), p2, fallback: "has %d ratings")
       }
-      /// Plural format key: "%@ %#@has_rating@"
+      /// has %d ratings
       internal static func stringInt(_ p1: Any, _ p2: Int) -> String {
-        return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-int", String(describing: p1), p2, fallback: "Plural format key: \"%@ %#@has_rating@\"")
+        return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-int", String(describing: p1), p2, fallback: "has %d ratings")
       }
-      /// Plural format key: "%@ %2$#@has_rating@"
+      /// has %d ratings
       internal static func stringPositional2int(_ p1: Any, _ p2: Int) -> String {
-        return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-positional2int", String(describing: p1), p2, fallback: "Plural format key: \"%@ %2$#@has_rating@\"")
+        return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-positional2int", String(describing: p1), p2, fallback: "has %d ratings")
       }
-      /// Plural format key: "%@ %3$#@has_rating@"
+      /// has %d ratings
       internal static func stringPositional3int(_ p1: Any, _ p2: Int) -> String {
-        return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-positional3int", String(describing: p1), p2, fallback: "Plural format key: \"%@ %3$#@has_rating@\"")
+        return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-positional3int", String(describing: p1), p2, fallback: "has %d ratings")
       }
     }
   }
   internal enum Multiple {
     internal enum PlaceholdersAndVariables {
-      /// Plural format key: "Your %3$@ list contains %1$#@first@ %2$@."
+      /// %1$d items. You should buy them
       internal static func intStringString(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
-        return L10n.tr("LocPluralAdvanced", "multiple.placeholders-and-variables.int-string-string", p1, String(describing: p2), String(describing: p3), fallback: "Plural format key: \"Your %3$@ list contains %1$#@first@ %2$@.\"")
+        return L10n.tr("LocPluralAdvanced", "multiple.placeholders-and-variables.int-string-string", p1, String(describing: p2), String(describing: p3), fallback: "%1$d items. You should buy them")
       }
     }
     internal enum Variables {
-      /// Plural format key: "%#@files@ (%#@bytes@, %#@minutes@)"
+      /// %d files remaining
       internal static func threeVariablesInFormatkey(_ p1: Int, _ p2: Int, _ p3: Int) -> String {
-        return L10n.tr("LocPluralAdvanced", "multiple.variables.three-variables-in-formatkey", p1, p2, p3, fallback: "Plural format key: \"%#@files@ (%#@bytes@, %#@minutes@)\"")
+        return L10n.tr("LocPluralAdvanced", "multiple.variables.three-variables-in-formatkey", p1, p2, p3, fallback: "%d files remaining")
       }
     }
   }

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/plurals-same-table.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/plurals-same-table.swift
@@ -31,9 +31,9 @@ internal enum L10n {
     return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: "Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'")
   }
   internal enum Apples {
-    /// Plural format key: "%#@apples@"
+    /// You have %d apples. Wow that is a lot!
     internal static func count(_ p1: Int) -> String {
-      return L10n.tr("Localizable", "apples.count", p1, fallback: "Plural format key: \"%#@apples@\"")
+      return L10n.tr("Localizable", "apples.count", p1, fallback: "You have %d apples. Wow that is a lot!")
     }
   }
   internal enum Bananas {
@@ -44,17 +44,17 @@ internal enum L10n {
   }
   internal enum Competition {
     internal enum Event {
-      /// Plural format key: "%#@Matches@"
+      /// %ld matches
       internal static func numberOfMatches(_ p1: Int) -> String {
-        return L10n.tr("Localizable", "competition.event.number-of-matches", p1, fallback: "Plural format key: \"%#@Matches@\"")
+        return L10n.tr("Localizable", "competition.event.number-of-matches", p1, fallback: "%ld matches")
       }
     }
   }
   internal enum Feed {
     internal enum Subscription {
-      /// Plural format key: "%#@Subscriptions@"
+      /// %ld subscriptions
       internal static func count(_ p1: Int) -> String {
-        return L10n.tr("Localizable", "feed.subscription.count", p1, fallback: "Plural format key: \"%#@Subscriptions@\"")
+        return L10n.tr("Localizable", "feed.subscription.count", p1, fallback: "%ld subscriptions")
       }
     }
   }

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/plurals-unsupported.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/plurals-unsupported.swift
@@ -12,9 +12,9 @@ import Foundation
 internal enum L10n {
   internal enum UnsupportedUse {
     internal enum PlaceholdersInVariableRule {
-      /// Plural format key: "%#@elements@"
+      /// %@ has %d ratings
       internal static func stringInt(_ p1: Int) -> String {
-        return L10n.tr("LocPluralUnsupported", "unsupported-use.placeholders-in-variable-rule.string-int", p1, fallback: "Plural format key: \"%#@elements@\"")
+        return L10n.tr("LocPluralUnsupported", "unsupported-use.placeholders-in-variable-rule.string-int", p1, fallback: "%@ has %d ratings")
       }
     }
   }

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/plurals.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/plurals.swift
@@ -11,24 +11,24 @@ import Foundation
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
 internal enum L10n {
   internal enum Apples {
-    /// Plural format key: "%#@apples@"
+    /// You have %d apples. Wow that is a lot!
     internal static func count(_ p1: Int) -> String {
-      return L10n.tr("Localizable", "apples.count", p1, fallback: "Plural format key: \"%#@apples@\"")
+      return L10n.tr("Localizable", "apples.count", p1, fallback: "You have %d apples. Wow that is a lot!")
     }
   }
   internal enum Competition {
     internal enum Event {
-      /// Plural format key: "%#@Matches@"
+      /// %ld matches
       internal static func numberOfMatches(_ p1: Int) -> String {
-        return L10n.tr("Localizable", "competition.event.number-of-matches", p1, fallback: "Plural format key: \"%#@Matches@\"")
+        return L10n.tr("Localizable", "competition.event.number-of-matches", p1, fallback: "%ld matches")
       }
     }
   }
   internal enum Feed {
     internal enum Subscription {
-      /// Plural format key: "%#@Subscriptions@"
+      /// %ld subscriptions
       internal static func count(_ p1: Int) -> String {
-        return L10n.tr("Localizable", "feed.subscription.count", p1, fallback: "Plural format key: \"%#@Subscriptions@\"")
+        return L10n.tr("Localizable", "feed.subscription.count", p1, fallback: "%ld subscriptions")
       }
     }
   }

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-advanced.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-advanced.swift
@@ -13,48 +13,48 @@ internal enum L10n {
   internal enum Many {
     internal enum Placeholders {
       internal enum Plurals {
-        /// Plural format key: "%@ - %#@d2@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@"
+        /// %d twos
         internal static func base(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Any, _ p9: Int, _ p10: Float) -> String {
-          return L10n.tr("LocPluralAdvanced", "many.placeholders.plurals.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), String(describing: p8), p9, p10, fallback: "Plural format key: \"%@ - %#@d2@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@\"")
+          return L10n.tr("LocPluralAdvanced", "many.placeholders.plurals.base", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), String(describing: p8), p9, p10, fallback: "%d twos")
         }
-        /// Plural format key: "%@ - %#@d2@ - %0$#@zero@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@"
+        /// %d twos
         internal static func zero(_ p1: Any, _ p2: Int, _ p3: Float, _ p4: Float, _ p5: Int, _ p6: Int, _ p7: Any, _ p8: Any, _ p9: Int, _ p10: Float) -> String {
-          return L10n.tr("LocPluralAdvanced", "many.placeholders.plurals.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), String(describing: p8), p9, p10, fallback: "Plural format key: \"%@ - %#@d2@ - %0$#@zero@ - %#@f3@ - %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@\"")
+          return L10n.tr("LocPluralAdvanced", "many.placeholders.plurals.zero", String(describing: p1), p2, p3, p4, p5, p6, String(describing: p7), String(describing: p8), p9, p10, fallback: "%d twos")
         }
       }
     }
   }
   internal enum Mixed {
     internal enum PlaceholdersAndVariables {
-      /// Plural format key: "%1$@ %3$#@has_rating@"
+      /// has %d ratings
       internal static func positionalstringPositional3int(_ p1: Any, _ p2: Int) -> String {
-        return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.positionalstring-positional3int", String(describing: p1), p2, fallback: "Plural format key: \"%1$@ %3$#@has_rating@\"")
+        return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.positionalstring-positional3int", String(describing: p1), p2, fallback: "has %d ratings")
       }
-      /// Plural format key: "%@ %#@has_rating@"
+      /// has %d ratings
       internal static func stringInt(_ p1: Any, _ p2: Int) -> String {
-        return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-int", String(describing: p1), p2, fallback: "Plural format key: \"%@ %#@has_rating@\"")
+        return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-int", String(describing: p1), p2, fallback: "has %d ratings")
       }
-      /// Plural format key: "%@ %2$#@has_rating@"
+      /// has %d ratings
       internal static func stringPositional2int(_ p1: Any, _ p2: Int) -> String {
-        return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-positional2int", String(describing: p1), p2, fallback: "Plural format key: \"%@ %2$#@has_rating@\"")
+        return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-positional2int", String(describing: p1), p2, fallback: "has %d ratings")
       }
-      /// Plural format key: "%@ %3$#@has_rating@"
+      /// has %d ratings
       internal static func stringPositional3int(_ p1: Any, _ p2: Int) -> String {
-        return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-positional3int", String(describing: p1), p2, fallback: "Plural format key: \"%@ %3$#@has_rating@\"")
+        return L10n.tr("LocPluralAdvanced", "mixed.placeholders-and-variables.string-positional3int", String(describing: p1), p2, fallback: "has %d ratings")
       }
     }
   }
   internal enum Multiple {
     internal enum PlaceholdersAndVariables {
-      /// Plural format key: "Your %3$@ list contains %1$#@first@ %2$@."
+      /// %1$d items. You should buy them
       internal static func intStringString(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
-        return L10n.tr("LocPluralAdvanced", "multiple.placeholders-and-variables.int-string-string", p1, String(describing: p2), String(describing: p3), fallback: "Plural format key: \"Your %3$@ list contains %1$#@first@ %2$@.\"")
+        return L10n.tr("LocPluralAdvanced", "multiple.placeholders-and-variables.int-string-string", p1, String(describing: p2), String(describing: p3), fallback: "%1$d items. You should buy them")
       }
     }
     internal enum Variables {
-      /// Plural format key: "%#@files@ (%#@bytes@, %#@minutes@)"
+      /// %d files remaining
       internal static func threeVariablesInFormatkey(_ p1: Int, _ p2: Int, _ p3: Int) -> String {
-        return L10n.tr("LocPluralAdvanced", "multiple.variables.three-variables-in-formatkey", p1, p2, p3, fallback: "Plural format key: \"%#@files@ (%#@bytes@, %#@minutes@)\"")
+        return L10n.tr("LocPluralAdvanced", "multiple.variables.three-variables-in-formatkey", p1, p2, p3, fallback: "%d files remaining")
       }
     }
   }

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-same-table.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-same-table.swift
@@ -31,9 +31,9 @@ internal enum L10n {
     return L10n.tr("Localizable", "types", String(describing: p1), p2, p3, p4, p5, Int(bitPattern: p6), fallback: "Object: '%@', Character: '%c', Integer: '%d', Float: '%f', CString: '%s', Pointer: '%p'")
   }
   internal enum Apples {
-    /// Plural format key: "%#@apples@"
+    /// You have %d apples. Wow that is a lot!
     internal static func count(_ p1: Int) -> String {
-      return L10n.tr("Localizable", "apples.count", p1, fallback: "Plural format key: \"%#@apples@\"")
+      return L10n.tr("Localizable", "apples.count", p1, fallback: "You have %d apples. Wow that is a lot!")
     }
   }
   internal enum Bananas {
@@ -44,17 +44,17 @@ internal enum L10n {
   }
   internal enum Competition {
     internal enum Event {
-      /// Plural format key: "%#@Matches@"
+      /// %ld matches
       internal static func numberOfMatches(_ p1: Int) -> String {
-        return L10n.tr("Localizable", "competition.event.number-of-matches", p1, fallback: "Plural format key: \"%#@Matches@\"")
+        return L10n.tr("Localizable", "competition.event.number-of-matches", p1, fallback: "%ld matches")
       }
     }
   }
   internal enum Feed {
     internal enum Subscription {
-      /// Plural format key: "%#@Subscriptions@"
+      /// %ld subscriptions
       internal static func count(_ p1: Int) -> String {
-        return L10n.tr("Localizable", "feed.subscription.count", p1, fallback: "Plural format key: \"%#@Subscriptions@\"")
+        return L10n.tr("Localizable", "feed.subscription.count", p1, fallback: "%ld subscriptions")
       }
     }
   }

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-unsupported.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-unsupported.swift
@@ -12,9 +12,9 @@ import Foundation
 internal enum L10n {
   internal enum UnsupportedUse {
     internal enum PlaceholdersInVariableRule {
-      /// Plural format key: "%#@elements@"
+      /// %@ has %d ratings
       internal static func stringInt(_ p1: Int) -> String {
-        return L10n.tr("LocPluralUnsupported", "unsupported-use.placeholders-in-variable-rule.string-int", p1, fallback: "Plural format key: \"%#@elements@\"")
+        return L10n.tr("LocPluralUnsupported", "unsupported-use.placeholders-in-variable-rule.string-int", p1, fallback: "%@ has %d ratings")
       }
     }
   }

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals.swift
@@ -11,24 +11,24 @@ import Foundation
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
 internal enum L10n {
   internal enum Apples {
-    /// Plural format key: "%#@apples@"
+    /// You have %d apples. Wow that is a lot!
     internal static func count(_ p1: Int) -> String {
-      return L10n.tr("Localizable", "apples.count", p1, fallback: "Plural format key: \"%#@apples@\"")
+      return L10n.tr("Localizable", "apples.count", p1, fallback: "You have %d apples. Wow that is a lot!")
     }
   }
   internal enum Competition {
     internal enum Event {
-      /// Plural format key: "%#@Matches@"
+      /// %ld matches
       internal static func numberOfMatches(_ p1: Int) -> String {
-        return L10n.tr("Localizable", "competition.event.number-of-matches", p1, fallback: "Plural format key: \"%#@Matches@\"")
+        return L10n.tr("Localizable", "competition.event.number-of-matches", p1, fallback: "%ld matches")
       }
     }
   }
   internal enum Feed {
     internal enum Subscription {
-      /// Plural format key: "%#@Subscriptions@"
+      /// %ld subscriptions
       internal static func count(_ p1: Int) -> String {
-        return L10n.tr("Localizable", "feed.subscription.count", p1, fallback: "Plural format key: \"%#@Subscriptions@\"")
+        return L10n.tr("Localizable", "feed.subscription.count", p1, fallback: "%ld subscriptions")
       }
     }
   }

--- a/Sources/TestUtils/Fixtures/StencilContexts/Strings/plurals-advanced.yaml
+++ b/Sources/TestUtils/Fixtures/StencilContexts/Strings/plurals-advanced.yaml
@@ -7,8 +7,7 @@ tables:
           strings:
           - key: "many.placeholders.plurals.base"
             name: "base"
-            translation: "Plural format key: \"%@ - %#@d2@ - %#@f3@ - %5$#@d5@ - %04$#@f4@
-              - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@ - %9$@ - %10$#@d10@\""
+            translation: "%d twos"
             types:
             - "String"
             - "Int"
@@ -22,9 +21,7 @@ tables:
             - "Float"
           - key: "many.placeholders.plurals.zero"
             name: "zero"
-            translation: "Plural format key: \"%@ - %#@d2@ - %0$#@zero@ - %#@f3@ -
-              %5$#@d5@ - %04$#@f4@ - %6$#@d6@ - %007$@ - %8$3.2#@f8@ - %11$#@f11@
-              - %9$@ - %10$#@d10@\""
+            translation: "%d twos"
             types:
             - "String"
             - "Int"
@@ -43,25 +40,25 @@ tables:
         strings:
         - key: "mixed.placeholders-and-variables.positionalstring-positional3int"
           name: "positionalstring-positional3int"
-          translation: "Plural format key: \"%1$@ %3$#@has_rating@\""
+          translation: "has %d ratings"
           types:
           - "String"
           - "Int"
         - key: "mixed.placeholders-and-variables.string-int"
           name: "string-int"
-          translation: "Plural format key: \"%@ %#@has_rating@\""
+          translation: "has %d ratings"
           types:
           - "String"
           - "Int"
         - key: "mixed.placeholders-and-variables.string-positional2int"
           name: "string-positional2int"
-          translation: "Plural format key: \"%@ %2$#@has_rating@\""
+          translation: "has %d ratings"
           types:
           - "String"
           - "Int"
         - key: "mixed.placeholders-and-variables.string-positional3int"
           name: "string-positional3int"
-          translation: "Plural format key: \"%@ %3$#@has_rating@\""
+          translation: "has %d ratings"
           types:
           - "String"
           - "Int"
@@ -71,7 +68,7 @@ tables:
         strings:
         - key: "multiple.placeholders-and-variables.int-string-string"
           name: "int-string-string"
-          translation: "Plural format key: \"Your %3$@ list contains %1$#@first@ %2$@.\""
+          translation: "%1$d items. You should buy them"
           types:
           - "Int"
           - "String"
@@ -80,7 +77,7 @@ tables:
         strings:
         - key: "multiple.variables.three-variables-in-formatkey"
           name: "three-variables-in-formatkey"
-          translation: "Plural format key: \"%#@files@ (%#@bytes@, %#@minutes@)\""
+          translation: "%d files remaining"
           types:
           - "Int"
           - "Int"

--- a/Sources/TestUtils/Fixtures/StencilContexts/Strings/plurals-same-table.yaml
+++ b/Sources/TestUtils/Fixtures/StencilContexts/Strings/plurals-same-table.yaml
@@ -5,7 +5,7 @@ tables:
       strings:
       - key: "apples.count"
         name: "count"
-        translation: "Plural format key: \"%#@apples@\""
+        translation: "You have %d apples. Wow that is a lot!"
         types:
         - "Int"
     - name: "bananas"
@@ -22,7 +22,7 @@ tables:
         strings:
         - key: "competition.event.number-of-matches"
           name: "number-of-matches"
-          translation: "Plural format key: \"%#@Matches@\""
+          translation: "%ld matches"
           types:
           - "Int"
       name: "competition"
@@ -31,7 +31,7 @@ tables:
         strings:
         - key: "feed.subscription.count"
           name: "count"
-          translation: "Plural format key: \"%#@Subscriptions@\""
+          translation: "%ld subscriptions"
           types:
           - "Int"
       name: "feed"

--- a/Sources/TestUtils/Fixtures/StencilContexts/Strings/plurals-unsupported.yaml
+++ b/Sources/TestUtils/Fixtures/StencilContexts/Strings/plurals-unsupported.yaml
@@ -6,7 +6,7 @@ tables:
         strings:
         - key: "unsupported-use.placeholders-in-variable-rule.string-int"
           name: "string-int"
-          translation: "Plural format key: \"%#@elements@\""
+          translation: "%@ has %d ratings"
           types:
           - "Int"
       name: "unsupported-use"

--- a/Sources/TestUtils/Fixtures/StencilContexts/Strings/plurals.yaml
+++ b/Sources/TestUtils/Fixtures/StencilContexts/Strings/plurals.yaml
@@ -5,7 +5,7 @@ tables:
       strings:
       - key: "apples.count"
         name: "count"
-        translation: "Plural format key: \"%#@apples@\""
+        translation: "You have %d apples. Wow that is a lot!"
         types:
         - "Int"
     - children:
@@ -13,7 +13,7 @@ tables:
         strings:
         - key: "competition.event.number-of-matches"
           name: "number-of-matches"
-          translation: "Plural format key: \"%#@Matches@\""
+          translation: "%ld matches"
           types:
           - "Int"
       name: "competition"
@@ -22,7 +22,7 @@ tables:
         strings:
         - key: "feed.subscription.count"
           name: "count"
-          translation: "Plural format key: \"%#@Subscriptions@\""
+          translation: "%ld subscriptions"
           types:
           - "Int"
       name: "feed"


### PR DESCRIPTION
* [x] I've started my branch from the `develop` branch (gitflow)
  * [x] And I've selected `develop` as the "base" branch for this Pull Request I'm about to create
* [x] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself  
      _(or added `#trivial` to the PR title if I think it doesn't warrant a mention in the CHANGELOG)_
  * [x] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
  * [x] Add a period and 2 spaces at the end of your short entry description
  * [x] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

Currently, SwiftGen, when parsing `.stringdict` for earch entry generates "translation" in format ```/// Plural format key: "%#@apples@"```, which is a bit confusing.  Since for other files i.e. `.strings`, real translation will be included.  

So this PR changes what will be returned in the `Strings.Entry`. Now, real translation will go to the translation, and additional optional parameter `formatKey` added for the cases, if formatKey needed for the templates (i.e. in comments)

