### PR TITLE
Add a workaround to percent sign handling in templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ _None_
 * Templates: added `// swiftlint:enable all` to the bottom of templates to fix [warning](https://github.com/realm/SwiftLint/pull/4731) introduced by SwiftLint [0.51.0](https://github.com/realm/SwiftLint/releases/tag/0.51.0).  
  [Zev Eisenberg](https://github.com/ZevEisenberg)
  [#1054](https://github.com/SwiftGen/pull/1054)
+* Templates: Add a workaround to handle a percent sign [Swift bug](https://github.com/SwiftGen/SwiftGen/issues/859) with `String(format:)` that hasn't been addressed for a while now.  
+  [qeude](https://github.com/qeude)
+  [#1133](https://github.com/SwiftGen/SwiftGen/pull/1133)
 
 ### Internal Changes
 

--- a/Sources/SwiftGenCLI/templates/strings/flat-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/flat-swift4.stencil
@@ -78,7 +78,7 @@ extension {{enumName}} {
     let format = {{param.bundle|default:"BundleToken.bundle"}}.localizedString(forKey: key, value: value, table: table)
     {% endif %}
     // Workaround for https://github.com/SwiftGen/SwiftGen/issues/859
-    let regex = try! NSRegularExpression(pattern: "(?<!%)%( |\.|$)")
+    let regex = try! NSRegularExpression(pattern: "(?<!%)%( |\\.|$)")
     let range = NSRange(location: 0, length: format.utf16.count)
     let result = regex.stringByReplacingMatches(in: format, options: [], range: range, withTemplate: "%%$1")
     return String(format: result, locale: Locale.current, arguments: args)

--- a/Sources/SwiftGenCLI/templates/strings/flat-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/flat-swift4.stencil
@@ -77,7 +77,11 @@ extension {{enumName}} {
     {% else %}
     let format = {{param.bundle|default:"BundleToken.bundle"}}.localizedString(forKey: key, value: value, table: table)
     {% endif %}
-    return String(format: format, locale: Locale.current, arguments: args)
+    // Workaround for https://github.com/SwiftGen/SwiftGen/issues/859
+    let regex = try! NSRegularExpression(pattern: "(?<!%)%( |\.|$)")
+    let range = NSRange(location: 0, length: format.utf16.count)
+    let result = regex.stringByReplacingMatches(in: format, options: [], range: range, withTemplate: "%%$1")
+    return String(format: result, locale: Locale.current, arguments: args)
   }
 }
 {% if not param.bundle and not param.lookupFunction %}

--- a/Sources/SwiftGenCLI/templates/strings/flat-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/flat-swift4.stencil
@@ -78,7 +78,7 @@ extension {{enumName}} {
     let format = {{param.bundle|default:"BundleToken.bundle"}}.localizedString(forKey: key, value: value, table: table)
     {% endif %}
     // Workaround for https://github.com/SwiftGen/SwiftGen/issues/859
-    let regex = try! NSRegularExpression(pattern: "(?<!%)%( |\\.|$)")
+    let regex = try! NSRegularExpression(pattern: "(?<!%)%(?!%|d|i|u|f|@|[0-9])")
     let range = NSRange(location: 0, length: format.utf16.count)
     let result = regex.stringByReplacingMatches(in: format, options: [], range: range, withTemplate: "%%$1")
     return String(format: result, locale: Locale.current, arguments: args)

--- a/Sources/SwiftGenCLI/templates/strings/flat-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/flat-swift5.stencil
@@ -78,7 +78,7 @@ extension {{enumName}} {
     let format = {{param.bundle|default:"BundleToken.bundle"}}.localizedString(forKey: key, value: value, table: table)
     {% endif %}
     // Workaround for https://github.com/SwiftGen/SwiftGen/issues/859
-    let regex = try! NSRegularExpression(pattern: "(?<!%)%( |\.|$)")
+    let regex = try! NSRegularExpression(pattern: "(?<!%)%( |\\.|$)")
     let range = NSRange(location: 0, length: format.utf16.count)
     let result = regex.stringByReplacingMatches(in: format, options: [], range: range, withTemplate: "%%$1")
     return String(format: result, locale: Locale.current, arguments: args)

--- a/Sources/SwiftGenCLI/templates/strings/flat-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/flat-swift5.stencil
@@ -77,7 +77,11 @@ extension {{enumName}} {
     {% else %}
     let format = {{param.bundle|default:"BundleToken.bundle"}}.localizedString(forKey: key, value: value, table: table)
     {% endif %}
-    return String(format: format, locale: Locale.current, arguments: args)
+    // Workaround for https://github.com/SwiftGen/SwiftGen/issues/859
+    let regex = try! NSRegularExpression(pattern: "(?<!%)%( |\.|$)")
+    let range = NSRange(location: 0, length: format.utf16.count)
+    let result = regex.stringByReplacingMatches(in: format, options: [], range: range, withTemplate: "%%$1")
+    return String(format: result, locale: Locale.current, arguments: args)
   }
 }
 {% if not param.bundle and not param.lookupFunction %}

--- a/Sources/SwiftGenCLI/templates/strings/flat-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/flat-swift5.stencil
@@ -78,7 +78,7 @@ extension {{enumName}} {
     let format = {{param.bundle|default:"BundleToken.bundle"}}.localizedString(forKey: key, value: value, table: table)
     {% endif %}
     // Workaround for https://github.com/SwiftGen/SwiftGen/issues/859
-    let regex = try! NSRegularExpression(pattern: "(?<!%)%( |\\.|$)")
+    let regex = try! NSRegularExpression(pattern: "(?<!%)%(?!%|d|i|u|f|@|[0-9])")
     let range = NSRange(location: 0, length: format.utf16.count)
     let result = regex.stringByReplacingMatches(in: format, options: [], range: range, withTemplate: "%%$1")
     return String(format: result, locale: Locale.current, arguments: args)

--- a/Sources/SwiftGenCLI/templates/strings/structured-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/structured-swift4.stencil
@@ -82,7 +82,7 @@ extension {{enumName}} {
     let format = {{param.bundle|default:"BundleToken.bundle"}}.localizedString(forKey: key, value: value, table: table)
     {% endif %}
     // Workaround for https://github.com/SwiftGen/SwiftGen/issues/859
-    let regex = try! NSRegularExpression(pattern: "(?<!%)%( |\.|$)")
+    let regex = try! NSRegularExpression(pattern: "(?<!%)%( |\\.|$)")
     let range = NSRange(location: 0, length: format.utf16.count)
     let result = regex.stringByReplacingMatches(in: format, options: [], range: range, withTemplate: "%%$1")
     return String(format: result, locale: Locale.current, arguments: args)

--- a/Sources/SwiftGenCLI/templates/strings/structured-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/structured-swift4.stencil
@@ -81,7 +81,11 @@ extension {{enumName}} {
     {% else %}
     let format = {{param.bundle|default:"BundleToken.bundle"}}.localizedString(forKey: key, value: value, table: table)
     {% endif %}
-    return String(format: format, locale: Locale.current, arguments: args)
+    // Workaround for https://github.com/SwiftGen/SwiftGen/issues/859
+    let regex = try! NSRegularExpression(pattern: "(?<!%)%( |\.|$)")
+    let range = NSRange(location: 0, length: format.utf16.count)
+    let result = regex.stringByReplacingMatches(in: format, options: [], range: range, withTemplate: "%%$1")
+    return String(format: result, locale: Locale.current, arguments: args)
   }
 }
 {% if not param.bundle and not param.lookupFunction %}

--- a/Sources/SwiftGenCLI/templates/strings/structured-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/structured-swift4.stencil
@@ -82,7 +82,7 @@ extension {{enumName}} {
     let format = {{param.bundle|default:"BundleToken.bundle"}}.localizedString(forKey: key, value: value, table: table)
     {% endif %}
     // Workaround for https://github.com/SwiftGen/SwiftGen/issues/859
-    let regex = try! NSRegularExpression(pattern: "(?<!%)%( |\\.|$)")
+    let regex = try! NSRegularExpression(pattern: "(?<!%)%(?!%|d|i|u|f|@|[0-9])")
     let range = NSRange(location: 0, length: format.utf16.count)
     let result = regex.stringByReplacingMatches(in: format, options: [], range: range, withTemplate: "%%$1")
     return String(format: result, locale: Locale.current, arguments: args)

--- a/Sources/SwiftGenCLI/templates/strings/structured-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/structured-swift5.stencil
@@ -82,7 +82,7 @@ extension {{enumName}} {
     let format = {{param.bundle|default:"BundleToken.bundle"}}.localizedString(forKey: key, value: value, table: table)
     {% endif %}
     // Workaround for https://github.com/SwiftGen/SwiftGen/issues/859
-    let regex = try! NSRegularExpression(pattern: "(?<!%)%( |\.|$)")
+    let regex = try! NSRegularExpression(pattern: "(?<!%)%( |\\.|$)")
     let range = NSRange(location: 0, length: format.utf16.count)
     let result = regex.stringByReplacingMatches(in: format, options: [], range: range, withTemplate: "%%$1")
     return String(format: result, locale: Locale.current, arguments: args)

--- a/Sources/SwiftGenCLI/templates/strings/structured-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/structured-swift5.stencil
@@ -81,7 +81,11 @@ extension {{enumName}} {
     {% else %}
     let format = {{param.bundle|default:"BundleToken.bundle"}}.localizedString(forKey: key, value: value, table: table)
     {% endif %}
-    return String(format: format, locale: Locale.current, arguments: args)
+    // Workaround for https://github.com/SwiftGen/SwiftGen/issues/859
+    let regex = try! NSRegularExpression(pattern: "(?<!%)%( |\.|$)")
+    let range = NSRange(location: 0, length: format.utf16.count)
+    let result = regex.stringByReplacingMatches(in: format, options: [], range: range, withTemplate: "%%$1")
+    return String(format: result, locale: Locale.current, arguments: args)
   }
 }
 {% if not param.bundle and not param.lookupFunction %}

--- a/Sources/SwiftGenCLI/templates/strings/structured-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/structured-swift5.stencil
@@ -82,7 +82,7 @@ extension {{enumName}} {
     let format = {{param.bundle|default:"BundleToken.bundle"}}.localizedString(forKey: key, value: value, table: table)
     {% endif %}
     // Workaround for https://github.com/SwiftGen/SwiftGen/issues/859
-    let regex = try! NSRegularExpression(pattern: "(?<!%)%( |\\.|$)")
+    let regex = try! NSRegularExpression(pattern: "(?<!%)%(?!%|d|i|u|f|@|[0-9])")
     let range = NSRange(location: 0, length: format.utf16.count)
     let result = regex.stringByReplacingMatches(in: format, options: [], range: range, withTemplate: "%%$1")
     return String(format: result, locale: Locale.current, arguments: args)


### PR DESCRIPTION
* [x] I've started my branch from the `develop` branch (gitflow)
  * [x] And I've selected `develop` as the "base" branch for this Pull Request I'm about to create
* [x] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself  
      _(or added `#trivial` to the PR title if I think it doesn't warrant a mention in the CHANGELOG)_
  * [x] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
  * [x] Add a period and 2 spaces at the end of your short entry description
  * [x] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

👋 Hey,

There is a Swift issue regarding the handling of percentages [here](https://github.com/SwiftGen/SwiftGen/issues/859)
It would be great to add a workaround for this as this is a common pattern, and it can be hard to solve without such a workaround (eg: if you share strings between iOS and Android).

Basically, this workaround is matching `%` that is alone in the string (which means we just want to use them as `%` sign and not placeholder) and double them to escape them.
