### PR TITLE
Fixed an issue with error logs in Xcode console during register custom variable fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ _None_
 * Templates: added `// swiftlint:enable all` to the bottom of templates to fix [warning](https://github.com/realm/SwiftLint/pull/4731) introduced by SwiftLint [0.51.0](https://github.com/realm/SwiftLint/releases/tag/0.51.0).  
  [Zev Eisenberg](https://github.com/ZevEisenberg)
  [#1054](https://github.com/SwiftGen/pull/1054)
+* Templates: fonts generate an issue with error logs in Xcode console during register custom variable fonts
+  [Christoph Giesenhagen](https://github.com/AF-cgi)
 
 ### Internal Changes
 

--- a/Sources/SwiftGenCLI/templates/fonts/swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/fonts/swift4.stencil
@@ -39,7 +39,12 @@
   {% endfor %}
   {{accessModifier}} static let allCustomFonts: [{{fontType}}] = [{% for family in families %}{{family.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}.all{{ ", " if not forloop.last }}{% endfor %}].flatMap { $0 }
   {{accessModifier}} static func registerAllCustomFonts() {
-    allCustomFonts.forEach { $0.register() }
+    let uniqueCustomFonts = allCustomFonts.reduce(into: []) { partialResult, fontConvertible in
+      if !partialResult.contains(where: { $0.path == fontConvertible.path }) {
+        partialResult.append(fontConvertible)
+      }
+    }
+    uniqueCustomFonts.forEach { $0.register() }
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length
@@ -108,4 +113,3 @@ private final class BundleToken {
 {% else %}
 // No fonts found
 {% endif %}
-// swiftlint:enable all

--- a/Sources/SwiftGenCLI/templates/fonts/swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/fonts/swift5.stencil
@@ -40,7 +40,12 @@
   {% endfor %}
   {{accessModifier}} static let allCustomFonts: [{{fontType}}] = [{% for family in families %}{{family.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}.all{{ ", " if not forloop.last }}{% endfor %}].flatMap { $0 }
   {{accessModifier}} static func registerAllCustomFonts() {
-    allCustomFonts.forEach { $0.register() }
+    let uniqueCustomFonts = allCustomFonts.reduce(into: []) { partialResult, fontConvertible in
+      if !partialResult.contains(where: { $0.path == fontConvertible.path }) {
+        partialResult.append(fontConvertible)
+      }
+    }
+    uniqueCustomFonts.forEach { $0.register() }
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length
@@ -160,4 +165,3 @@ private final class BundleToken {
 {% else %}
 // No fonts found
 {% endif %}
-// swiftlint:enable all


### PR DESCRIPTION
Fixed an issue where the Xcode console prints an error message during registration a custom variable font. The path of a variable font is the same for each style.

* [x] I've started my branch from the `develop` branch (gitflow)
  * [x] And I've selected `develop` as the "base" branch for this Pull Request I'm about to create
* [x] I've added an entry in the `CHANGELOG.md` file to explain my changes and credit myself  
      _(or added `#trivial` to the PR title if I think it doesn't warrant a mention in the CHANGELOG)_
  * [x] Add the entry in the appropriate section (Bug Fix / New Feature / Breaking Change / Internal Change)
  * [x] Add a period and 2 spaces at the end of your short entry description
  * [x] Add links to your GitHub profile to credit yourself and to the related PR and issue after your description

---

