### PR TITLE
Escape quoted localization keys in strings templates

### DIFF
--- a/Sources/SwiftGenCLI/templates/strings/flat-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/flat-swift4.stencil
@@ -38,15 +38,16 @@ import Foundation
   /// {{line}}
   {% endfor %}
   {% endif %}
+  {% set key string.key|replace:'"','\"' %}
   {% set translation string.translation|replace:'"','\"'|replace:'	','\t' %}
   {% if string.types %}
   {{accessModifier}} static func {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}({% call parametersBlock string.types %}) -> String {
-    return {{enumName}}.tr("{{table}}", "{{string.key}}", {%+ call argumentsBlock string.types %}, fallback: "{{translation}}")
+    return {{enumName}}.tr("{{table}}", "{{key}}", {%+ call argumentsBlock string.types %}, fallback: "{{translation}}")
   }
   {% elif param.lookupFunction %}
-  {{accessModifier}} static var {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: "{{translation}}") }
+  {{accessModifier}} static var {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{key}}", fallback: "{{translation}}") }
   {% else %}
-  {{accessModifier}} static let {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: "{{translation}}")
+  {{accessModifier}} static let {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{key}}", fallback: "{{translation}}")
   {% endif %}
   {% endfor %}
   {% for child in item.children %}

--- a/Sources/SwiftGenCLI/templates/strings/flat-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/flat-swift5.stencil
@@ -38,15 +38,16 @@ import Foundation
   /// {{line}}
   {% endfor %}
   {% endif %}
+  {% set key string.key|replace:'"','\"' %}
   {% set translation string.translation|replace:'"','\"'|replace:'	','\t' %}
   {% if string.types %}
   {{accessModifier}} static func {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}({% call parametersBlock string.types %}) -> String {
-    return {{enumName}}.tr("{{table}}", "{{string.key}}", {%+ call argumentsBlock string.types %}, fallback: "{{translation}}")
+    return {{enumName}}.tr("{{table}}", "{{key}}", {%+ call argumentsBlock string.types %}, fallback: "{{translation}}")
   }
   {% elif param.lookupFunction %}
-  {{accessModifier}} static var {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: "{{translation}}") }
+  {{accessModifier}} static var {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{key}}", fallback: "{{translation}}") }
   {% else %}
