### PR TITLE
Strings: Plural with positional parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ _None_
 
 ### New Features
 
-_None_
+* Strings: added support for plural with positional parameters.  
+  [Arnaud Dorgans](https://github.com/arnauddorgans)
+  [#1147](https://github.com/SwiftGen/SwiftGen/pull/1147)
 
 ### Bug Fixes
 

--- a/Documentation/Parsers/strings.md
+++ b/Documentation/Parsers/strings.md
@@ -137,6 +137,33 @@ This example should cover the most common use case of plurals that is also suppo
 
 <details>
 
+<summary>Placeholders with positional arguments that are only used in the variables but not in the format key</summary>
+
+```xml
+<key>multiple.placeholders-and-variables.positionalstring-positional2int</key>
+<dict>
+    <key>NSStringLocalizedFormatKey</key>
+    <string>%#@elements@</string>
+    <key>elements</key>
+    <dict>
+        <key>NSStringFormatSpecTypeKey</key>
+        <string>NSStringPluralRuleType</string>
+        <key>NSStringFormatValueTypeKey</key>
+        <string>d</string>
+        <key>zero</key>
+        <string>%1$@ has no rating</string>
+        <key>one</key>
+        <string>%1$@ has one rating</string>
+        <key>other</key>
+        <string>%1$@ has %2$d ratings</string>
+    </dict>
+</dict>
+```
+
+</details>
+
+<details>
+
 <summary>Multiple variables in format key</summary>
 
 ```xml

--- a/Sources/SwiftGenKit/Parsers/Strings/FileTypeParser/StringsDictFileParser.swift
+++ b/Sources/SwiftGenKit/Parsers/Strings/FileTypeParser/StringsDictFileParser.swift
@@ -36,9 +36,7 @@ extension Strings {
           return Entry(
             key: key,
             translation: "Plural format key: \"\(pluralEntry.formatKey)\"",
-            types: try PlaceholderType.placeholderTypes(
-              fromFormat: pluralEntry.formatKeyWithVariableValueTypes
-            ),
+            types: try pluralEntry.placeholderTypes(),
             keyStructureSeparator: options[Option.separator]
           )
         }

--- a/Sources/SwiftGenKit/Parsers/Strings/PlaceholderType.swift
+++ b/Sources/SwiftGenKit/Parsers/Strings/PlaceholderType.swift
@@ -64,10 +64,18 @@ extension Strings.PlaceholderType {
   ///
   /// Example: "I give %d apples to %@" --> [.int, .string]
   static func placeholderTypes(fromFormat formatString: String) throws -> [Strings.PlaceholderType] {
+    let chars = placeholderChars(fromFormat: formatString)
+    return try placeholderTypes(fromChars: chars)
+  }
+
+  /// Extracts an array of format chars and their optional positional specifier from a format key
+  ///
+  /// Example: "I give %1$d apples to %2$@" --> [("d", 1), ("@", 2)]
+  static func placeholderChars(fromFormat formatString: String) -> [(String, Int?)] {
     let range = NSRange(location: 0, length: (formatString as NSString).length)
 
     // Extract the list of chars (conversion specifiers) and their optional positional specifier
-    let chars = formatTypesRegEx.matches(in: formatString, options: [], range: range)
+    return formatTypesRegEx.matches(in: formatString, options: [], range: range)
       .compactMap { match -> (String, Int?)? in
         let range: NSRange
         if match.range(at: 3).location != NSNotFound {
@@ -94,8 +102,6 @@ extension Strings.PlaceholderType {
           return (char, pos)
         }
       }
-
-    return try placeholderTypes(fromChars: chars)
   }
 
   /// Creates an array of `PlaceholderType` from an array of format chars and their optional positional specifier
@@ -107,7 +113,7 @@ extension Strings.PlaceholderType {
   /// - Parameter chars: An array of format chars and their optional positional specifier
   /// - Throws: `Strings.ParserError.invalidPlaceholder` in case a `PlaceholderType` would be overwritten
   /// - Returns: An array of `PlaceholderType`
-  private static func placeholderTypes(fromChars chars: [(String, Int?)]) throws -> [Strings.PlaceholderType] {
+  static func placeholderTypes(fromChars chars: [(String, Int?)]) throws -> [Strings.PlaceholderType] {
     var list = [Int: Strings.PlaceholderType]()
     var nextNonPositional = 1
 

--- a/Sources/SwiftGenKit/Parsers/Strings/StringsDictEntry.swift
+++ b/Sources/SwiftGenKit/Parsers/Strings/StringsDictEntry.swift
@@ -167,6 +167,40 @@ extension StringsDict {
 }
 
 extension StringsDict.PluralEntry {
+  func placeholderTypes() throws -> [Strings.PlaceholderType] {
+    if let rulesPlaceholderTypes = try placeholderTypesFromRulesWithPosition(), rulesPlaceholderTypes.count > 1 {
+      return rulesPlaceholderTypes
+    }
+    return try Strings.PlaceholderType.placeholderTypes(fromFormat: formatKeyWithVariableValueTypes)
+  }
+
+  func placeholderTypesFromRulesWithPosition() throws -> [Strings.PlaceholderType]? {
+    var chars = [(String, Int)]()
+    for variable in variables {
+      let knownRules = [
+        variable.rule.zero,
+        variable.rule.one,
+        variable.rule.two,
+        variable.rule.few,
+        variable.rule.many,
+        variable.rule.other
+      ].compactMap { $0 }
+
+      for rule in knownRules {
+        let ruleChars = Strings.PlaceholderType.placeholderChars(fromFormat: rule)
+        let ruleCharsWithPositions = ruleChars.compactMap { char, position -> (String, Int)? in
+          guard let position else { return nil }
+          return (char, position)
+        }
+        guard ruleCharsWithPositions.count == ruleChars.count else {
+          return nil // Some placeholders do not have a position
+        }
+        chars.append(contentsOf: ruleCharsWithPositions)
+      }
+    }
+    return try Strings.PlaceholderType.placeholderTypes(fromChars: chars)
+  }
+
   /// Extract the placeholders (`NSStringFormatValueTypeKey`) from the different variable
   /// definitions into a single flattened list of placeholders
   var formatKeyWithVariableValueTypes: String {

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/plurals-advanced.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift4/plurals-advanced.swift
@@ -37,6 +37,10 @@ internal enum L10n {
   internal static func multiplePlaceholdersAndVariablesIntStringString(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
     return L10n.tr("LocPluralAdvanced", "multiple.placeholders-and-variables.int-string-string", p1, String(describing: p2), String(describing: p3), fallback: "Plural format key: \"Your %3$@ list contains %1$#@first@ %2$@.\"")
   }
+  /// Plural format key: "%#@elements@"
+  internal static func multiplePlaceholdersAndVariablesPositionalstringPositional2int(_ p1: Any, _ p2: Int) -> String {
+    return L10n.tr("LocPluralAdvanced", "multiple.placeholders-and-variables.positionalstring-positional2int", String(describing: p1), p2, fallback: "Plural format key: \"%#@elements@\"")
+  }
   /// Plural format key: "%#@files@ (%#@bytes@, %#@minutes@)"
   internal static func multipleVariablesThreeVariablesInFormatkey(_ p1: Int, _ p2: Int, _ p3: Int) -> String {
     return L10n.tr("LocPluralAdvanced", "multiple.variables.three-variables-in-formatkey", p1, p2, p3, fallback: "Plural format key: \"%#@files@ (%#@bytes@, %#@minutes@)\"")

--- a/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/plurals-advanced.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/flat-swift5/plurals-advanced.swift
@@ -37,6 +37,10 @@ internal enum L10n {
   internal static func multiplePlaceholdersAndVariablesIntStringString(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
     return L10n.tr("LocPluralAdvanced", "multiple.placeholders-and-variables.int-string-string", p1, String(describing: p2), String(describing: p3), fallback: "Plural format key: \"Your %3$@ list contains %1$#@first@ %2$@.\"")
   }
+  /// Plural format key: "%#@elements@"
+  internal static func multiplePlaceholdersAndVariablesPositionalstringPositional2int(_ p1: Any, _ p2: Int) -> String {
+    return L10n.tr("LocPluralAdvanced", "multiple.placeholders-and-variables.positionalstring-positional2int", String(describing: p1), p2, fallback: "Plural format key: \"%#@elements@\"")
+  }
   /// Plural format key: "%#@files@ (%#@bytes@, %#@minutes@)"
   internal static func multipleVariablesThreeVariablesInFormatkey(_ p1: Int, _ p2: Int, _ p3: Int) -> String {
     return L10n.tr("LocPluralAdvanced", "multiple.variables.three-variables-in-formatkey", p1, p2, p3, fallback: "Plural format key: \"%#@files@ (%#@bytes@, %#@minutes@)\"")

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/plurals-advanced.h
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-h/plurals-advanced.h
@@ -19,6 +19,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString*)mixedPlaceholdersAndVariablesStringPositional3intWithValues:(id)p1 :(NSInteger)p2;
 /// Plural format key: "Your %3$@ list contains %1$#@first@ %2$@."
 + (NSString*)multiplePlaceholdersAndVariablesIntStringStringWithValues:(NSInteger)p1 :(id)p2 :(id)p3;
+/// Plural format key: "%#@elements@"
++ (NSString*)multiplePlaceholdersAndVariablesPositionalstringPositional2intWithValues:(id)p1 :(NSInteger)p2;
 /// Plural format key: "%#@files@ (%#@bytes@, %#@minutes@)"
 + (NSString*)multipleVariablesThreeVariablesInFormatkeyWithValues:(NSInteger)p1 :(NSInteger)p2 :(NSInteger)p3;
 @end

--- a/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/plurals-advanced.m
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/objc-m/plurals-advanced.m
@@ -54,6 +54,10 @@ static NSString* tr(NSString *tableName, NSString *key, NSString *value, ...) {
 {
     return tr(@"LocPluralAdvanced", @"multiple.placeholders-and-variables.int-string-string", @"Plural format key: \"Your %3$@ list contains %1$#@first@ %2$@.\"", p1, p2, p3);
 }
++ (NSString*)multiplePlaceholdersAndVariablesPositionalstringPositional2intWithValues:(id)p1 :(NSInteger)p2
+{
+    return tr(@"LocPluralAdvanced", @"multiple.placeholders-and-variables.positionalstring-positional2int", @"Plural format key: \"%#@elements@\"", p1, p2);
+}
 + (NSString*)multipleVariablesThreeVariablesInFormatkeyWithValues:(NSInteger)p1 :(NSInteger)p2 :(NSInteger)p3
 {
     return tr(@"LocPluralAdvanced", @"multiple.variables.three-variables-in-formatkey", @"Plural format key: \"%#@files@ (%#@bytes@, %#@minutes@)\"", p1, p2, p3);

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/plurals-advanced.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift4/plurals-advanced.swift
@@ -50,6 +50,10 @@ internal enum L10n {
       internal static func intStringString(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
         return L10n.tr("LocPluralAdvanced", "multiple.placeholders-and-variables.int-string-string", p1, String(describing: p2), String(describing: p3), fallback: "Plural format key: \"Your %3$@ list contains %1$#@first@ %2$@.\"")
       }
+      /// Plural format key: "%#@elements@"
+      internal static func positionalstringPositional2int(_ p1: Any, _ p2: Int) -> String {
+        return L10n.tr("LocPluralAdvanced", "multiple.placeholders-and-variables.positionalstring-positional2int", String(describing: p1), p2, fallback: "Plural format key: \"%#@elements@\"")
+      }
     }
     internal enum Variables {
       /// Plural format key: "%#@files@ (%#@bytes@, %#@minutes@)"

--- a/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-advanced.swift
+++ b/Sources/TestUtils/Fixtures/Generated/Strings/structured-swift5/plurals-advanced.swift
@@ -50,6 +50,10 @@ internal enum L10n {
       internal static func intStringString(_ p1: Int, _ p2: Any, _ p3: Any) -> String {
         return L10n.tr("LocPluralAdvanced", "multiple.placeholders-and-variables.int-string-string", p1, String(describing: p2), String(describing: p3), fallback: "Plural format key: \"Your %3$@ list contains %1$#@first@ %2$@.\"")
       }
+      /// Plural format key: "%#@elements@"
+      internal static func positionalstringPositional2int(_ p1: Any, _ p2: Int) -> String {
+        return L10n.tr("LocPluralAdvanced", "multiple.placeholders-and-variables.positionalstring-positional2int", String(describing: p1), p2, fallback: "Plural format key: \"%#@elements@\"")
+      }
     }
     internal enum Variables {
       /// Plural format key: "%#@files@ (%#@bytes@, %#@minutes@)"

--- a/Sources/TestUtils/Fixtures/Resources/Strings/LocPluralAdvanced.stringsdict
+++ b/Sources/TestUtils/Fixtures/Resources/Strings/LocPluralAdvanced.stringsdict
@@ -93,6 +93,24 @@
 			<string>%1$d items. You should buy them</string>
 		</dict>
 	</dict>
+	<key>multiple.placeholders-and-variables.positionalstring-positional2int</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@elements@</string>
+		<key>elements</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>zero</key>
+			<string>%1$@ has no rating</string>
+			<key>one</key>
+			<string>%1$@ has one rating</string>
+			<key>other</key>
+			<string>%1$@ has %2$d ratings</string>
+		</dict>
+	</dict>
 	<key>multiple.variables.three-variables-in-formatkey</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Sources/TestUtils/Fixtures/StencilContexts/Strings/plurals-advanced.yaml
+++ b/Sources/TestUtils/Fixtures/StencilContexts/Strings/plurals-advanced.yaml
@@ -76,6 +76,12 @@ tables:
           - "Int"
           - "String"
           - "String"
+        - key: "multiple.placeholders-and-variables.positionalstring-positional2int"
+          name: "positionalstring-positional2int"
+          translation: "Plural format key: \"%#@elements@\""
+          types:
+          - "String"
+          - "Int"
       - name: "variables"
         strings:
         - key: "multiple.variables.three-variables-in-formatkey"


### PR DESCRIPTION
# Strings: Plural with positional parameters

Add support for plural with positional parameters
Use case: Plural strings exported using [Lokalise](https://app.lokalise.com/) with multiple parameters

<img width="664" alt="Screenshot 2025-04-09 at 20 09 14" src="https://github.com/user-attachments/assets/f97534e4-4472-4ffd-832a-a55a32770d68" />

Will be generated as

```swift
/// Plural format key: "%#@format@"
public static func testPluralWithParameters(_ p1: Int, _ p2: String) -> L10n {
  return L10n("Localizable", "testPluralWithParameters", p1, p2, fallback: "Plural format key: \"%#@format@\"")
}
```

Instead of
```swift
/// Plural format key: "%#@format@"
public static func testPluralWithParameters(_ p1: Int) -> L10n {
  return L10n("Localizable", "testPluralWithParameters", p1, fallback: "Plural format key: \"%#@format@\"")
}
```

Will also fix this issue https://github.com/SwiftGen/SwiftGen/issues/1137

---

* [X] I've started my branch from the `develop` branch (gitflow)
  * [X] And I've selected `develop` as the "base" branch for this Pull Request I'm about to create
* [X] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself  
      _(or added `#trivial` to the PR title if I think it doesn't warrant a mention in the CHANGELOG)_
  * [X] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
  * [X] Add a period and 2 spaces at the end of your short entry description
  * [X] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description