### PR TITLE
Fix structured-swift5 template when having the Type keyword in a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ _None_
 * Templates: added `// swiftlint:enable all` to the bottom of templates to fix [warning](https://github.com/realm/SwiftLint/pull/4731) introduced by SwiftLint [0.51.0](https://github.com/realm/SwiftLint/releases/tag/0.51.0).  
  [Zev Eisenberg](https://github.com/ZevEisenberg)
  [#1054](https://github.com/SwiftGen/pull/1054)
+* Templates: Fix the way we escpe the `type` keyword in strings using the `structured-swift5.stencil` template. It's now `_Type` instead of `` `Type` ``.  
+  [qeude](https://github.com/qeude)
+  [#1131](https://github.com/SwiftGen/SwiftGen/pull/1131)
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ _None_
 * Templates: added `// swiftlint:enable all` to the bottom of templates to fix [warning](https://github.com/realm/SwiftLint/pull/4731) introduced by SwiftLint [0.51.0](https://github.com/realm/SwiftLint/releases/tag/0.51.0).  
  [Zev Eisenberg](https://github.com/ZevEisenberg)
  [#1054](https://github.com/SwiftGen/pull/1054)
-* Templates: Fix the way we escpe the `type` keyword in strings using the `structured-swift5.stencil` template. It's now `_Type` instead of `` `Type` ``.  
+* Templates: Fix the way we escape the `type` keyword in strings using the `structured-swift5.stencil` template. It's now `_Type` instead of `` `Type` ``.  
   [qeude](https://github.com/qeude)
   [#1131](https://github.com/SwiftGen/SwiftGen/pull/1131)
 

--- a/Sources/SwiftGenCLI/templates/strings/structured-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/structured-swift5.stencil
@@ -50,9 +50,15 @@ import Foundation
   {% endif %}
   {% endfor %}
   {% for child in item.children %}
+  {% if child.name == "type" %}
+  {{accessModifier}} enum _{{child.name|swiftIdentifier:"pretty"}} {
+    {% filter indent:2 %}{% call recursiveBlock table child %}{% endfilter %}
+  }
+  {% else %}
   {{accessModifier}} enum {{child.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
     {% filter indent:2," ",true %}{% call recursiveBlock table child %}{% endfilter %}
   }
+  {% endif %}
   {% endfor %}
 {% endmacro %}
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length


### PR DESCRIPTION
* [x] I've started my branch from the `develop` branch (gitflow)
  * [x] And I've selected `develop` as the "base" branch for this Pull Request I'm about to create
* [x] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself  
      _(or added `#trivial` to the PR title if I think it doesn't warrant a mention in the CHANGELOG)_
  * [x] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
  * [x] Add a period and 2 spaces at the end of your short entry description
  * [x] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

👋 Hey,

I was using SwiftGen for strings and I realized that there is a bug when having a string key containing `type` as a keyword such as this one `dashboard.item.type.item`. It creates a `` enum `Type` `` but for some reason that seems to come from a Swift bug, it's not usable with `` L10n.Dashboard.Item.`Type`.item `` as it ends up with a compiler error.

To fix that, I added a condition in the `structured-swift5.stencil` so the `type` keyword is handled as a number would be. That way we would have `enum _Type` instead which works as expected. With this fix, we would have to use the previous example this way ` L10n.Dashboard.Item._Type.item`.

I know this might not seem like the best solution, but as it seems to be a Swift bug, I don't think we have another option.