### PR TITLE
Fix strings parser to prevent wrong matching with percent sign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ _None_
 * Templates: added `// swiftlint:enable all` to the bottom of templates to fix [warning](https://github.com/realm/SwiftLint/pull/4731) introduced by SwiftLint [0.51.0](https://github.com/realm/SwiftLint/releases/tag/0.51.0).  
  [Zev Eisenberg](https://github.com/ZevEisenberg)
  [#1054](https://github.com/SwiftGen/pull/1054)
-* Srings parser: Fix regex to avoid matching placeholders with space such as `% i`
+* Srings parser: Fix regex to avoid matching placeholders with space such as `% i`  
   [qeude](https://github.com/qeude)
   [#1132](https://github.com/SwiftGen/SwiftGen/pull/1132)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ _None_
 * Templates: added `// swiftlint:enable all` to the bottom of templates to fix [warning](https://github.com/realm/SwiftLint/pull/4731) introduced by SwiftLint [0.51.0](https://github.com/realm/SwiftLint/releases/tag/0.51.0).  
  [Zev Eisenberg](https://github.com/ZevEisenberg)
  [#1054](https://github.com/SwiftGen/pull/1054)
+* Srings parser: Fix regex to avoid matching placeholders with space such as `% i`
+  [qeude](https://github.com/qeude)
+  [#1132](https://github.com/SwiftGen/SwiftGen/pull/1132)
 
 ### Internal Changes
 

--- a/Sources/SwiftGenKit/Parsers/Strings/PlaceholderType.swift
+++ b/Sources/SwiftGenKit/Parsers/Strings/PlaceholderType.swift
@@ -48,7 +48,7 @@ extension Strings.PlaceholderType {
     // like in "%3$" to make positional specifiers
     let position = "(\\d+\\$)?"
     // precision like in "%1.2f"
-    let precision = "[-+# 0]?\\d?(?:\\.\\d)?"
+    let precision = "[-+#0]?\\d?(?:\\.\\d)?"
 
     do {
       return try NSRegularExpression(


### PR DESCRIPTION
* [x] I've started my branch from the `develop` branch (gitflow)
  * [x] And I've selected `develop` as the "base" branch for this Pull Request I'm about to create
* [x] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself  
      _(or added `#trivial` to the PR title if I think it doesn't warrant a mention in the CHANGELOG)_
  * [x] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
  * [x] Add a period and 2 spaces at the end of your short entry description
  * [x] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

👋 Hey,

I recently faced a bug with the pattern matching for placeholders in strings in such string
```
The remaining % is you.
```
the `% i` is parsed as a variable while it shouldn't be.
I changed the regex that matches that case so it doesn't do that weird behavior anymore
