### PR TITLE
Debug CI #trivial

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -56,7 +56,7 @@ jobs:
         run: bundle exec rake release:artifactbundle
       -
         name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: SwiftGen.zip
           path: .build/swiftgen-*.zip

--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   install:
     name: Install
-    runs-on: macos-12
+    runs-on: macos-26
     steps:
       - 
         name: Checkout
@@ -33,7 +33,7 @@ jobs:
 
   zip:
     name: Zip
-    runs-on: macos-12
+    runs-on: macos-26
     steps:
       - 
         name: Checkout

--- a/.github/workflows/compile-output.yml
+++ b/.github/workflows/compile-output.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   compile:
     name: Compile Output
-    runs-on: macos-12
+    runs-on: macos-26
     steps:
       - 
         name: Checkout

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   lint:
     name: SwiftLint
-    runs-on: macos-12
+    runs-on: macos-26
     steps:
       - 
         name: Checkout

--- a/.github/workflows/tag-publish.yml
+++ b/.github/workflows/tag-publish.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   cocoapods:
     name: Push To CocoaPods
-    runs-on: macos-12
+    runs-on: macos-26
     steps:
       -
         name: Checkout

--- a/.github/workflows/test-spm.yml
+++ b/.github/workflows/test-spm.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   macos:
     name: Test SPM macOS
-    runs-on: macos-12
+    runs-on: macos-26
     steps:
       - 
         name: Checkout


### PR DESCRIPTION
This is a temporary draft PR to debug the current CI behavior.

It contains a single empty commit and no code changes. The goal is to compare CI behavior for an internal branch against PR #1056, which comes from a fork, especially around Danger secret availability and queued macOS jobs.