-  {{accessModifier}} static let {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: "{{translation}}")
+  {{accessModifier}} static let {{string.key|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{key}}", fallback: "{{translation}}")
   {% endif %}
   {% endfor %}
   {% for child in item.children %}

--- a/Sources/SwiftGenCLI/templates/strings/objc-m.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/objc-m.stencil
@@ -59,6 +59,7 @@ static NSString* tr(NSString *tableName, NSString *key, NSString *value, ...) {
 {% endmacro %}
 {% macro tableContents table item %}
   {% for string in item.strings %}
+  {% set key string.key|replace:'"','\"' %}
   {% if string.types %}
     {% if string.types.count == 1 %}
 + (NSString*){{string.key|swiftIdentifier:"pretty"|lowerFirstWord}}WithValue:{% call parametersBlock string.types +%}
@@ -66,11 +67,11 @@ static NSString* tr(NSString *tableName, NSString *key, NSString *value, ...) {
 + (NSString*){{string.key|swiftIdentifier:"pretty"|lowerFirstWord}}WithValues:{% call parametersBlock string.types +%}
     {% endif %}
 {
-    return tr(@"{{table}}", @"{{string.key}}", @"{{string.translation|replace:'"','\"'|replace:'	','\t'}}", {%+ call argumentsBlock string.types %});
+    return tr(@"{{table}}", @"{{key}}", @"{{string.translation|replace:'"','\"'|replace:'	','\t'}}", {%+ call argumentsBlock string.types %});
 }
 {% else %}
 + (NSString*){{string.key|swiftIdentifier:"pretty"|lowerFirstWord}} {
-    return tr(@"{{table}}", @"{{string.key}}", @"{{string.translation|replace:'"','\"'|replace:'	','\t'}}");
+    return tr(@"{{table}}", @"{{key}}", @"{{string.translation|replace:'"','\"'|replace:'	','\t'}}");
 }
   {% endif %}
   {% endfor %}

--- a/Sources/SwiftGenCLI/templates/strings/structured-swift4.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/structured-swift4.stencil
@@ -38,15 +38,16 @@ import Foundation
   /// {{line}}
   {% endfor %}
   {% endif %}
+  {% set key string.key|replace:'"','\"' %}
   {% set translation string.translation|replace:'"','\"'|replace:'	','\t' %}
   {% if string.types %}
   {{accessModifier}} static func {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}({% call parametersBlock string.types %}) -> String {
-    return {{enumName}}.tr("{{table}}", "{{string.key}}", {%+ call argumentsBlock string.types %}, fallback: "{{translation}}")
+    return {{enumName}}.tr("{{table}}", "{{key}}", {%+ call argumentsBlock string.types %}, fallback: "{{translation}}")
   }
   {% elif param.lookupFunction %}
-  {{accessModifier}} static var {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: "{{translation}}") }
+  {{accessModifier}} static var {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{key}}", fallback: "{{translation}}") }
   {% else %}
-  {{accessModifier}} static let {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: "{{translation}}")
+  {{accessModifier}} static let {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{key}}", fallback: "{{translation}}")
   {% endif %}
   {% endfor %}
   {% for child in item.children %}

--- a/Sources/SwiftGenCLI/templates/strings/structured-swift5.stencil
+++ b/Sources/SwiftGenCLI/templates/strings/structured-swift5.stencil
@@ -38,15 +38,16 @@ import Foundation
   /// {{line}}
   {% endfor %}
   {% endif %}
+  {% set key string.key|replace:'"','\"' %}
   {% set translation string.translation|replace:'"','\"'|replace:'	','\t' %}
   {% if string.types %}
   {{accessModifier}} static func {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}({% call parametersBlock string.types %}) -> String {
-    return {{enumName}}.tr("{{table}}", "{{string.key}}", {%+ call argumentsBlock string.types %}, fallback: "{{translation}}")
+    return {{enumName}}.tr("{{table}}", "{{key}}", {%+ call argumentsBlock string.types %}, fallback: "{{translation}}")
   }
   {% elif param.lookupFunction %}
-  {{accessModifier}} static var {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: "{{translation}}") }
+  {{accessModifier}} static var {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}}: String { return {{enumName}}.tr("{{table}}", "{{key}}", fallback: "{{translation}}") }
   {% else %}
-  {{accessModifier}} static let {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{string.key}}", fallback: "{{translation}}")
+  {{accessModifier}} static let {{string.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{enumName}}.tr("{{table}}", "{{key}}", fallback: "{{translation}}")
   {% endif %}
   {% endfor %}
   {% for child in item.children %}

--- a/Tests/TemplatesTests/StringsTests.swift
+++ b/Tests/TemplatesTests/StringsTests.swift
@@ -119,6 +119,33 @@ final class StringsTests: XCTestCase {
     )
   }
 
+  func testSwiftTemplatesEscapeQuotedKeys() throws {
+    let context: [String: Any] = [
+      "tables": [[
+        "name": "Localizable",
+        "levels": [
+          "strings": [[
+            "key": #"click "Connect" to get started"#,
+            "name": "clickConnect",
+            "translation": #"click "Connect" to get started"#
+          ]]
+        ]
+      ]]
+    ]
+
+    for templateName in ["flat-swift4", "flat-swift5", "structured-swift4", "structured-swift5"] {
+      let template = try Template.load(
+        from: Fixtures.template(for: "\(templateName).stencil", sub: .strings),
+        modernSpacing: true
+      )
+      let result = try template.render(context)
+      XCTAssertTrue(
+        result.contains(#"click \"Connect\" to get started"#),
+        "Expected quoted key to be escaped in \(templateName):\n\(result)"
+      )
+    }
+  }
+
   func testObjectiveCHeader() {
     test(
       template: "objc-h",


### PR DESCRIPTION
## Summary

- escape quoted localization keys before rendering them inside generated Swift and Objective-C string literals
- keep the raw key for identifier transformations
- add a regression test covering quoted keys across the Swift string templates

Fixes #1150

## Validation

- `swift build --cache-path /Volumes/ZHUOLIN/Project/.cache/swiftpm --product swiftgen` ✅
- generated output smoke test with a quoted-key `.strings` fixture ✅
- `StringsTests/testSwiftTemplatesEscapeQuotedKeys` could not complete locally because the installed CommandLineTools cannot resolve XCTest; the product build and generator smoke test pass
